### PR TITLE
Master to develop

### DIFF
--- a/ScoutSuite/output/html.py
+++ b/ScoutSuite/output/html.py
@@ -96,8 +96,7 @@ class Scout2Report(HTMLReport):
             with open(os.path.join(self.html_data_path, self.html_root)) as f:
                 with open(new_file, 'wt') as nf:
                     for line in f:
-                        newline = line.replace(REPORT_TITLE,
-                                               REPORT_TITLE + ' [' + self.profile + ']')
+                        newline = line
                         if self.profile != 'default':
                             newline = newline.replace(AWSCONFIG_FILE,
                                                       AWSCONFIG_FILE.replace('.js', '-%s.js' % self.profile))


### PR DESCRIPTION
Master is currently ahead of develop. Let's try avoiding this. I suggest setting the default branch to `develop` instead of `master`. This way, new PRs will be against `develop` by default.

One argument against using develop as the default branch is that people looking at the repo will see the develop branch by default. 