### PR TITLE
Feature/61 ui improvements

### DIFF
--- a/ScoutSuite/output/data/html/partials/about_scoutsuite.html
+++ b/ScoutSuite/output/data/html/partials/about_scoutsuite.html
@@ -1,0 +1,26 @@
+<script id="about_scoutsuite-template" type="text/x-handlebars-template">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">About Scout Suite</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="row list-group-item">
+                    <p>Scout Suite is an open-source tool released by <a href="https://www.nccgroup.trust" rel="author" target="_blank">NCC Group</a>.</p>
+                    <p>Use the top navigation bar to review the configuration of the supported cloud provider services.</p>
+                    <p>
+                        For more information about Scout Suite, please check out the project's page on
+                        <a href="https://github.com/nccgroup/ScoutSuite" target="_blank">GitHub</a>.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</script>
+
+<script>
+    var about_scoutsuite_template = Handlebars.compile($("#about_scoutsuite-template").html());
+</script>

--- a/ScoutSuite/output/data/html/partials/aws/services.cloudformation.regions.id.stacks.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.cloudformation.regions.id.stacks.html
@@ -1,6 +1,6 @@
 <!-- CloudFormation stack partial -->
 <script id="services.cloudformation.regions.id.stacks.partial" type="text/x-handlebars-template">
-  <div class="list-group-item active">
+  <div id="resource-name" class="list-group-item active">
     <h4 class="list-group-item-heading">{{name}}</h4>
   </div>
   <div class="list-group-item">
@@ -43,8 +43,7 @@
 
 <!-- Single CloudFormation stack template -->
 <script id="single_cloudformation_stack-template" type="text/x-handlebars-template">
-  <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-  {{> services.cloudformation.regions.id.stacks}}
+  {{> modal-template template='services.cloudformation.regions.id.stacks' }}
 </script>
 
 <script>

--- a/ScoutSuite/output/data/html/partials/aws/services.cloudtrail.regions.id.trails.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.cloudtrail.regions.id.trails.html
@@ -2,7 +2,7 @@
 <!-- Trail partial -->
 <script id="services.cloudtrail.regions.id.trails.partial" type="text/x-handlebars-template">
   {{#unless scout2_link}}
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
       <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -36,8 +36,7 @@
 
 <!-- Single EC2 instance template -->
 <script id="single_cloudtrail_trail-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.cloudtrail.regions.id.trails}}
+    {{> modal-template template='services.cloudtrail.regions.id.trails' }}
 </script>
 <script>
     var single_cloudtrail_trail_template = Handlebars.compile($("#single_cloudtrail_trail-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.cloudwatch.regions.id.alarms.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.cloudwatch.regions.id.alarms.html
@@ -1,7 +1,7 @@
 
 <!-- Alarm partial -->
 <script id="services.cloudwatch.regions.id.alarms.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -40,8 +40,7 @@
 
 <!-- Single CloudWatch alarm template -->
 <script id="single_cloudwatch_alarm-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.cloudwatch.regions.id.alarms}}
+  {{> modal-template template='services.cloudwatch.regions.id.alarms' }}
 </script>
 <script>
     var single_cloudwatch_alarm_template = Handlebars.compile($("#single_cloudwatch_alarm-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.snapshots.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.snapshots.html
@@ -5,7 +5,6 @@
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
-         this }}
         <h4 class="list-group-item-heading">Information</h4>
         <ul>
             <li class="list-group-item-text">Id: {{id}}</li>

--- a/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.volumes.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.volumes.html
@@ -1,7 +1,6 @@
-
 <!-- EBS volume partial -->
 <script id="services.ec2.regions.id.volumes.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -16,8 +15,7 @@
 
 <!-- Single EBS volume template -->
 <script id="single_ebs_volume-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.ec2.regions.id.volumes}}
+    {{> modal-template template='services.ec2.regions.id.volumes' }}
 </script>
 
 <script>

--- a/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.vpcs.id.images.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.vpcs.id.images.html
@@ -1,6 +1,6 @@
 <!-- AIMs partial -->
 <script id="services.ec2.regions.id.images.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -19,9 +19,8 @@
 
 <!-- Single AIM template -->
 <script id="single_ec2_image-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.ec2.regions.id.images}}
-    </script>
+    {{> modal-template template='services.ec2.regions.id.images' }}
+</script>
 <script>
     var single_ec2__template = Handlebars.compile($("#single_ec2_image-template").html());
 </script>

--- a/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.vpcs.id.instances.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.vpcs.id.instances.html
@@ -1,7 +1,7 @@
 
     <!-- EC2 instance partial -->
     <script id="services.ec2.regions.id.vpcs.id.instances.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
             <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -36,8 +36,7 @@
 
     <!-- Single EC2 instance template -->
     <script id="single_ec2_instance-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.ec2.regions.id.vpcs.id.instances}}
+        {{> modal-template template='services.ec2.regions.id.vpcs.id.instances' }}
     </script>
     <script>
         var single_ec2_instance_template = Handlebars.compile($("#single_ec2_instance-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.vpcs.id.security_groups.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.vpcs.id.security_groups.html
@@ -1,6 +1,6 @@
 <!-- EC2 security group partial -->
 <script id="services.ec2.regions.id.vpcs.id.security_groups.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
       <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
 
@@ -40,8 +40,7 @@
 
 <!-- Single EC2 security group template -->
 <script id="single_ec2_security_group-template" type="text/x-handlebars-template">
-  <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-  {{> services.ec2.regions.id.vpcs.id.security_groups}}
+  {{> modal-template template='services.ec2.regions.id.vpcs.id.security_groups'}}
 </script>
 
 <script>

--- a/ScoutSuite/output/data/html/partials/aws/services.elb.regions.id.elb_policies.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.elb.regions.id.elb_policies.html
@@ -1,7 +1,7 @@
 
     <!-- ELB Policy partial -->
     <script id="services.elb.regions.id.elb_policies.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
           <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         {{#ifEqual PolicyTypeName 'SSLNegotiationPolicyType'}}
@@ -47,8 +47,7 @@
 
     <!-- Single elb security group template -->
     <script id="single_elb_elb_policy-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.elb.regions.id.elb_policies}}
+        {{> modal-template template='services.elb.regions.id.elb_policies'}}
     </script>
     <script>
         var single_elb_elb_policy_template = Handlebars.compile($("#single_elb_elb_policy-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.emr.regions.id.vpcs.id.clusters.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.emr.regions.id.vpcs.id.clusters.html
@@ -1,7 +1,7 @@
 
     <!-- EMR cluster partial -->
     <script id="services.emr.regions.id.vpcs.id.clusters.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
             <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -52,8 +52,7 @@
 
     <!-- Single EMR cluster template -->
     <script id="single_emr_cluster-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.emr.regions.id.vpcs.id.clusters}}
+        {{> modal-template template='services.emr.regions.id.vpcs.id.clusters'}}
     </script>
     <script>
         var single_emr_cluster_template = Handlebars.compile($("#single_emr_cluster-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.iam.credential_reports.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.iam.credential_reports.html
@@ -1,7 +1,7 @@
 
   <!-- IAM credential report partial -->
   <script id="services.iam.credential_reports.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
       <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -25,8 +25,7 @@
 
 <!-- Single IAM credential_reports template -->
 <script id="services.iam.credential_reports.template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.iam.credential_reports}}
+    {{> modal-template template='services.iam.credential_reports'}}
 </script>
 
 <script>

--- a/ScoutSuite/output/data/html/partials/aws/services.iam.groups.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.iam.groups.html
@@ -1,7 +1,7 @@
 
     <!-- IAM group partial -->
     <script id="services.iam.groups.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
           <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -37,8 +37,7 @@
 
     <!-- Single IAM group template -->
     <script id="services.iam.groups.template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.iam.groups}}
+        {{> modal-template template='services.iam.groups'}}
     </script>
     <script>
         var single_iam_group_template = Handlebars.compile($("#services\\.iam\\.groups\\.template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.iam.managed_policies.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.iam.managed_policies.html
@@ -1,7 +1,7 @@
 
     <!-- IAM managed policy partial -->
     <script id="services.iam.policies.partial" type="text/x-handlebars-template">
-      <div class="list-group-item active">
+      <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
       </div>
       <div class="list-group-item">
@@ -28,8 +28,7 @@
 
     <!-- Single IAM managed policy template -->
     <script id="services.iam.policy.template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.iam.policies}}
+        {{> modal-template template='services.iam.policies'}}
     </script>
     <script>
         var single_iam_policy_template = Handlebars.compile($("#services\\.iam\\.policy\\.template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.iam.roles.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.iam.roles.html
@@ -1,7 +1,7 @@
 
     <!-- IAM role partial -->
     <script id="services.iam.roles.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
           <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -43,8 +43,7 @@
 
     <!-- Single IAM role template -->
     <script id="services.iam.roles.template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.iam.roles}}
+        {{> modal-template template='services.iam.roles'}}
     </script>
     <script>
         var single_iam_role_template = Handlebars.compile($("#services\\.iam\\.roles\\.template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.iam.users.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.iam.users.html
@@ -1,7 +1,7 @@
 
   <!-- IAM user partial -->
   <script id="services.iam.users.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
       <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -63,8 +63,7 @@
 
     <!-- Single IAM user template -->
     <script id="services.iam.users.template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.iam.users}}
+        {{> modal-template template='services.iam.users'}}
     </script>
     <script>
         var single_iam_user_template = Handlebars.compile($("#services\\.iam\\.users\\.template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.rds.regions.id.vpcs.id.instances.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.rds.regions.id.vpcs.id.instances.html
@@ -1,7 +1,7 @@
 
     <!-- RDS instance partial -->
     <script id="services.rds.regions.id.vpcs.id.instances.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
           <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -39,8 +39,7 @@
 
     <!-- Single RDS instance template -->
     <script id="single_rds_instance-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.rds.regions.id.vpcs.id.instances}}
+        {{> modal-template template='services.rds.regions.id.vpcs.id.instances'}}
     </script>
     <script>
         var single_rds_instance_template = Handlebars.compile($("#single_rds_instance-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.route53.domains.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.route53.domains.html
@@ -1,7 +1,7 @@
 
     <!-- Route53 domain partial -->
     <script id="services.route53.domains.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
             <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -23,8 +23,7 @@
 
     <!-- Single Route53 domain template -->
     <script id="services.route53.domains.template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.route53.domains}}
+        {{> modal-template template='services.route53.domains'}}
     </script>
     <script>
         var single_route53_domain_template = Handlebars.compile($("#services\\.route53\\.domains\\.template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.route53.hosted_zones.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.route53.hosted_zones.html
@@ -1,7 +1,7 @@
 
     <!-- Route53 hosted_zone partial -->
     <script id="services.route53.hosted_zones.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
             <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -32,8 +32,7 @@
 
     <!-- Single Route53 hosted_zone template -->
     <script id="services.route53.hosted_zones.template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.route53.hosted_zones}}
+        {{> modal-template template='services.route53.hosted_zones'}}
     </script>
     <script>
         var single_route53_hosted_zone_template = Handlebars.compile($("#services\\.route53\\.hosted_zones\\.template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.s3.buckets.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.s3.buckets.html
@@ -1,7 +1,7 @@
 
     <!-- S3 bucket partial -->
     <script id="services.s3.buckets.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
           <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -68,8 +68,7 @@
 
     <!-- Single S3 bucket template -->
     <script id="single_s3_bucket-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.s3.buckets}}
+        {{> modal-template template='services.s3.buckets' }}
     </script>
     <script>
         var single_s3_bucket_template = Handlebars.compile($("#single_s3_bucket-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.s3.buckets.objects.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.s3.buckets.objects.html
@@ -2,7 +2,7 @@
     <!-- S3 object partial -->
     <script id="services.s3.buckets.objects.partial" type="text/x-handlebars-template">
       <div class="list-group" id="services.s3.buckets.objects.{{name}}.details">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
           <h4 class="list-group-item-heading">{{get_value_at 'services.s3.buckets' bucket_id 'name'}}/{{get_value_at 'services.s3.buckets' bucket_id 'keys' key_id 'name'}}</h4>
         </div>
         <div class="list-group-item">
@@ -23,8 +23,7 @@
 
     <!-- Single S3 object template -->
     <script id="single_s3_object-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.s3.buckets.objects}}
+        {{> modal-template template='services.s3.buckets.objects'}}
     </script>
     <script>
       var single_s3_object_template = Handlebars.compile($("#single_s3_object-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.ses.regions.id.identities.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.ses.regions.id.identities.html
@@ -1,7 +1,7 @@
 
     <!-- SES queue partial -->
     <script id="services.ses.regions.id.identities.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
             <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -24,8 +24,7 @@
 
     <!-- Single SES queue template -->
     <script id="single_ses_queue-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.ses.regions.id.identities}}
+        {{> modal-template template='services.ses.regions.id.identities'}}
     </script>
     <script>
         var single_ses_queue_template = Handlebars.compile($("#single_ses_queue-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.sns.regions.id.topics.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.sns.regions.id.topics.html
@@ -1,7 +1,7 @@
 
     <!-- SNS topic partial -->
     <script id="services.sns.regions.id.topics.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
           <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -55,8 +55,7 @@
 
     <!-- Single SNS topic template -->
     <script id="single_sns_topic-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.sns.regions.id.topics}}
+        {{> modal-template template='services.sns.regions.id.topics'}}
     </script>
     <script>
         var single_sns_topic_template = Handlebars.compile($("#single_sns_topic-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.sqs.regions.id.queues.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.sqs.regions.id.queues.html
@@ -1,7 +1,7 @@
 
     <!-- SNS queue partial -->
     <script id="services.sqs.regions.id.queues.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
           <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -22,8 +22,7 @@
 
     <!-- Single SNS queue template -->
     <script id="single_sqs_queue-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.sqs.regions.id.queues}}
+        {{> modal-template template='services.sqs.regions.id.queues'}}
     </script>
     <script>
         var single_sqs_queue_template = Handlebars.compile($("#single_sqs_queue-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.stackdriverlogging.sinks.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.stackdriverlogging.sinks.html
@@ -1,7 +1,7 @@
 
 <!-- Stackdriver Logging sinks partial -->
 <script id="services.stackdriverlogging.sinks.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -18,8 +18,7 @@
 
 <!-- Single stackdriverlogging sink template -->
 <script id="single_stackdriverlogging_sink-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.stackdriverlogging.sinks}}
+    {{> modal-template template='services.stackdriverlogging.sinks'}}
 </script>
 <script>
     var single_stackdriverlogging_sink_template = Handlebars.compile($("#single_stackdriverlogging_sink-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.peering_connections.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.peering_connections.html
@@ -1,7 +1,7 @@
 
     <!-- VPC peering connection partial -->
     <script id="services.vpc.regions.id.peering_connections.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
             <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -40,8 +40,7 @@
 
     <!-- Single VPC Subnet template -->
     <script id="single_vpc_peering_connection-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.vpc.regions.id.peering_connections}}
+        {{> modal-template template='services.vpc.regions.id.peering_connections'}}
     </script>
     <script>
         var single_vpc_peering_connection_template = Handlebars.compile($("#single_vpc_peering_connection-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.vpcs.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.vpcs.html
@@ -1,7 +1,7 @@
 
     <!-- VPC partial -->
     <script id="services.vpc.regions.id.vpcs.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
           <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -62,8 +62,7 @@
 
     <!-- Single VPC template -->
     <script id="single_vpc-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.vpc.regions.id.vpcs}}
+        {{> modal-template template='services.vpc.regions.id.vpcs'}}
     </script>
     <script>
         var single_vpc_template = Handlebars.compile($("#single_vpc-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.vpcs.id.flow_logs.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.vpcs.id.flow_logs.html
@@ -1,7 +1,7 @@
 
     <!-- VPC Flow log partial -->
     <script id="services.vpc.regions.id.vpcs.id.flow_logs.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
             <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         <div class="list-group-item">
@@ -22,8 +22,7 @@
 
     <!-- Single VPC Subnet template -->
     <script id="single_vpc_flow_log-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.vpc.regions.id.vpcs.id.flow_logs}}
+        {{> modal-template template='services.vpc.regions.id.vpcs.id.flow_logs'}}
     </script>
     <script>
         var single_vpc_flow_log_template = Handlebars.compile($("#single_vpc_flow_log-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.vpcs.id.network_acls.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.vpcs.id.network_acls.html
@@ -1,7 +1,7 @@
 
     <!-- VPC Network ACL partial -->
     <script id="services.vpc.regions.id.vpcs.id.network_acls.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
             <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
         {{#each rules}}
@@ -47,8 +47,7 @@
 
     <!-- Single VPC Network ACL template -->
     <script id="single_vpc_network_acl-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.vpc.regions.id.vpcs.id.network_acls}}
+        {{> modal-template template='services.vpc.regions.id.vpcs.id.network_acls'}}
     </script>
     <script>
         var single_vpc_network_acl_template = Handlebars.compile($("#single_vpc_network_acl-template").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.vpcs.id.subnets.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.vpcs.id.subnets.html
@@ -1,7 +1,7 @@
 
     <!-- VPC Subnet partial -->
     <script id="services.vpc.regions.id.vpcs.id.subnets.partial" type="text/x-handlebars-template">
-        <div class="list-group-item active">
+        <div id="resource-name" class="list-group-item active">
             <h4 class="list-group-item-heading">{{name}}</h4>
         </div>
             <div class="list-group-item">
@@ -41,8 +41,7 @@
 
     <!-- Single VPC Subnet template -->
     <script id="single_vpc_subnet-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> services.vpc.regions.id.vpcs.id.subnets}}
+        {{> modal-template template='services.vpc.regions.id.vpcs.id.subnets'}}
     </script>
     <script>
         var single_vpc_subnet_template = Handlebars.compile($("#single_vpc_subnet-template").html());

--- a/ScoutSuite/output/data/html/partials/dashboard.html
+++ b/ScoutSuite/output/data/html/partials/dashboard.html
@@ -8,25 +8,26 @@
                     <input class="form-control dashboard-filter" type="text" id="dashboardFilter" placeholder="Filter findings">
                 </div>
                 <div class="col-sm-2">
-                    <button class="form-control btn finding-title-unknown text-info" id="finding-title">Show All</button>
+                    <button class="form-control btn btn-light" id="finding-title">Show All</button>
                 </div>
                 <div class="col-sm-2">
-                    <button class="form-control btn finding-title-good" id="finding-title-good">Good</button>
+                    <button class="form-control btn btn-success" id="finding-title-good">Good</button>
                 </div>
                 <div class="col-sm-2">
-                    <button class="form-control btn finding-title-warning" id="finding-title-warning">Warning</button>
+                    <button class="form-control btn btn-warning" id="finding-title-warning">Warning</button>
                 </div>
                 <div class="col-sm-2">
-                    <button class="form-control btn finding-title-danger" id="finding-title-danger">Danger</button>
+                    <button class="form-control btn btn-danger" id="finding-title-danger">Danger</button>
                 </div>
               </div>
 
               <ul class="list-group">
                   {{#each_dict_as_sorted_list findings}}
-                  <div id="list-{{key}}" class="finding_items">
-                      <div class="list-group-item finding-title-{{dashboard_color level checked_items flagged_items}} plain-link">
+                  <div id="list-{{key}}" class="finding_items ">
+                      <div class="list-group-item finding-title finding-title-{{dashboard_color level checked_items flagged_items}} plain-link">
                           <div class="row">
                               <div class="col-sm-11">
+                                  <span class="finding-badge finding-badge-{{dashboard_color level checked_items flagged_items}}"></span>
                                   <a href="#services.{{../service_name}}.findings.{{key}}.items">{{description}}</a>
                               </div>
                               <div class="col-sm-1">
@@ -34,17 +35,15 @@
                               </div>
                           </div>
                       </div>
-                      <div class="list-group-item">
-                          <div id="item-{{key}}" class="row collapse" aria-labelledby="item-{{key}}" data-parent="#list-{{key}}">
-                              <div class="col-sm-9">
-                                  <p>{{rationale}}</p>
-                              </div>
-                              <div class="col-sm-3">
-                                  <ul>
-                                      <li>{{dashboard_name}} checked: {{checked_items}}</li>
-                                      <li>{{dashboard_name}} flagged: {{flagged_items}}</li>
-                                  </ul>
-                              </div>
+                      <div class="list-group-item collapse" id="item-{{key}}" aria-labelledby="item-{{key}}" data-parent="#list-{{key}}">
+                          <div class="col-sm-9">
+                              <p>{{rationale}}</p>
+                          </div>
+                          <div class="col-sm-3">
+                              <ul>
+                                  <li>{{dashboard_name}} checked: {{checked_items}}</li>
+                                  <li>{{dashboard_name}} flagged: {{flagged_items}}</li>
+                              </ul>
                           </div>
                       </div>
                   </div>
@@ -67,6 +66,7 @@
                       $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
                   });
               });
+
               // Filter by button
               $('.btn').click(function() {
                   var value = $(this).attr('id');

--- a/ScoutSuite/output/data/html/partials/dashboard.html
+++ b/ScoutSuite/output/data/html/partials/dashboard.html
@@ -26,7 +26,7 @@
                       <div id="list-{{key}}" class="card finding_items">
                         <div class="card-header row finding-title finding-title-{{dashboard_color level checked_items flagged_items}} plain-link">
                             <div class="col-sm-11">
-                                <span class="finding-badge finding-badge-{{dashboard_color level checked_items flagged_items}}"></span>
+                                <i class="fa finding-badge finding-badge-{{dashboard_color level checked_items flagged_items}}"></i>
                                 <a href="#services.{{../service_name}}.findings.{{key}}.items">{{description}}</a>
                             </div>
                             <div class="col-sm-1">

--- a/ScoutSuite/output/data/html/partials/dashboard.html
+++ b/ScoutSuite/output/data/html/partials/dashboard.html
@@ -21,32 +21,32 @@
                 </div>
               </div>
 
-              <ul class="list-group">
+              <ul class="list-group accordion">
                   {{#each_dict_as_sorted_list findings}}
-                  <div id="list-{{key}}" class="finding_items">
-                      <div class="list-group-item finding-title finding-title-{{dashboard_color level checked_items flagged_items}} plain-link">
-                          <div class="row">
-                              <div class="col-sm-11">
-                                  <span class="finding-badge finding-badge-{{dashboard_color level checked_items flagged_items}}"></span>
-                                  <a href="#services.{{../service_name}}.findings.{{key}}.items">{{description}}</a>
-                              </div>
-                              <div class="col-sm-1">
-                                  <button class="finding btn fa collapsed" style="background-color:transparent" data-toggle="collapse" data-target="#item-{{key}}" aria-expanded="false" aria-controls="item-{{key}}"></button>
-                              </div>
-                          </div>
-                      </div>
-                      <div class="list-group-item collapse" id="item-{{key}}" aria-labelledby="item-{{key}}" data-parent="#list-{{key}}">
-                          <div class="col-sm-9">
-                              <p>{{rationale}}</p>
-                          </div>
-                          <div class="col-sm-3">
-                              <ul>
-                                  <li>{{dashboard_name}} checked: {{checked_items}}</li>
-                                  <li>{{dashboard_name}} flagged: {{flagged_items}}</li>
-                              </ul>
-                          </div>
-                      </div>
-                  </div>
+                      <div id="list-{{key}}" class="card finding_items">
+                        <div class="card-header row finding-title finding-title-{{dashboard_color level checked_items flagged_items}} plain-link">
+                            <div class="col-sm-11">
+                                <span class="finding-badge finding-badge-{{dashboard_color level checked_items flagged_items}}"></span>
+                                <a href="#services.{{../service_name}}.findings.{{key}}.items">{{description}}</a>
+                            </div>
+                            <div class="col-sm-1">
+                                <button class="finding btn fa collapsed" style="background-color:transparent" data-toggle="collapse" data-target="#item-{{key}}" aria-expanded="false" aria-controls="item-{{key}}"></button>
+                            </div>
+                        </div>
+                        <div class="collapse" id="item-{{key}}" aria-labelledby="item-{{key}}" data-parent="#list-{{key}}">
+                            <div class="card-body">
+                                <div class="col-sm-9">
+                                    <p>{{rationale}}</p>
+                                </div>
+                                <div class="col-sm-3">
+                                    <ul>
+                                        <li>{{dashboard_name}} checked: {{checked_items}}</li>
+                                        <li>{{dashboard_name}} flagged: {{flagged_items}}</li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                   {{/each_dict_as_sorted_list}}
               </ul>
 

--- a/ScoutSuite/output/data/html/partials/dashboard.html
+++ b/ScoutSuite/output/data/html/partials/dashboard.html
@@ -34,7 +34,7 @@
                             </div>
                         </div>
                         <div class="collapse" id="item-{{key}}" aria-labelledby="item-{{key}}" data-parent="#list-{{key}}">
-                            <div class="card-body">
+                            <div class="card-body row">
                                 <div class="col-sm-9">
                                     <p>{{rationale}}</p>
                                 </div>

--- a/ScoutSuite/output/data/html/partials/dashboard.html
+++ b/ScoutSuite/output/data/html/partials/dashboard.html
@@ -23,7 +23,7 @@
 
               <ul class="list-group">
                   {{#each_dict_as_sorted_list findings}}
-                  <div id="list-{{key}}" class="finding_items ">
+                  <div id="list-{{key}}" class="finding_items">
                       <div class="list-group-item finding-title finding-title-{{dashboard_color level checked_items flagged_items}} plain-link">
                           <div class="row">
                               <div class="col-sm-11">

--- a/ScoutSuite/output/data/html/partials/dashboard.html
+++ b/ScoutSuite/output/data/html/partials/dashboard.html
@@ -30,7 +30,7 @@
                                   <a href="#services.{{../service_name}}.findings.{{key}}.items">{{description}}</a>
                               </div>
                               <div class="col-sm-1">
-                                  <button class="btn fa fa-plus" style="background-color:transparent" data-toggle="collapse" data-target="#item-{{key}}" aria-expanded="false" aria-controls="item-{{key}}"></button>
+                                  <button class="finding btn fa collapsed" style="background-color:transparent" data-toggle="collapse" data-target="#item-{{key}}" aria-expanded="false" aria-controls="item-{{key}}"></button>
                               </div>
                           </div>
                       </div>

--- a/ScoutSuite/output/data/html/partials/gcp/services.cloudresourcemanager.bindings.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.cloudresourcemanager.bindings.html
@@ -1,7 +1,7 @@
 
 <!-- Cloud Resources Manager bindings' partial -->
 <script id="services.cloudresourcemanager.bindings.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -49,8 +49,7 @@
 
 <!-- Single cloudresourcemanager binding template -->
 <script id="single_cloudresourcemanager_binding-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.cloudresourcemanager.bindings}}
+    {{> modal-template template='services.cloudresourcemanager.bindings'}}
 </script>
 <script>
     var single_cloudresourcemanager_binding_template = Handlebars.compile($("#single_cloudresourcemanager_binding-template").html());

--- a/ScoutSuite/output/data/html/partials/gcp/services.cloudsql.instances.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.cloudsql.instances.html
@@ -1,7 +1,7 @@
 
 <!-- Cloud Storage instances partial -->
 <script id="services.cloudsql.instances.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -21,8 +21,7 @@
 
 <!-- Single cloudsql instance template -->
 <script id="single_cloudsql_instance-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.cloudsql.instances}}
+    {{> modal-template template='services.cloudsql.instances'}}
 </script>
 <script>
     var single_cloudsql_instance_template = Handlebars.compile($("#single_cloudsql_instance-template").html());

--- a/ScoutSuite/output/data/html/partials/gcp/services.cloudstorage.buckets.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.cloudstorage.buckets.html
@@ -1,7 +1,7 @@
 
 <!-- Cloud Storage bucket partial -->
 <script id="services.cloudstorage.buckets.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -38,8 +38,7 @@
 
 <!-- Single cloudstorage bucket template -->
 <script id="single_cloudstorage_bucket-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.cloudstorage.buckets}}
+    {{> modal-template template='services.cloudstorage.buckets'}}
 </script>
 <script>
     var single_cloudstorage_bucket_template = Handlebars.compile($("#single_cloudstorage_bucket-template").html());

--- a/ScoutSuite/output/data/html/partials/gcp/services.computeengine.firewalls.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.computeengine.firewalls.html
@@ -1,7 +1,7 @@
 
 <!-- Compute Engine firewalls partial -->
 <script id="services.computeengine.firewalls.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -91,8 +91,7 @@
 
 <!-- Single computeengine firewall template -->
 <script id="single_computeengine_firewall-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.computeengine.firewalls}}
+    {{> modal-template template='services.computeengine.firewalls'}}
 </script>
 <script>
     var single_computeengine_firewall_template = Handlebars.compile($("#single_computeengine_firewall-template").html());

--- a/ScoutSuite/output/data/html/partials/gcp/services.computeengine.instances.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.computeengine.instances.html
@@ -1,7 +1,7 @@
 
 <!-- Compute Engine instances partial -->
 <script id="services.computeengine.instances.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -60,8 +60,7 @@
 
 <!-- Single computeengine instance template -->
 <script id="single_computeengine_instance-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.computeengine.instances}}
+    {{> modal-template template='services.computeengine.instances'}}
 </script>
 <script>
     var single_computeengine_instance_template = Handlebars.compile($("#single_computeengine_instance-template").html());

--- a/ScoutSuite/output/data/html/partials/gcp/services.computeengine.networks.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.computeengine.networks.html
@@ -1,7 +1,7 @@
 
 <!-- Compute Engine networks partial -->
 <script id="services.computeengine.networks.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -20,8 +20,7 @@
 
 <!-- Single computeengine network template -->
 <script id="single_computeengine_network-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.computeengine.networks}}
+    {{> modal-template template='services.computeengine.networks'}}
 </script>
 <script>
     var single_computeengine_network_template = Handlebars.compile($("#single_computeengine_network-template").html());

--- a/ScoutSuite/output/data/html/partials/gcp/services.computeengine.snapshots.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.computeengine.snapshots.html
@@ -1,7 +1,7 @@
 
 <!-- Compute Engine snapshots partial -->
 <script id="services.computeengine.snapshots.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -19,8 +19,7 @@
 
 <!-- Single computeengine snapshot template -->
 <script id="single_computeengine_snapshot-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.computeengine.snapshots}}
+    {{> modal-template template='services.computeengine.snapshots'}}
 </script>
 <script>
     var single_computeengine_snapshot_template = Handlebars.compile($("#single_computeengine_snapshot-template").html());

--- a/ScoutSuite/output/data/html/partials/gcp/services.computeengine.subnetworks.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.computeengine.subnetworks.html
@@ -1,7 +1,7 @@
 
 <!-- Compute Engine subnetworks partial -->
 <script id="services.computeengine.subnetworks.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -23,8 +23,7 @@
 
 <!-- Single computeengine subnetwork template -->
 <script id="single_computeengine_subnetwork-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.computeengine.subnetworks}}
+    {{> modal-template template='services.computeengine.subnetworks'}}
 </script>
 <script>
     var single_computeengine_subnetwork_template = Handlebars.compile($("#single_computeengine_subnetwork-template").html());

--- a/ScoutSuite/output/data/html/partials/gcp/services.iam.service_accounts.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.iam.service_accounts.html
@@ -1,7 +1,7 @@
 
 <!-- Cloud Storage service_accounts partial -->
 <script id="services.iam.service_accounts.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -53,8 +53,7 @@
 
 <!-- Single iam service_account template -->
 <script id="single_iam_service_account-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.iam.service_accounts}}
+    {{> modal-template template='services.iam.service_accounts'}}
 </script>
 <script>
     var single_iam_service_account_template = Handlebars.compile($("#single_iam_service_account-template").html());

--- a/ScoutSuite/output/data/html/partials/gcp/services.stackdriverlogging.sinks.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.stackdriverlogging.sinks.html
@@ -1,7 +1,7 @@
 
 <!-- Stackdriver Logging sinks partial -->
 <script id="services.stackdriverlogging.sinks.partial" type="text/x-handlebars-template">
-    <div class="list-group-item active">
+    <div id="resource-name" class="list-group-item active">
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
@@ -18,8 +18,7 @@
 
 <!-- Single stackdriverlogging sink template -->
 <script id="single_stackdriverlogging_sink-template" type="text/x-handlebars-template">
-    <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    {{> services.stackdriverlogging.sinks}}
+    {{> modal-template template='services.stackdriverlogging.sinks'}}
 </script>
 <script>
     var single_stackdriverlogging_sink_template = Handlebars.compile($("#single_stackdriverlogging_sink-template").html());

--- a/ScoutSuite/output/data/html/partials/last_run_details.html
+++ b/ScoutSuite/output/data/html/partials/last_run_details.html
@@ -1,0 +1,27 @@
+<script id="last_run_details-template" type="text/x-handlebars-template">
+    <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Last run details</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="list-group-item-text item-margin">Last run:
+                    <div class="list-group-item-text item-margin">Time: {{time}}</div>
+                    <div class="list-group-item-text item-margin">Command: <code>{{cmd}}</code></div>
+                </div>
+                <div class="list-group-item-text item-margin">&nbsp;</div>
+                <div class="list-group-item-text item-margin">Report generated with Scout Suite version <samp>{{version}}</samp></div>
+                <div class="list-group-item-text item-margin">&nbsp;</div>
+                <div class="list-group-item-text item-margin">Using ruleset <samp>{{ruleset_name}}</samp>:
+                <div class="list-group-item-text item-margin"><p><em>{{ruleset_about}}</em></p></div>
+            </div>
+        </div>
+    </div>
+</script>
+
+<script>
+    var last_run_details_template = Handlebars.compile($("#last_run_details-template").html());
+</script>

--- a/ScoutSuite/output/data/html/partials/last_run_details.html
+++ b/ScoutSuite/output/data/html/partials/last_run_details.html
@@ -7,17 +7,15 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <div class="modal-body">
-                <div class="list-group-item-text item-margin">Last run:
-                    <div class="list-group-item-text item-margin">Time: {{time}}</div>
-                    <div class="list-group-item-text item-margin">Command: <code>{{cmd}}</code></div>
+            <div class="modal-body m-3">
+                <div>
+                    <p><strong>Provider:</strong> {{provider_name}}</p>
+                    <p><strong>Time:</strong> {{format_date last_run.time}}</p>
+                    <p><strong>Command:</strong> <code>{{last_run.cmd}}</code></p>
+                    <p><strong>Report generated with</strong> Scout Suite version <samp>{{last_run.version}}</samp></p>
+                    <p><strong>Using ruleset</strong> <samp>{{last_run.ruleset_name}}</samp>:
+                    <p class="ml-4 mr-4 text-justify"><em>{{last_run.ruleset_about}}</em></p>
                 </div>
-                <div class="list-group-item-text item-margin">&nbsp;</div>
-                <div class="list-group-item-text item-margin">Report generated with Scout Suite version <samp>{{version}}</samp></div>
-                <div class="list-group-item-text item-margin">&nbsp;</div>
-                <div class="list-group-item-text item-margin">Using ruleset <samp>{{ruleset_name}}</samp>:
-                <div class="list-group-item-text item-margin"><p><em>{{ruleset_about}}</em></p></div>
-            </div>
         </div>
     </div>
 </script>

--- a/ScoutSuite/output/data/html/partials/metadata.html
+++ b/ScoutSuite/output/data/html/partials/metadata.html
@@ -81,6 +81,7 @@
               <li class="nav-item dropdown">
                 <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
                 <ul class="dropdown-menu">
+                  <li><a class="dropdown-item" href="javascript:showLastRunDetails()">Last run details</a></li>
                   <li><a class="dropdown-item" href="javascript:about()">About Scout Suite</a></li>
                   <li><a class="dropdown-item" href="javascript:download_exceptions()">Export exceptions</a><a id="downloadAnchorElem" style="display:none"></a></li>
                   <li><a class="dropdown-item">Dark theme

--- a/ScoutSuite/output/data/html/partials/metadata.html
+++ b/ScoutSuite/output/data/html/partials/metadata.html
@@ -1,18 +1,72 @@
-
-  <!-- Per Service Type navigation bar -->
-  <script id="metadata.list.template" type="text/x-handlebars-template">
+<!-- Per Service Type navigation bar -->
+<script id="metadata.list.template" type="text/x-handlebars-template">
       <div class="container">
         <div class="navbar-header">
           <span class="navbar-brand"><a class="text-white" href="javascript:show_main_dashboard()">Scout Suite</a></span>
         </div>
         <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              {{#each items}}
+                {{#each items}}
                 <li class="nav-item dropdown">
-                  <a href="#groups.{{@key}}.list"><span class="nav-link dropdown-toggle" id="metadata.{{@key}}">{{make_title @key}}</b></a>
+                    <a href="#" class="nav-link dropdown-toggle" role="button" data-toggle="dropdown">{{make_title @key}}</a>
+                    <ul class="dropdown-menu" role="button">
+                        {{#if summaries}}
+                            <li class="dropdown-submenu">
+                                <a href="#" class="dropdown-toggle nav-link" data-toggle="dropdown">Summaries</a>
+                                <ul class="dropdown-menu">
+                                    {{#each summaries}}
+                                    <li><a class="dropdown-item nav-link" href="#{{path}}">{{make_title @key}}</a></li>
+                                    {{/each}}
+                                </ul>
+                                <div class="dropdown-divider"></div>
+                            </li>
+                        {{/if}} 
+
+                        {{#each this}} {{#unlessEqual @key 'summaries'}} {{#unless hidden}}
+                            <li class="dropdown-submenu">
+                                <a href="#" class="dropdown-toggle nav-link" data-toggle="dropdown">{{ make_title @key }}</a>
+                                <ul class="dropdown-menu">
+                                    <li class="dropdown-header">Summaries</li>
+                                    <li><a class="dropdown-item" href="#services.{{@key}}.findings">Dashboard</a></li>
+                                    {{#each summaries}} {{#if risks}}
+                                        <li class="dropdown-submenu"><a href="#{{path}}">{{make_title @key}}</a>
+                                            <ul class="dropdown-menu">
+                                                <li class="dropdown-header">Security risks</li>
+                                                {{#each risks}}
+                                                <li><a class="dropdown-item" href="#services.{{@../../key}}.findings.{{this}}.items">{{get_value_at
+                                                    'services' @../../key 'findings' this 'description'}}</a></li>
+                                                {{/each}}
+                                            </ul>
+                                        </li>
+                                    {{else}}
+                                        <li><a class="dropdown-item" href="#{{path}}">{{make_title @key}}</a></li>
+                                    {{/if}} {{/each}}
+
+                                    <li class="dropdown-divider"></li>
+                                    <li class="dropdown-header">{{make_title @key}} config</li>
+                                    {{#each resources}} {{#unless hidden}} {{#if risks}}
+                                        <li class="dropdown-submenu"><a href="#{{path}}">{{make_title @key}} ({{count}})</a>
+                                            <ul class="dropdown-menu">
+                                                <li class="dropdown-header">Security risks</li>
+                                                {{#each risks}}
+                                                <li><a class="dropdown-item" href="#services.{{@../../key}}.findings.{{this}}.items">{{get_value_at
+                                                        'services' @../../key 'findings' this 'description'}}</a></li>
+                                                {{/each}}
+                                            </ul>
+                                        </li>
+                                    {{else}} {{#if count}}
+                                        <li><a class="dropdown-item" href="#{{path}}">{{make_title @key}} ({{count}})</a></li>
+                                    {{else}}
+                                        <li class="disabled"><a class="dropdown-item disabled" href="">{{make_title @key}}</a></li>
+                                    {{/if}} {{/if}} {{/unless}} {{/each}}
+                                </ul>
+                            </li>
+                        {{/unless}} {{/unlessEqual}} {{/each}}
+                    </ul>
                 </li>
-              {{/each}}
+                {{/each}}
             </ul>
+
             <ul class="nav navbar-nav ml-auto">
               <li class="nav-item dropdown">
                 <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">Regions</a>
@@ -40,72 +94,4 @@
             </ul>
           </div>
       </div>
-      {{#each items}}
-      <div class="container navbar-expand-md bg-primary nav sub-navbar" id="groups.{{@key}}.list">
-        <div class="navbar-collapse collapse">
-            <ul class="nav navbar-nav">
-              {{#if summaries}}
-              <li class="dropdown">
-                <a href="#" class="dropdown-toggle nav-link text-white" data-toggle="dropdown">Summaries</a>
-                <ul class="dropdown-menu">
-                  {{#each summaries}}
-                    <li><a class="dropdown-item" href="#{{path}}">{{make_title @key}}</a></li>
-                  {{/each}}
-                </ul>
-              </li>
-              {{/if}}
-              {{#each this}}
-              {{#unlessEqual @key 'summaries'}}
-              {{#unless hidden}}
-                <li class="dropdown">
-                  <a href="#" class="dropdown-toggle nav-link text-white" data-toggle="dropdown">{{make_title @key}}</a>
-                  <ul class="dropdown-menu">
-                    <li class="dropdown-header">Summaries</li>
-                    <li><a class="dropdown-item" href="#services.{{@key}}.findings">Dashboard</a></li>
-                    {{#each summaries}}
-                      {{#if risks}}
-                        <li class="dropdown-submenu"><a href="#{{path}}">{{make_title @key}}</a>
-                          <ul class="dropdown-menu">
-                            <li class="dropdown-header">Security risks</li>
-                            {{#each risks}}
-                              <li><a class="dropdown-item" href="#services.{{@../../key}}.findings.{{this}}.items">{{get_value_at 'services' @../../key 'findings' this 'description'}}</a></li>
-                            {{/each}}
-                          </ul>
-                        </li>
-                      {{else}}
-                        <li><a class="dropdown-item" href="#{{path}}">{{make_title @key}}</a></li>
-                      {{/if}}
-                    {{/each}}
-                    <li class="dropdown-divider"></li>
-                    <li class="dropdown-header">{{make_title @key}} config</li>
-                    {{#each resources}}
-                      {{#unless hidden}}
-                      {{#if risks}}
-                        <li class="dropdown-submenu"><a href="#{{path}}">{{make_title @key}} ({{count}})</a>
-                          <ul class="dropdown-menu">
-                            <li class="dropdown-header">Security risks</li>
-                            {{#each risks}}
-                              <li><a class="dropdown-item" href="#services.{{@../../key}}.findings.{{this}}.items">{{get_value_at 'services' @../../key 'findings' this 'description'}}</a></li>
-                            {{/each}}
-                          </ul>
-                        </li>
-                      {{else}}
-                        {{#if count}}
-                            <li><a class="dropdown-item" href="#{{path}}">{{make_title @key}} ({{count}})</a></li>
-                        {{else}}
-                            <li class="disabled"><a class="dropdown-item disabled" href="">{{make_title @key}}</a></li>
-                        {{/if}}
-                      {{/if}}
-                      {{/unless}}
-                    {{/each}}
-                  </ul>
-                </li>
-              {{/unless}}
-              {{/unlessEqual}}
-              {{/each}}
-            </ul>
-          </div>
-      </div>
-      {{/each}}
   </script>
-

--- a/ScoutSuite/output/data/html/partials/metadata.html
+++ b/ScoutSuite/output/data/html/partials/metadata.html
@@ -82,7 +82,7 @@
                 <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
                 <ul class="dropdown-menu">
                   <li><a class="dropdown-item" href="javascript:showLastRunDetails()">Last run details</a></li>
-                  <li><a class="dropdown-item" href="javascript:about()">About Scout Suite</a></li>
+                  <li><a class="dropdown-item" href="javascript:showAbout()">About Scout Suite</a></li>
                   <li><a class="dropdown-item" href="javascript:download_exceptions()">Export exceptions</a><a id="downloadAnchorElem" style="display:none"></a></li>
                   <li><a class="dropdown-item">Dark theme
                     <label class="switch">

--- a/ScoutSuite/output/data/html/partials/modal.html
+++ b/ScoutSuite/output/data/html/partials/modal.html
@@ -1,0 +1,28 @@
+<script id="modal-template" type="text/x-handlebars-template">
+    {{#if name}}
+    <style>
+        .modal-dialog #resource-name { display: none; }        
+    </style>
+    {{/if}}
+
+    <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">{{name}}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+                {{> (lookup . 'template') }}
+            </div>
+        </div>
+    </div>
+</script>
+
+<script>
+    Handlebars.registerPartial("modal-template", $("#modal-template").html());
+</script>

--- a/ScoutSuite/output/data/html/partials/network_interface.html
+++ b/ScoutSuite/output/data/html/partials/network_interface.html
@@ -44,13 +44,7 @@
 
 <!-- Single CloudFormation stack template -->
 <script id="single_network_interface-template" type="text/x-handlebars-template">
-  <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-  <div class="list-group-item active">
-    <h4 class="list-group-item-heading">{{network_interface}}</h4>
-  </div>
-  <div class="list-group-item">
-    {{> network_interface}}
-  </div>
+    {{> modal-template template='network_interface' name=network_interface}}
 </script>
 
 <script>

--- a/ScoutSuite/output/data/html/partials/singles.html
+++ b/ScoutSuite/output/data/html/partials/singles.html
@@ -1,18 +1,9 @@
 
-    <!-- Close popup button -->
-    <script id="close_button-template" type="text/x-handlebars-template">
-      <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-    </script>
-    <script>
-      var close_button_template = Handlebars.compile($("#close_button-template").html());
-    </script>
-
-    <!-- Single Redshift cluster template -->
-    <script id="single_redshift_cluster-template" type="text/x-handlebars-template">
-        <div style="text-align: right; padding-right: 10px; text-weight: bold;"><a href="javascript:hidePopup()">X</a></div>
-        {{> redshift_cluster}}
-    </script>
-    <script>
-        var single_redshift_cluster_template = Handlebars.compile($("#single_redshift_cluster-template").html());
-    </script>
+<!-- Single Redshift cluster template -->
+<script id="single_redshift_cluster-template" type="text/x-handlebars-template">
+    {{> modal-template template='redshift_cluster'}}
+</script>
+<script>
+    var single_redshift_cluster_template = Handlebars.compile($("#single_redshift_cluster-template").html());
+</script>
 

--- a/ScoutSuite/output/data/html/report.html
+++ b/ScoutSuite/output/data/html/report.html
@@ -199,9 +199,9 @@
                     $('#footer').css('margin-top', 0 + (docHeight - footerTop) + 'px');
             });
         </script>
-
     </div>
 
+    <div id="modal-container" class="modal fade" tabindex="-1" role="dialog"></div>
 </body>
 
 </html>

--- a/ScoutSuite/output/data/html/report.html
+++ b/ScoutSuite/output/data/html/report.html
@@ -124,7 +124,7 @@
                             {{#each items.summary}}
                             <a href="#services.{{@key}}.findings" class="card" style="color: black !important">
                                 <div class="finding-title card-header">
-                                    <span class="finding-badge finding-badge-{{dashboard_color max_level checked_items flagged_items}}"></span>
+                                    <i class="fa finding-badge finding-badge-{{dashboard_color max_level checked_items flagged_items}}"></i>
                                     {{make_title @key}}
                                     <div class="col-sm-2 float-right" style="text-align: center">{{checked_items}}</div>
                                     <div class="col-sm-2 float-right" style="text-align: center">{{flagged_items}}</div>

--- a/ScoutSuite/output/data/html/report.html
+++ b/ScoutSuite/output/data/html/report.html
@@ -139,7 +139,9 @@
                                 </div>
                                 {{#each items.summary}}
                                 <a href="#services.{{@key}}.findings" style="color: black !important;">
-                                    <div class="list-group-item finding-title-{{dashboard_color max_level checked_items flagged_items}}">{{make_title @key}}
+                                    <div class="list-group-item finding-title">
+                                        <span class="finding-badge finding-badge-{{dashboard_color max_level checked_items flagged_items}}"></span>
+                                        {{make_title @key}}
                                         <div class="col-sm-2 float-right" style="text-align: center">{{checked_items}}</div>
                                         <div class="col-sm-2 float-right" style="text-align: center">{{flagged_items}}</div>
                                         <div class="col-sm-2 float-right" style="text-align: center">{{rules_count}}</div>
@@ -185,6 +187,9 @@
             </div>
         </footer>
 
+        <!-- Used by showPopup -->
+        <div id="modal-container" class="modal fade" tabindex="-1" role="dialog"></div>
+
         <!--Always put footer at end of page-->
         <script>
             $(document).ready(function() {
@@ -196,8 +201,6 @@
             });
         </script>
     </div>
-
-    <div id="modal-container" class="modal fade" tabindex="-1" role="dialog"></div>
 </body>
 
 </html>

--- a/ScoutSuite/output/data/html/report.html
+++ b/ScoutSuite/output/data/html/report.html
@@ -113,25 +113,26 @@
                             <div class="list-group-item-heading">Dashboard</div>
                         </div>
                         <div class="accordion" id="last_run">
-                            <div class="card">
+                            <a class="card">
                                 <div class="card-header">Service
                                     <div class="col-sm-2 float-right" style="text-align: center">Checks</div>
                                     <div class="col-sm-2 float-right" style="text-align: center">Findings</div>
                                     <div class="col-sm-2 float-right" style="text-align: center">Rules</div>
                                     <div class="col-sm-2 float-right" style="text-align: center">Resources</div>
                                 </div>
-                                {{#each items.summary}}
-                                <a href="#services.{{@key}}.findings" class="card-header" style="color: black !important">
-                                    <div class="finding-title">
-                                        <span class="finding-badge finding-badge-{{dashboard_color max_level checked_items flagged_items}}"></span>
-                                        {{make_title @key}}
-                                        <div class="col-sm-2 float-right" style="text-align: center">{{checked_items}}</div>
-                                        <div class="col-sm-2 float-right" style="text-align: center">{{flagged_items}}</div>
-                                        <div class="col-sm-2 float-right" style="text-align: center">{{rules_count}}</div>
-                                        <div class="col-sm-2 float-right" style="text-align: center">{{resources_count}}</div>
-                                    </div>
-                                </a>
-                                {{/each}}
+                            </a>
+                            {{#each items.summary}}
+                            <a href="#services.{{@key}}.findings" class="card" style="color: black !important">
+                                <div class="finding-title card-header">
+                                    <span class="finding-badge finding-badge-{{dashboard_color max_level checked_items flagged_items}}"></span>
+                                    {{make_title @key}}
+                                    <div class="col-sm-2 float-right" style="text-align: center">{{checked_items}}</div>
+                                    <div class="col-sm-2 float-right" style="text-align: center">{{flagged_items}}</div>
+                                    <div class="col-sm-2 float-right" style="text-align: center">{{rules_count}}</div>
+                                    <div class="col-sm-2 float-right" style="text-align: center">{{resources_count}}</div>
+                                </div>
+                            </a>
+                            {{/each}}
                             </div>
                         </div>
                     </div>

--- a/ScoutSuite/output/data/html/report.html
+++ b/ScoutSuite/output/data/html/report.html
@@ -112,17 +112,17 @@
                         <div class="list-group-item active">
                             <div class="list-group-item-heading">Dashboard</div>
                         </div>
-                        <div class="list-group-item" id="last_run">
-                            <div class="list-group-item-text">
-                                <div class="list-group-item">Service
+                        <div class="accordion" id="last_run">
+                            <div class="card">
+                                <div class="card-header">Service
                                     <div class="col-sm-2 float-right" style="text-align: center">Checks</div>
                                     <div class="col-sm-2 float-right" style="text-align: center">Findings</div>
                                     <div class="col-sm-2 float-right" style="text-align: center">Rules</div>
                                     <div class="col-sm-2 float-right" style="text-align: center">Resources</div>
                                 </div>
                                 {{#each items.summary}}
-                                <a href="#services.{{@key}}.findings" style="color: black !important;">
-                                    <div class="list-group-item finding-title">
+                                <a href="#services.{{@key}}.findings" class="card-header" style="color: black !important">
+                                    <div class="finding-title">
                                         <span class="finding-badge finding-badge-{{dashboard_color max_level checked_items flagged_items}}"></span>
                                         {{make_title @key}}
                                         <div class="col-sm-2 float-right" style="text-align: center">{{checked_items}}</div>

--- a/ScoutSuite/output/data/html/report.html
+++ b/ScoutSuite/output/data/html/report.html
@@ -133,7 +133,7 @@
                         <div class="list-group-item active">
                             <div class="list-group-item-heading">Dashboard</div>
                         </div>
-                        <div class="list-group-item">
+                        <div class="list-group-item" id="last_run">
                             <div class="list-group-item-text">
                                 <div class="list-group-item">Service
                                     <div class="col-sm-2 float-right" style="text-align: center">Checks</div>
@@ -151,17 +151,6 @@
                                     </div>
                                 </a>
                                 {{/each}}
-                            </div>
-                            <div class="list-group-item-text item-margin">&nbsp;</div>
-                            <div class="list-group-item-text item-margin">Last run:
-                                <div class="list-group-item-text item-margin">Time: {{items.time}}</div>
-                                <div class="list-group-item-text item-margin">Command: <code>{{items.cmd}}</code></div>
-                            </div>
-                            <div class="list-group-item-text item-margin">&nbsp;</div>
-                            <div class="list-group-item-text item-margin">Report generated with Scout Suite version <samp>{{items.version}}</samp></div>
-                            <div class="list-group-item-text item-margin">&nbsp;</div>
-                            <div class="list-group-item-text item-margin">Using ruleset <samp>{{items.ruleset_name}}</samp>:
-                                <div class="list-group-item-text item-margin"><p><em>{{items.ruleset_about}}</em></p></div>
                             </div>
                         </div>
                     </div>

--- a/ScoutSuite/output/data/html/report.html
+++ b/ScoutSuite/output/data/html/report.html
@@ -91,23 +91,6 @@
 
             <!-- PLACEHOLDER -->
 
-            <!-- About Scout -->
-            <div class="row" id="about.details">
-                <div class="list-group">
-                    <div class="row list-group-item active">
-                        About Scout Suite
-                    </div>
-                    <div class="row list-group-item">
-                        <p>Scout Suite is an open-source tool released by <a href="https://www.nccgroup.trust" rel="author" target="_blank">NCC Group</a>.</p>
-                        <p>Use the top navigation bar to review the configuration of the supported cloud provider services.</p>
-                        <p>
-                            For more information about Scout Suite, please check out the project's page on
-                            <a href="https://github.com/nccgroup/ScoutSuite" target="_blank">GitHub</a>.
-                        </p>
-                    </div>
-                </div>
-            </div>
-
             <!-- Please wait -->
             <div class="row" id="please_wait.details">
                 <div class="list-group">

--- a/ScoutSuite/output/data/html/report.html
+++ b/ScoutSuite/output/data/html/report.html
@@ -56,10 +56,6 @@
         <!-- Empty header -->
         <div class="spacer"></div>
 
-        <!-- Overlay divs used to show entity details in a pop up fashion -->
-        <div id="overlay-background" class="overlay-bg"></div>
-        <div id="overlay-details" class="overlay col-sm-6"></div>
-
         <!-- AWS account ID -->
         <div class="row justify-content-center" id="aws_account_id.details">
             <h4>

--- a/ScoutSuite/output/data/html/ruleset-generator.html
+++ b/ScoutSuite/output/data/html/ruleset-generator.html
@@ -99,10 +99,6 @@
             <div class="page-header">
             </div>
 
-            <!-- Overlay divs used to show entity details in a pop up fashion -->
-            <div id="overlay-background" class="overlay-bg"></div>
-            <div id="overlay-details" class="overlay col-sm-6"></div>
-
             <!-- Title section -->
             <div id="section_title-div">
                 <h2 id="section_title-h2"></h2>

--- a/ScoutSuite/output/data/html/ruleset-generator.html
+++ b/ScoutSuite/output/data/html/ruleset-generator.html
@@ -65,7 +65,7 @@
                         <li class="dropdown">
                             <a href="#" class="dropdown-toggle" data-toggle="dropdown"><i class="fa fa-cog"></i></a>
                             <ul class="dropdown-menu">
-                                <li><a href="javascript:about()">About</a></li>
+                                <li><a href="javascript:showAbout()">About</a></li>
                             </ul>
                         </li>
                     </ul>

--- a/ScoutSuite/output/data/inc-scoutsuite/modal.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/modal.css
@@ -1,0 +1,27 @@
+.modal-dialog .list-group-item { 
+    border: none;
+}
+
+.modal-header {
+    background-color: #2C3E50;
+    border-radius: 3px 3px 0 0;
+    color: white;
+}
+
+.modal .close,
+.modal .close:not(:disabled):not(.disabled):hover, 
+.modal .close:not(:disabled):not(.disabled):focus {
+    color: white;
+}
+
+.modal-header {
+    height: 65px;
+}
+
+.modal-body {
+    overflow-y: auto;
+}
+
+.modal-content {
+    max-height: 80vh;
+}

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -53,7 +53,7 @@
     color: #23af44 !important;
 }
 .finding-title {
-    background: #f5f5f5 !important;
+    background: #f5f5f5;
 }
 
 .finding-badge {
@@ -114,34 +114,24 @@ ul.no-bullet {
 .plain-link a:link,
 .plain-link a:visited,
 .plain-link a:active {
-    color: #019479 !important;
-    text-decoration: none !important;
+    color: black;
+    text-decoration: none;
 }
 
 .plain-link a:hover {
-    color: #007f67 !important;
-    text-decoration: underline !important;
+    text-decoration: underline;
 }
 
-.disabled-link a:link{
+.disabled-link a:link,
+.disabled-link a:active,
+.disabled-link a:visited,
+.disabled-link a:hover {
+    color: rgb(110, 110, 110);
     pointer-events: none;
     cursor: default;
 }
-.disabled-link a:visited{
-    pointer-events: none;
-    cursor: default;
-}
-.disabled-link a:hover{
-    pointer-events: none;
-    cursor: default;
-}
-.disabled-link a:active{
-    pointer-events: none;
-    cursor: default;
-}
-
 .active a{
-    text-decoration: none !important;
+    text-decoration: none;
     color: black;
 }
 
@@ -336,6 +326,7 @@ input:checked + .slider:before {
 }
 
 .finding_items {
+    font-size: 18px;
     margin: 4px 0;
     border-radius: 3px;
 }

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -2,10 +2,6 @@
 
 /* Bootstrap overrides */
 
-.card-header:first-child {
-    border-radius: calc(.25rem - 1px) calc(.25rem - 1px) 0 0;
-}
-
 .btn-success,
 .btn-success:focus
  {
@@ -277,6 +273,7 @@ input:checked + .slider:before {
 }
 
 .finding:before {
+    color: black;
     content: "\f068"; /* Fontawesome '+' */
     left:5px;
     position:absolute;
@@ -286,6 +283,7 @@ input:checked + .slider:before {
 
 
 .collapsed.finding:before {
+    color: black;
     content: "\f067"; /* Fontawesome '-' */
     left:5px;
     position:absolute;

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -1,3 +1,5 @@
+@import url("./modal.css");
+
 .item-margin {
     margin-left: 25px;
 }

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -1,5 +1,38 @@
 @import url("./modal.css");
 
+/* Bootstrap overrides */
+
+.btn-success,
+.btn-success:focus
+ {
+    color: #fff;
+    background-color: #23af44;
+    border-color: #23af44;
+}
+
+.btn-success:hover,
+.btn-success:active
+ {
+    color: #fff;
+    background-color: #1f9b3c;
+    border-color: #1f9b3c;
+}
+
+.btn-warning:focus {
+    color: #fff;
+    background-color: #F39C12;
+    border-color: #F39C12;
+}
+
+.btn-danger:focus {
+    color: #fff;
+    background-color: #E74C3C;
+    border-color: #E74C3C;
+}
+
+/* Scout Suite */
+
+
 .item-margin {
     margin-left: 25px;
 }
@@ -11,25 +44,34 @@
     display: none;
 }
 .finding-danger {
-    color:  red !important;
-}
-.finding-title-danger {
-    background: red!important;
+    color:  #ee293d !important;
 }
 .finding-warning {
-    color: orange !important;
-}
-.finding-title-warning {
-    background: orange !important;
+    color: #fdbe00 !important;
 }
 .finding-good {
-    color: green !important;
+    color: #23af44 !important;
 }
-.finding-title-good {
-    background: green !important;
+.finding-title {
+    background: #f5f5f5 !important;
 }
-.finding-title-unknown {
-    background: #eee !important;
+
+.finding-badge {
+    margin-bottom: 1px;
+    margin-right: 8px;
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 100%;
+    box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.4), inset 0px -1px 2px rgba(255, 255, 255, 0.5);
+}
+
+.finding-badge-good { background-color: #23af44; }
+.finding-badge-warning { background-color: #fdbe00; }
+.finding-badge-danger { background-color: #ee293d; }
+.finding-badge-unknown { 
+    background-color: rgba(225, 225, 225); 
+    box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.2), inset 0px -1px 2px rgba(255, 255, 255, 0.5);
 }
 
 ul.no-bullet {
@@ -69,22 +111,18 @@ ul.no-bullet {
     border-radius: 5px;
 }
 
-.plain-link a:link {
-    color: black !important;
-    text-decoration: none !important;
-}
-.plain-link a:visited {
-    color: black !important;
-    text-decoration: none !important;
-}
-.plain-link a:hover {
-    color: black !important;
-    text-decoration: none !important;
-}
+.plain-link a:link,
+.plain-link a:visited,
 .plain-link a:active {
-    color: black !important;
+    color: #019479 !important;
     text-decoration: none !important;
 }
+
+.plain-link a:hover {
+    color: #007f67 !important;
+    text-decoration: none !important;
+}
+
 .disabled-link a:link{
     pointer-events: none;
     cursor: default;
@@ -104,7 +142,7 @@ ul.no-bullet {
 
 .active a{
     text-decoration: none !important;
-    color: black !important;
+    color: black;
 }
 
 .dropdown-submenu {
@@ -278,4 +316,26 @@ input:checked + .slider:before {
 
 #last_run {
     width: 100%;
+}
+
+#double-column-left .list-group {
+    margin: 3px 0;
+}
+
+#double-column-left .active a,
+#double-column-left .active .fa {
+    color: rgba(24, 188, 155);
+}
+
+#double-column-left .active .fa:hover {
+    color: rgba(24, 188, 155);
+}
+
+.finding-learn-more i {
+    font-size: 0.8em;
+}
+
+.finding_items {
+    margin: 4px 0;
+    border-radius: 3px;
 }

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -120,7 +120,7 @@ ul.no-bullet {
 
 .plain-link a:hover {
     color: #007f67 !important;
-    text-decoration: none !important;
+    text-decoration: underline !important;
 }
 
 .disabled-link a:link{

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -48,15 +48,27 @@
     margin-bottom: 1px;
     margin-right: 8px;
     display: inline-block;
-    width: 12px;
-    height: 12px;
     border-radius: 100%;
 }
 
-.finding-badge-good { background-image: linear-gradient(#23af44 10%, #21983d 90%); }
-.finding-badge-warning { background-image: linear-gradient(#fdbe00 10%, #daa300 90%); }
-.finding-badge-danger { background-image: linear-gradient(#ee293d 10%, #cc2233 90%); }
-.finding-badge-unknown {  background-image: linear-gradient(rgb(225, 225, 225) 10%, rgb(201, 201, 201) 90%); background-color:  }
+.finding-badge-good:before { 
+    content: '\f06a';
+    color: #23af44; 
+}
+
+.finding-badge-warning:before { 
+    content: '\f06a';
+    color: #fdbe00; 
+}
+
+.finding-badge-danger:before { 
+    content: '\f714';
+    color:#ee293d; 
+}
+.finding-badge-unknown:before {  
+    content: '\f111';
+    color: rgb(225, 225, 225);
+}
 
 ul.no-bullet {
     list-style-type: none;
@@ -278,7 +290,6 @@ input:checked + .slider:before {
     left:5px;
     position:absolute;
     top:0;
-    
 }
 
 

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -260,7 +260,7 @@ input:checked + .slider:before {
 
 .finding:before {
     content: "\f068";
-    left:-5px;
+    left:5px;
     position:absolute;
     top:0;
 }
@@ -268,7 +268,7 @@ input:checked + .slider:before {
 
 .collapsed.finding:before {
     content: "\f067";
-    left:-5px;
+    left:5px;
     position:absolute;
     top:0;
 }

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -134,7 +134,6 @@ ul.no-bullet {
     border-width: 5px 0 5px 5px;
     border-left-color: #ccc;
     margin-top: 5px;
-    margin-right: -10px;
 }
 
 .dropdown-submenu:hover>a:after {
@@ -151,6 +150,14 @@ ul.no-bullet {
     -webkit-border-radius: 6px 0 6px 6px;
     -moz-border-radius: 6px 0 6px 6px;
     border-radius: 6px 0 6px 6px;
+}
+
+.dropdown-item.disabled, .dropdown-item:disabled {
+    color: #bbcdce;
+}
+
+.dropdown-item {
+    color: #647273;
 }
 
 .rationale-overlay {

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -2,6 +2,10 @@
 
 /* Bootstrap overrides */
 
+.card-header:first-child {
+    border-radius: calc(.25rem - 1px) calc(.25rem - 1px) 0 0;
+}
+
 .btn-success,
 .btn-success:focus
  {
@@ -40,18 +44,6 @@
     margin-left: -25px !important;
 }
 
-.finding-hidden {
-    display: none;
-}
-.finding-danger {
-    color:  #ee293d !important;
-}
-.finding-warning {
-    color: #fdbe00 !important;
-}
-.finding-good {
-    color: #23af44 !important;
-}
 .finding-title {
     background: #f5f5f5;
 }
@@ -63,7 +55,7 @@
     width: 10px;
     height: 10px;
     border-radius: 100%;
-    box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.4), inset 0px -1px 2px rgba(255, 255, 255, 0.5);
+    box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.2), inset 0px -1px 2px rgba(255, 255, 255, 0.5);
 }
 
 .finding-badge-good { background-color: #23af44; }
@@ -327,6 +319,4 @@ input:checked + .slider:before {
 
 .finding_items {
     font-size: 18px;
-    margin: 4px 0;
-    border-radius: 3px;
 }

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -253,3 +253,22 @@ input:checked + .slider:before {
 .std-size {
     font-size: 18px;
 }
+
+.finding {
+    position: relative;
+}
+
+.finding:before {
+    content: "\f068";
+    left:-5px;
+    position:absolute;
+    top:0;
+}
+
+
+.collapsed.finding:before {
+    content: "\f067";
+    left:-5px;
+    position:absolute;
+    top:0;
+}

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -52,19 +52,15 @@
     margin-bottom: 1px;
     margin-right: 8px;
     display: inline-block;
-    width: 10px;
-    height: 10px;
+    width: 12px;
+    height: 12px;
     border-radius: 100%;
-    box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.2), inset 0px -1px 2px rgba(255, 255, 255, 0.5);
 }
 
-.finding-badge-good { background-color: #23af44; }
-.finding-badge-warning { background-color: #fdbe00; }
-.finding-badge-danger { background-color: #ee293d; }
-.finding-badge-unknown { 
-    background-color: rgba(225, 225, 225); 
-    box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.2), inset 0px -1px 2px rgba(255, 255, 255, 0.5);
-}
+.finding-badge-good { background-image: linear-gradient(#23af44 10%, #21983d 90%); }
+.finding-badge-warning { background-image: linear-gradient(#fdbe00 10%, #daa300 90%); }
+.finding-badge-danger { background-image: linear-gradient(#ee293d 10%, #cc2233 90%); }
+.finding-badge-unknown {  background-image: linear-gradient(rgb(225, 225, 225) 10%, rgb(201, 201, 201) 90%); background-color:  }
 
 ul.no-bullet {
     list-style-type: none;

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.css
@@ -259,16 +259,21 @@ input:checked + .slider:before {
 }
 
 .finding:before {
-    content: "\f068";
+    content: "\f068"; /* Fontawesome '+' */
+    left:5px;
+    position:absolute;
+    top:0;
+    
+}
+
+
+.collapsed.finding:before {
+    content: "\f067"; /* Fontawesome '-' */
     left:5px;
     position:absolute;
     top:0;
 }
 
-
-.collapsed.finding:before {
-    content: "\f067";
-    left:5px;
-    position:absolute;
-    top:0;
+#last_run {
+    width: 100%;
 }

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -632,8 +632,7 @@ function showObject(path, attr_name, attr_value) {
 
     resource = makeResourceTypeSingular(resource_type);
     template = 'single_' + resource + '_template';
-    $('#overlay-details').html(window[template](data));
-    showPopup();
+    showPopup(window[template](data));
 };
 
 /**
@@ -716,19 +715,10 @@ function showS3Object(bucket_id, key_id) {
 /**
  *
  */
-function showPopup() {
-    $("#overlay-background").show();
-    $("#overlay-details").show();
+function showPopup(content) {
+    $('#modal-container').html(content);
+    $('#modal-container').modal();
 };
-
-/**
- *
- */
-function hidePopup() {
-    $("#overlay-background").hide();
-    $("#overlay-details").hide();
-};
-
 
 /**
  * Set up dashboards and dropdown menus
@@ -782,6 +772,15 @@ function about() {
     $('#findings_download_button').hide();
     $('#section_title-h2').text('');
 };
+
+
+/**
+ * 
+ */
+function showLastRunDetails() {
+    $('#modal-container').html(last_run_details_template(run_results.last_run));
+    $('#modal-container').modal();
+}
 
 /**
  * Show main dashboard

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -540,16 +540,16 @@ function findAndShowEC2Object(path, id) {
     var object = findEC2Object(run_results['services']['ec2'], entities, id);
     var etype = entities.pop();
     if (etype == 'instances') {
-        $('#overlay-details').html(single_ec2_instance_template(object));
+        showPopup(single_ec2_instance_template(object));
     } else if (etype == 'security_groups') {
-        $('#overlay-details').html(single_ec2_security_group_template(object));
+        showPopup(single_ec2_security_group_template(object));
     } else if (etype == 'vpcs') {
-        $('#overlay-details').html(single_vpc_template(object));
+        showPopup(single_vpc_template(object));
     } else if (etype == 'network_acls') {
         object['name'] = id;
-        $('#overlay-details').html(single_vpc_network_acl_template(object));
+        showPopup(single_vpc_network_acl_template(object));
     };
-    showPopup();
+    
 };
 
 /**
@@ -562,9 +562,8 @@ function findAndShowEC2ObjectByAttr(path, attributes) {
     var object = findEC2ObjectByAttr(run_results['services']['ec2'], entities, attributes);
     var etype = entities.pop();
     if (etype == 'security_groups') {
-        $('#overlay-details').html(single_ec2_security_group_template(object));
+        showPopup(single_ec2_security_group_template(object));
     };
-    showPopup();
 };
 
 /**
@@ -572,8 +571,7 @@ function findAndShowEC2ObjectByAttr(path, attributes) {
  * @param data
  */
 function showEC2Instance2(data) {
-    $('#overlay-details').html(single_ec2_instance_template(data));
-    showPopup();
+    showPopup(single_ec2_instance_template(data));
 };
 
 /**
@@ -584,8 +582,7 @@ function showEC2Instance2(data) {
  */
 function showEC2Instance(region, vpc, id) {
     var data = run_results['services']['ec2']['regions'][region]['vpcs'][vpc]['instances'][id];
-    $('#overlay-details').html(single_ec2_instance_template(data));
-    showPopup();
+    showPopup(single_ec2_instance_template(data));
 };
 
 /**
@@ -596,8 +593,7 @@ function showEC2Instance(region, vpc, id) {
  */
 function showEC2SecurityGroup(region, vpc, id) {
     var data = run_results['services']['ec2']['regions'][region]['vpcs'][vpc]['security_groups'][id];
-    $('#overlay-details').html(single_ec2_security_group_template(data));
-    showPopup();
+    showPopup(single_ec2_security_group_template(data));
 };
 
 /**
@@ -683,8 +679,7 @@ function showIAMInlinePolicy(iam_entity_type, iam_entity_name, policy_id) {
  * @param data
  */
 function showIAMPolicy(data) {
-    $('#overlay-details').html(single_iam_policy_template(data));
-    showPopup();
+    showPopup(single_iam_policy_template(data));
     var id = '#iam_policy_details-' + data['report_id'];
     $(id).toggle();
 };
@@ -695,8 +690,7 @@ function showIAMPolicy(data) {
  */
 function showS3Bucket(bucket_name) {
     var data = run_results['services']['s3']['buckets'][bucket_name];
-    $('#overlay-details').html(single_s3_bucket_template(data));
-    showPopup();
+    showPopup(single_s3_bucket_template(data));
 };
 
 /**
@@ -708,8 +702,7 @@ function showS3Object(bucket_id, key_id) {
     var data = run_results['services']['s3']['buckets'][bucket_id]['keys'][key_id];
     data['key_id'] = key_id;
     data['bucket_id'] = bucket_id;
-    $('#overlay-details').html(single_s3_object_template(data));
-    showPopup();
+    showPopup(single_s3_object_template(data));
 };
 
 /**

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -799,25 +799,6 @@ function show_main_dashboard() {
 };
 
 /**
- * Remove everything from "#" in URL
- */
-function removeHash() {
-    var scrollV, scrollH, loc = window.location;
-    if ("pushState" in history)
-        history.pushState("", document.title, loc.pathname + loc.search);
-    else {
-        // Prevent scrolling by storing the page's current scroll offset
-        scrollV = document.body.scrollTop;
-        scrollH = document.body.scrollLeft;
-        // Remove hash value
-        loc.hash = "";
-        // Restore the scroll offset, should be flicker free
-        document.body.scrollTop = scrollV;
-        document.body.scrollLeft = scrollH;
-    };
-};
-
-/**
  * Show All Resources
  * @param script_id
  */

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -769,7 +769,7 @@ function showAbout() {
  * 
  */
 function showLastRunDetails() {
-    $('#modal-container').html(last_run_details_template(run_results.last_run));
+    $('#modal-container').html(last_run_details_template(run_results));
     $('#modal-container').modal();
 }
 

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -759,11 +759,9 @@ function load_metadata() {
 /**
  * Show About Scout Suite div
  */
-function about() {
-    hideAll();
-    showRow('about');
-    $('#findings_download_button').hide();
-    $('#section_title-h2').text('');
+function showAbout() {
+    $('#modal-container').html(about_scoutsuite_template());
+    $('#modal-container').modal();
 };
 
 


### PR DESCRIPTION
This PR addresses a couple of UI issues (#61). There is still quite a lot do to in my opinion, but this takes care a few irritants.

1. Navbar refactoring (you can now click outside to close the navbar
2. The last run data was moved to a modal accessible near the "about section" in the top right corner
3. Expanding a finding by clicking the `+` transforms the said `+` to a `-`, and vice versa
4. The services issues page needed a bit more guidance, I refactored it
5. Added a bit of spacing in the sidebar
6. Refactored the whole modal system. Clicking outside will now close them. They also have a fancy fade-in animation. There is no code-duplication nightmare anymore.

Sorry about all the file changes. They are mostly one-liners though. It's for a good cause.

![demo-ui-improvements](https://user-images.githubusercontent.com/6698529/52028387-d109db80-24dc-11e9-8b46-bba57b08a0df.gif)
