### PR TITLE
Bugfix/17 cloudtrail regions missing

### DIFF
--- a/ScoutSuite/providers/aws/configs/regions.py
+++ b/ScoutSuite/providers/aws/configs/regions.py
@@ -235,6 +235,8 @@ class RegionConfig(BaseConfig):
     def __init__(self, region_name, resource_types=None):
         resource_types = {} if resource_types is None else resource_types
         self.region = region_name
+        self.name = region_name
+        self.id = region_name
         for resource_type in resource_types['region'] + resource_types['global']:
             setattr(self, resource_type, {})
             setattr(self, '%s_count' % resource_type, 0)

--- a/ScoutSuite/providers/base/provider.py
+++ b/ScoutSuite/providers/base/provider.py
@@ -167,10 +167,14 @@ class BaseProvider(object):
                             [x for x in
                              self.metadata[service_group][service]['resources'][resource]['full_path'].split(
                                  '.') if x != 'id'])
+                    
                     # Update counts
-                    count = '%s_count' % resource
                     service_config = self.services[service]
-                    if service_config and resource != 'regions':
+                    if not service_config :
+                        continue
+                    
+                    count = '%s_count' % resource
+                    if resource != 'regions':
                         if 'regions' in service_config.keys() and isinstance(service_config['regions'], dict):
                             self.metadata[service_group][service]['resources'][resource]['count'] = 0
                             for region in service_config['regions']:
@@ -183,6 +187,9 @@ class BaseProvider(object):
                                     service_config[count]
                             except Exception as e:
                                 printException(e)
+                    else:
+                        self.metadata[service_group][service]['resources'][resource]['count'] = len(service_config['regions'])
+
 
     def manage_object(self, object, attr, init, callback=None):
         """


### PR DESCRIPTION
Fixes bug #17, grayed-out regions button in the CloudTrail sub-menu.

The grayed-out button can be explained by the missing regions count in the metadata. Once I fixed that, there were other issues. The regions were not appearing in the regions' view and the left menu links were broken. This is because these features rely on the `name` and `id` tags, so I added that to the region.

![image](https://user-images.githubusercontent.com/6698529/51774702-3adf4b00-20c1-11e9-809a-848f6ff1eaf6.png)
