### PR TITLE
separate credential test for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 #  - '[ "${TRAVIS_SECURE_ENV_VARS}" = "true" ] && nosetests tests/test-utils_sns.py || false'
     - nosetests --with-coverage tests/test-rules-ruleset.py
     - nosetests --with-coverage tests/test-rules-processingengine.py
-    - nosetests --with-coverage --nocapture tests/test-scoutsuite.py
+    - nosetests --with-coverage --nocapture tests/test-scoutsuite.py -a "!credential"
 
 # use container-base infrastructure
 sudo: required

--- a/tests/test-scoutsuite.py
+++ b/tests/test-scoutsuite.py
@@ -1,6 +1,8 @@
 import subprocess
 
 import mock
+from nose.plugins.attrib import attr
+
 from opinel.utils.console import configPrintException
 from opinel.utils.credentials import read_creds_from_environment_variables
 
@@ -51,6 +53,7 @@ class TestScoutSuiteClass:
     #
     # Make sure that ScoutSuite's default run does not crash
     #
+    @attr("credential")
     def test_scout_suite_default_run(self):
         rc = self.call_scout_suite([])
         assert (rc == 0)
@@ -58,6 +61,7 @@ class TestScoutSuiteClass:
     #
     # Make sure that ScoutSuite's CIS ruleset run does not crash
     #
+    @attr("credential")
     def test_scout_suite_cis_ruleset_run(self):
         rc = self.call_scout_suite(['--ruleset', 'cis-02-29-2016.json'])
         assert (rc == 0)


### PR DESCRIPTION
Hi, 
I have exclude failed test with attribute function of nose.

Current master
https://travis-ci.org/mitsuo0114/ScoutSuite/builds/463708298

With this PR
https://travis-ci.org/mitsuo0114/ScoutSuite/builds/463716513

These 2 tests require AWS credentials as ENV but it should make tests fragile.
but it may necessary in some environment. To meet these expectations, I use attrib function.
https://nose.readthedocs.io/en/latest/plugins/attrib.html

I hope this way is good for CI.