### PR TITLE
Bugfix/98 service filtering cloudtrail

### DIFF
--- a/ScoutSuite/core/processingengine.py
+++ b/ScoutSuite/core/processingengine.py
@@ -31,7 +31,7 @@ class ProcessingEngine(object):
             cloud_provider.services[service][self.ruleset.rule_type] = {}
 
         # Process each rule
-        for finding_path in self.rules:
+        for finding_path in self._filter_rules(self.rules, cloud_provider.service_list):
             for rule in self.rules[finding_path]:
                 
                 if not rule.enabled:  # or rule.service not in []: # TODO: handle this...
@@ -64,4 +64,8 @@ class ProcessingEngine(object):
                     # Fallback if process rule failed to ensure report creation and data dump still happen
                     cloud_provider.services[service][self.ruleset.rule_type][rule.key]['checked_items'] = 0
                     cloud_provider.services[service][self.ruleset.rule_type][rule.key]['flagged_items'] = 0
+
+    def _filter_rules(self, rules, services):
+        return { rule: rules[rule] for rule in rules if rule.split('.')[0] in services }
+
 

--- a/ScoutSuite/providers/aws/configs/base.py
+++ b/ScoutSuite/providers/aws/configs/base.py
@@ -14,10 +14,7 @@ from opinel.utils.aws import handle_truncated_response
 class AWSBaseConfig(BaseConfig):
 
     def _is_provider(self, provider_name):
-        if provider_name == 'aws':
-            return True
-        else:
-            return False
+        return provider_name == 'aws'
 
     def _get_method(self, api_client, target_type, list_method_name):
         """

--- a/ScoutSuite/providers/aws/configs/services.py
+++ b/ScoutSuite/providers/aws/configs/services.py
@@ -67,10 +67,7 @@ class AWSServicesConfig(BaseServicesConfig):
         self.vpc = VPCConfig(metadata['network']['vpc'], thread_config)
 
     def _is_provider(self, provider_name):
-        if provider_name == 'aws':
-            return True
-        else:
-            return False
+        return provider_name == 'aws'
 
     # TODO is this ever called?
     # def single_service_pass(self):

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -147,7 +147,7 @@ class AWSProvider(BaseProvider):
                     data_logging_trails_count += 1
 
         cloudtrail_config['data_logging_trails_count'] = data_logging_trails_count
-        cloudtrail_config['IncludeGlobalServiceEvents'] = global_events_logging > 0
+        cloudtrail_config['IncludeGlobalServiceEvents'] = len(global_events_logging) > 0
         cloudtrail_config['DuplicatedGlobalServiceEvents'] = len(global_events_logging) > 1
 
     def process_network_acls_callback(self, current_config, path, current_path, privateip_id, callback_args):

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -140,15 +140,15 @@ class AWSProvider(BaseProvider):
                 if 'HomeRegion' in trail and trail['HomeRegion'] != region:
                     # Part of a multi-region trail, skip until we find the whole object
                     continue
-                if trail['IncludeGlobalServiceEvents'] == True and trail['IsLogging'] == True:
+                if trail['IncludeGlobalServiceEvents'] and trail['IsLogging']:
                     global_events_logging.append((region, trail_id,))
                 # Any wildcard logging?
                 if trail.get('wildcard_data_logging', False):
                     data_logging_trails_count += 1
 
         cloudtrail_config['data_logging_trails_count'] = data_logging_trails_count
-        cloudtrail_config['IncludeGlobalServiceEvents'] = False if (len(global_events_logging) == 0) else True
-        cloudtrail_config['DuplicatedGlobalServiceEvents'] = True if (len(global_events_logging) > 1) else False
+        cloudtrail_config['IncludeGlobalServiceEvents'] = global_events_logging > 0
+        cloudtrail_config['DuplicatedGlobalServiceEvents'] = len(global_events_logging) > 1
 
     def process_network_acls_callback(self, current_config, path, current_path, privateip_id, callback_args):
         # Check if the network ACL allows all traffic from all IP addresses

--- a/ScoutSuite/providers/azure/configs/base.py
+++ b/ScoutSuite/providers/azure/configs/base.py
@@ -16,10 +16,7 @@ class AzureBaseConfig(BaseConfig):
         super(AzureBaseConfig, self).__init__(thread_config)
 
     def _is_provider(self, provider_name):
-        if provider_name == 'azure':
-            return True
-        else:
-            return False
+        return provider_name == 'azure'
 
     def _get_method(self, api_client, target_type, list_method_name):
         """

--- a/ScoutSuite/providers/azure/configs/services.py
+++ b/ScoutSuite/providers/azure/configs/services.py
@@ -12,7 +12,4 @@ class AzureServicesConfig(BaseServicesConfig):
         self.storageaccounts = StorageAccountsConfig(thread_config=thread_config)
 
     def _is_provider(self, provider_name):
-        if provider_name == 'azure':
-            return True
-        else:
-            return False
+        return provider_name == 'azure'

--- a/ScoutSuite/providers/gcp/configs/base.py
+++ b/ScoutSuite/providers/gcp/configs/base.py
@@ -34,10 +34,7 @@ class GCPBaseConfig(BaseConfig):
         super(GCPBaseConfig, self).__init__(thread_config)
 
     def _is_provider(self, provider_name):
-        if provider_name == 'gcp':
-            return True
-        else:
-            return False
+        return provider_name == 'gcp'
 
     def get_regions(self, **kwargs):
         """

--- a/ScoutSuite/providers/gcp/configs/services.py
+++ b/ScoutSuite/providers/gcp/configs/services.py
@@ -37,10 +37,7 @@ class GCPServicesConfig(BaseServicesConfig):
         # self.stackdrivermonitoring = StackdriverMonitoringConfig(thread_config=thread_config)
 
     def _is_provider(self, provider_name):
-        if provider_name == 'gcp':
-            return True
-        else:
-            return False
+        return provider_name == 'gcp'
 
     def set_projects(self, projects):
         """

--- a/tests/test-rules-processingengine.py
+++ b/tests/test-rules-processingengine.py
@@ -21,18 +21,6 @@ class TestAWSScout2RulesProcessingEngine:
         self.rule_counters = {'found': 0, 'tested': 0, 'verified': 0}
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
 
-        # Build a fake ruleset
-
-    #    filename = 'foobar.json'
-    #    ruleset = {'rules': {}}
-    #    ruleset['rules'][filename] = []
-    #    ruleset['rules'][filename].append({'enabled': True, 'level': 'danger'})
-    #    pass
-
-    # finding_rules = Ruleset(profile_name, filename=args.ruleset, ip_ranges=args.ip_ranges)
-    # pe = ProcessingEngine(finding_rules)
-    # pe.run(aws_config)
-
     # TODO
     # Check that one testcase per finding rule exists (should be within default
     # reulset)

--- a/tests/test-rules-processingengine.py
+++ b/tests/test-rules-processingengine.py
@@ -36,7 +36,6 @@ class TestAWSScout2RulesProcessingEngine:
     def test_all_finding_rules(self):
         test_dir = os.path.dirname(os.path.realpath(__file__))
         test_ruleset_file_name = os.path.join(test_dir, 'data/ruleset-test.json')
-
         #FIXME this is only for AWS
         with open(os.path.join(test_dir, '../ScoutSuite/providers/aws/rules/rulesets/default.json'), 'rt') as f:
             ruleset = json.load(f)
@@ -64,8 +63,9 @@ class TestAWSScout2RulesProcessingEngine:
                 test_config_dict = json.load(f)
                 for key in test_config_dict:
                     setattr(dummy_provider, key, test_config_dict[key])
-            pe.run(dummy_provider)
             service = file_name.split('-')[0]
+            dummy_provider.service_list = [service]
+            pe.run(dummy_provider)
             findings = dummy_provider.services[service]['findings']
             findings = findings[list(findings.keys())[0]]['items']
             test_result_file_name = os.path.join(test_dir, 'data/rule-results/%s' % file_name)
@@ -82,6 +82,6 @@ class TestAWSScout2RulesProcessingEngine:
                 printError('Expected items:\n %s' % json.dumps(sorted(items)))
                 printError('Reported items:\n %s' % json.dumps(sorted(findings)))
                 assert (False)
-        printError('Existing  rules: %d' % rule_counters['found'])
-        printError('Processed rules: %d' % rule_counters['tested'])
-        printError('Verified  rules: %d' % rule_counters['verified'])
+        print('Existing  rules: %d' % rule_counters['found'])
+        print('Processed rules: %d' % rule_counters['tested'])
+        print('Verified  rules: %d' % rule_counters['verified'])

--- a/tests/test-rules-processingengine.py
+++ b/tests/test-rules-processingengine.py
@@ -84,8 +84,9 @@ class TestAWSScout2RulesProcessingEngine:
         test_ruleset = {'rules': {}, 'about': 'regression test'}
         test_ruleset['rules'][rule_file_name] = [rule]
 
-        with tempfile.NamedTemporaryFile('wt', delete=True) as f:
+        with tempfile.NamedTemporaryFile('wt', delete=False) as f:
             f.write(json.dumps(test_ruleset, indent=4))
-            return Ruleset(filename=f.name)
+
+        return Ruleset(filename=f.name)
 
         return None

--- a/tests/test-rules-processingengine.py
+++ b/tests/test-rules-processingengine.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import tempfile
 
 from opinel.utils.console import configPrintException, printError
 
@@ -12,10 +13,13 @@ from ScoutSuite.core.ruleset import Ruleset
 class DummyObject(object):
     pass
 
+
 class TestAWSScout2RulesProcessingEngine:
 
     def setup(self):
         configPrintException(True)
+        self.rule_counters = {'found': 0, 'tested': 0, 'verified': 0}
+        self.test_dir = os.path.dirname(os.path.realpath(__file__))
 
         # Build a fake ruleset
 
@@ -34,54 +38,66 @@ class TestAWSScout2RulesProcessingEngine:
     # reulset)
 
     def test_all_finding_rules(self):
-        test_dir = os.path.dirname(os.path.realpath(__file__))
-        test_ruleset_file_name = os.path.join(test_dir, 'data/ruleset-test.json')
-        #FIXME this is only for AWS
-        with open(os.path.join(test_dir, '../ScoutSuite/providers/aws/rules/rulesets/default.json'), 'rt') as f:
+        ruleset_file_name = os.path.join(self.test_dir, 'data/ruleset-test.json')
+        # FIXME this is only for AWS
+        with open(os.path.join(self.test_dir, '../ScoutSuite/providers/aws/rules/rulesets/default.json'), 'rt') as f:
             ruleset = json.load(f)
 
-        rule_counters = {'found': 0, 'tested': 0, 'verified': 0}
-        for file_name in ruleset['rules']:
-            rule_counters['found'] += 1
-            test_config_file_name = os.path.join(test_dir, 'data/rule-configs/%s' % file_name)
-            if not os.path.isfile(test_config_file_name):
-                continue
-            rule_counters['tested'] += 1
-            test_ruleset = {'rules': {}, 'about': 'regression test'}
-            test_ruleset['rules'][file_name] = []
-            rule = ruleset['rules'][file_name][0]
+        for rule_file_name in ruleset['rules']:
+            self.rule_counters['found'] += 1
+            rule = ruleset['rules'][rule_file_name][0]
             rule['enabled'] = True
-            test_ruleset['rules'][file_name].append(rule)
-            with open(test_ruleset_file_name, 'wt') as f:
-                f.write(json.dumps(test_ruleset, indent=4))
-            #            printError('Ruleset ::')
-            #            printError(str(test_ruleset))
-            rules = Ruleset(filename=test_ruleset_file_name)
-            pe = ProcessingEngine(rules)
-            with open(test_config_file_name, 'rt') as f:
-                dummy_provider = DummyObject()
-                test_config_dict = json.load(f)
-                for key in test_config_dict:
-                    setattr(dummy_provider, key, test_config_dict[key])
-            service = file_name.split('-')[0]
-            dummy_provider.service_list = [service]
-            pe.run(dummy_provider)
-            findings = dummy_provider.services[service]['findings']
-            findings = findings[list(findings.keys())[0]]['items']
-            test_result_file_name = os.path.join(test_dir, 'data/rule-results/%s' % file_name)
-            if not os.path.isfile(test_result_file_name):
-                printError('Expected findings:: ')
-                printError(json.dumps(findings, indent=4))
-                continue
-            rule_counters['verified'] += 1
-            with open(test_result_file_name, 'rt') as f:
-                items = json.load(f)
-            try:
-                assert (set(sorted(findings)) == set(sorted(items)))
-            except Exception as e:
-                printError('Expected items:\n %s' % json.dumps(sorted(items)))
-                printError('Reported items:\n %s' % json.dumps(sorted(findings)))
-                assert (False)
-        print('Existing  rules: %d' % rule_counters['found'])
-        print('Processed rules: %d' % rule_counters['tested'])
-        print('Verified  rules: %d' % rule_counters['verified'])
+            self._test_rule(ruleset_file_name, rule_file_name, rule)
+
+        print('Existing  rules: %d' % self.rule_counters['found'])
+        print('Processed rules: %d' % self.rule_counters['tested'])
+        print('Verified  rules: %d' % self.rule_counters['verified'])
+
+
+    def _test_rule(self, ruleset_file_name, rule_file_name, rule):
+        test_config_file_name = os.path.join(self.test_dir, 'data/rule-configs/%s' % rule_file_name)
+        if not os.path.isfile(test_config_file_name):
+            return
+        self.rule_counters['tested'] += 1
+
+        ruleset = self._generate_ruleset(rule_file_name, rule)
+        pe = ProcessingEngine(ruleset)
+
+        dummy_provider = DummyObject()
+        with open(test_config_file_name, 'rt') as f:
+            test_config_dict = json.load(f)
+            for key in test_config_dict:
+                setattr(dummy_provider, key, test_config_dict[key])
+        service = rule_file_name.split('-')[0]
+        dummy_provider.service_list = [service]
+        pe.run(dummy_provider)
+        findings = dummy_provider.services[service]['findings']
+        findings = findings[list(findings.keys())[0]]['items']
+        
+        test_result_file_name = os.path.join(self.test_dir, 'data/rule-results/%s' % rule_file_name)
+        if not os.path.isfile(test_result_file_name):
+            printError('Expected findings:: ')
+            printError(json.dumps(findings, indent=4))
+            return
+
+        self.rule_counters['verified'] += 1
+        with open(test_result_file_name, 'rt') as f:
+            items = json.load(f)
+        
+        try:
+            assert (set(sorted(findings)) == set(sorted(items)))
+        except Exception as e:
+            printError(e)
+            printError('Expected items:\n %s' % json.dumps(sorted(items)))
+            printError('Reported items:\n %s' % json.dumps(sorted(findings)))
+            assert (False)
+
+    def _generate_ruleset(self, rule_file_name, rule):
+        test_ruleset = {'rules': {}, 'about': 'regression test'}
+        test_ruleset['rules'][rule_file_name] = [rule]
+
+        with tempfile.NamedTemporaryFile('wt', delete=True) as f:
+            f.write(json.dumps(test_ruleset, indent=4))
+            return Ruleset(filename=f.name)
+
+        return None


### PR DESCRIPTION
My investigations showed that the problem was not the services filtering but the rules filtering. I modified the processing engine so that it only checks the rules for enabled services, aka services in the provider's `service_list` (#98 ). 

As we can see in the screenshot below, CloudTrail is not enabled anymore.
![image](https://user-images.githubusercontent.com/6698529/51803102-1ef1bb80-221f-11e9-9528-3abde4ebd186.png)
