### PR TITLE
feature/#30-new-finding-azure-storageaccounts-access-keys-not-rotated

### DIFF
--- a/ScoutSuite/output/data/html/partials/azure/services.storageaccounts.storage_accounts.html
+++ b/ScoutSuite/output/data/html/partials/azure/services.storageaccounts.storage_accounts.html
@@ -8,6 +8,7 @@
         <h4 class="list-group-item-heading">Information</h4>
         <div class="list-group-item-text item-margin">Storage Account Name: <span id="storageaccounts.storage_accounts.{{@key}}.name">{{name}}</span></div>
         <div class="list-group-item-text item-margin">Public traffic: <span id="storageaccounts.storage_accounts.{{@key}}.public_traffic_allowed">{{ convert_bool_to_enabled public_traffic_allowed }}</span></div>
+        <div class="list-group-item-text item-margin">Access Key Rotated: <span id="monitor.activity_logs.storage_accounts.{{@key}}.access_keys_rotated">{{ get_value_at 'services' 'monitor' 'activity_logs' 'storage_accounts' @key 'access_keys_rotated' }}</span></div>
     </div>
 
     <div class="list-group-item">

--- a/ScoutSuite/providers/azure/configs/services.py
+++ b/ScoutSuite/providers/azure/configs/services.py
@@ -2,6 +2,7 @@
 
 from ScoutSuite.providers.base.configs.services import BaseServicesConfig
 from ScoutSuite.providers.azure.services.storageaccounts import StorageAccountsConfig
+from ScoutSuite.providers.azure.services.monitor import MonitorConfig
 
 
 class AzureServicesConfig(BaseServicesConfig):
@@ -9,6 +10,7 @@ class AzureServicesConfig(BaseServicesConfig):
     def __init__(self, metadata=None, thread_config=4, **kwargs):
 
         self.storageaccounts = StorageAccountsConfig(thread_config=thread_config)
+        self.monitor = MonitorConfig(thread_config=thread_config)
 
     def _is_provider(self, provider_name):
         return provider_name == 'azure'

--- a/ScoutSuite/providers/azure/rules/findings/storageaccount-access-keys-not-rotated.json
+++ b/ScoutSuite/providers/azure/rules/findings/storageaccount-access-keys-not-rotated.json
@@ -1,0 +1,10 @@
+{
+    "dashboard_name": "Storage Accounts",
+    "description": "Access Keys Not Rotated",
+    "rationale": "The access keys of your storage accounts should be rotated at least every 90 days. See CIS 3.3.",
+    "path": "storageaccounts.storage_accounts.id",
+    "conditions": [ "and",
+        [ "monitor.activity_logs.storage_accounts._GET_VALUE_AT_(storageaccounts.storage_accounts.id).access_keys_rotated", "false", "" ]
+    ],
+    "id_suffix": "access_keys_rotated"
+}

--- a/ScoutSuite/providers/azure/rules/findings/storageaccount-account-allowing-clear-text.json
+++ b/ScoutSuite/providers/azure/rules/findings/storageaccount-account-allowing-clear-text.json
@@ -1,6 +1,7 @@
 {
     "description": "HTTPS Not Enforced",
     "path": "storageaccounts.storage_accounts.id",
+    "rationale": "You should ensure that secure transfer is required to access your storage accounts. See CIS 3.1.",
     "dashboard_name": "Accounts",
     "conditions": [ "and",
         [ "storageaccounts.storage_accounts.id.https_traffic_enabled", "false", "" ]

--- a/ScoutSuite/providers/azure/rules/findings/storageaccount-public-blob-container.json
+++ b/ScoutSuite/providers/azure/rules/findings/storageaccount-public-blob-container.json
@@ -1,0 +1,11 @@
+{
+    "dashboard_name": "Storage Accounts",
+    "description": "Public Blob Container",
+    "rationale": "Your blob containers should be private. See CIS 3.7.",
+    "path": "storageaccounts.storage_accounts.id.blob_containers.id",
+    "display_path": "storageaccounts.storage_accounts.id",
+    "conditions": [ "and",
+        [ "storageaccounts.storage_accounts.id.blob_containers.id.public_access_allowed", "true", "" ]
+    ],
+    "id_suffix": "public_access_allowed"
+}

--- a/ScoutSuite/providers/azure/rules/rulesets/default.json
+++ b/ScoutSuite/providers/azure/rules/rulesets/default.json
@@ -6,6 +6,18 @@
         "enabled": true,
         "level": "warning"
       }
+    ],
+    "storageaccount-public-blob-container.json": [
+      {
+        "enabled": true,
+        "level": "danger"
+      }
+    ],
+    "storageaccount-access-keys-not-rotated.json": [
+      {
+        "enabled": true,
+        "level": "warning"
+      }
     ]
   }
 }

--- a/ScoutSuite/providers/azure/services/monitor.py
+++ b/ScoutSuite/providers/azure/services/monitor.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+import datetime
+
+from ScoutSuite.providers.azure.configs.base import AzureBaseConfig
+
+
+class MonitorConfig(AzureBaseConfig):
+    time_format = "%Y-%m-%dT%H:%M:%S.%f"
+    utc_now = datetime.datetime.utcnow()
+    end_time = utc_now.strftime(time_format)
+    timespan = datetime.timedelta(90)  # 90 days of timespan
+    start_time = (utc_now - timespan).strftime(time_format)
+
+    targets = (
+        ('activity_logs', 'Activity Logs', 'list',
+         {'filter': "eventTimestamp ge {} and eventTimestamp le {}".format(start_time, end_time)},
+         False),
+    )
+
+    def __init__(self, thread_config):
+
+        self.activity_logs = {}
+        self.activity_logs['storage_accounts'] = {}
+
+        super(MonitorConfig, self).__init__(thread_config)
+
+    def parse_activity_logs(self, activity_log, params):
+        if activity_log.resource_type.value == 'Microsoft.Storage/storageAccounts':
+            self._parse_storage_account_logs(activity_log)
+
+    def _parse_storage_account_logs(self, activity_log):
+            storage_account_id = self.get_non_provider_id(activity_log.resource_id.lower())
+
+            if storage_account_id not in self.activity_logs['storage_accounts']:
+                self.activity_logs['storage_accounts'][storage_account_id] =\
+                    {'access_keys_rotated': False}
+                
+            if activity_log.operation_name.value == 'Microsoft.Storage/storageAccounts/regenerateKey/action':
+                self.activity_logs['storage_accounts'][storage_account_id]['access_keys_rotated'] = True

--- a/ScoutSuite/providers/azure/services/storageaccounts.py
+++ b/ScoutSuite/providers/azure/services/storageaccounts.py
@@ -21,7 +21,7 @@ class StorageAccountsConfig(AzureBaseConfig):
 
         storage_account_dict = {}
 
-        storage_account_dict['id'] = self.get_non_provider_id(storage_account.id)
+        storage_account_dict['id'] = self.get_non_provider_id(storage_account.id.lower())
         storage_account_dict['name'] = storage_account.name
         storage_account_dict['https_traffic_enabled'] = storage_account.enable_https_traffic_only
         storage_account_dict['public_traffic_allowed'] = self._is_public_traffic_allowed(storage_account)

--- a/ScoutSuite/providers/azure/utils.py
+++ b/ScoutSuite/providers/azure/utils.py
@@ -3,12 +3,15 @@
 from opinel.utils.console import printException, printInfo
 
 from azure.mgmt.storage import StorageManagementClient
+from azure.mgmt.monitor import MonitorManagementClient
 
 def azure_connect_service(service, credentials, region_name=None):
 
     try:
         if service == 'storageaccounts':
             return StorageManagementClient(credentials.credentials, credentials.subscription_id)
+        elif service == 'monitor':
+            return MonitorManagementClient(credentials.credentials, credentials.subscription_id)
 
         else:
             printException('Service %s not supported' % service)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ oauth2client>=4.1.3
 
 # Azure Provider
 azure-mgmt-storage>=3.0.0
+azure-mgmt-monitor
 azure-cli-core
 pyyaml>=4.2b1


### PR DESCRIPTION
This PR implements the rule that checks whether the access keys of a storage account have been rotated in the last 90 days, as described in CIS Microsoft Azure Foundations 3.3.
Even though the finding is related to the storage accounts service, it is based on the activity logs provided by the monitor service. Support for this one is therefore added in this PR.