### PR TITLE
Feature/120 gcp svc act multi proj

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,27 +109,27 @@ There are five ways to run scout against an Azure organization.
 
 1.  azure-cli
     1. On most system, you can install azure-cli using `pip install azure-cli`.
-    2. Log into an account. The easiest way to do it it with `az login`(for more authentication method, 
+    2. Log into an account. The easiest way to do it it with `az login`(for more authentication method,
     you can refer to https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli?view=azure-cli-latest).
     3. Run Scout with the `--azure-cli` flag.
 2.  Managed Service Identity
-    1. Configure your identity on the Azure portal(you can refer to 
+    1. Configure your identity on the Azure portal(you can refer to
     https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/)
     2. Run Scout with the `--azure-msi` flag.
 3.  Service Principal
-    1. Set up a service principal on the Azure portal(you can refer to 
+    1. Set up a service principal on the Azure portal(you can refer to
     https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal)
-    2. Run Scout with the `--azure-service-principal` flag. Scout will prompt you for the 
+    2. Run Scout with the `--azure-service-principal` flag. Scout will prompt you for the
     required information.
 4.  File-based Authentication
-    1. Create a Service Principal for azure SDK. You can do this with azure-cli using 
+    1. Create a Service Principal for azure SDK. You can do this with azure-cli using
     `az ad sp create-for-rbac --sdk-auth > mycredentials.json`.
-    2. Run Scout while providing it with the credentials file using 
+    2. Run Scout while providing it with the credentials file using
     `--azure-file-auth path/to/credentials/file`.
 5.  User Credentials
     1. Run Scout using `--azure-user-credentials`. The application will prompt you for your credentials.
 
-Scout will require the Reader role over all the resources you want to check. The easiest way is to give 
+Scout will require the Reader role over all the resources you want to check. The easiest way is to give
 it Reader over the Subscription, as it will be inherited on all the resources.
 
 ### Compliance
@@ -152,7 +152,7 @@ References:
 
 #### Azure
 
-Use of Scout Suite does not require Azure users to contact Microsoft to begin testing. The only requirement is that 
+Use of Scout Suite does not require Azure users to contact Microsoft to begin testing. The only requirement is that
 users abide by the Microsoft Cloud Unified Penetration Testing Rules of Engagement.
 
 References:
@@ -195,32 +195,33 @@ Using a computer already configured to use gcloud command-line tool, you may use
 To run Scout using Service Account keys, using the following command:
 
     $ python Scout.py --provider gcp --service-account --key-file </PATH/TO/KEY_FILE.JSON>
-By default, using the `--service-account` argument will audit all the projects that the provided service account has access to. If you only want to scan a single project, include the `--project-id` argument.
+By default, using the `--service-account` argument will audit only the inferred project that is part of its credentials key file. To scan all projects that a service account has access to, use the `--all` flag to override. If you only want to scan a single project, include the `--project-id` argument.
 
 To scan a GCP ...
 - Organization, use the `organization-id <ORGANIZATION ID>` argument
 - Folder, use the `folder-id <FOLDER ID>` argument.
 - Project, use the `project-id <PROJECT ID>` argument
+- All projects that a user/service account has access to, use the `--all` flags.
 
 #### Azure
 
 Using a computer already configured to use azure-cli, you may use Scout using the following command:
 
     $ python Scout.py --provider azure --azure-cli
-    
-When using Scout in an Azure virtual machine with the Reader role, you may use 
+
+When using Scout in an Azure virtual machine with the Reader role, you may use
 Scout using the following command:
 
     $ python Scout.py --provider azure --azure-msi
-    
+
 When using Scout with a Service Principal, you may run Scout using the following command:
 
     $ python Scout.py --provider azure --azure-service-principal
-    
+
 When using Scout with an authentication file, you may run Scout using the following command:
 
     $ python Scout.py --provider azure --azure-file-auth path/to/auth/file
-  
+
 When using Scout against your user account, you may run Scout using the following command:
 
     $ python Scout.py --provider azure --azure-user-credentials

--- a/README.md
+++ b/README.md
@@ -111,15 +111,19 @@ There are five ways to run scout against an Azure organization.
     1. On most system, you can install azure-cli using `pip install azure-cli`.
     2. Log into an account. The easiest way to do it it with `az login`(for more authentication method,
     you can refer to https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli?view=azure-cli-latest).
-    3. Run Scout with the `--azure-cli` flag.
+    3. Run Scout with the `--cli` flag.
 2.  Managed Service Identity
     1. Configure your identity on the Azure portal(you can refer to
     https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/)
-    2. Run Scout with the `--azure-msi` flag.
+    2. Run Scout with the `--msi` flag.
 3.  Service Principal
     1. Set up a service principal on the Azure portal(you can refer to
     https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal)
+<<<<<<< HEAD
     2. Run Scout with the `--azure-service-principal` flag. Scout will prompt you for the
+=======
+    2. Run Scout with the `--service-principal` flag. Scout will prompt you for the 
+>>>>>>> upstream/refactor/127-cli-refactoring
     required information.
 4.  File-based Authentication
     1. Create a Service Principal for azure SDK. You can do this with azure-cli using
@@ -127,7 +131,7 @@ There are five ways to run scout against an Azure organization.
     2. Run Scout while providing it with the credentials file using
     `--azure-file-auth path/to/credentials/file`.
 5.  User Credentials
-    1. Run Scout using `--azure-user-credentials`. The application will prompt you for your credentials.
+    1. Run Scout using `--user-account`. The application will prompt you for your credentials.
 
 Scout will require the Reader role over all the resources you want to check. The easiest way is to give
 it Reader over the Subscription, as it will be inherited on all the resources.
@@ -165,37 +169,51 @@ The following command will provide the list of available command line options:
 
     $ python Scout.py --help
 
+You can also use this to get help on a specific provider:
+
+    $ python Scout.py aws --help
+
 For further details, checkout our Wiki pages at <https://github.com/nccgroup/ScoutSuite/wiki>.
 
 After performing a number of API calls, Scout will create a local HTML report and open it in the default browser.
+
+Also note that the command line will try to infer the argument name if possible when receiving partial switch. For
+example, this will work and use the selected profile:
+
+    $python Scout.py aws --pro PROFILE
 
 #### Amazon Web Services
 
 Using a computer already configured to use the AWS CLI, you may use Scout using the following command:
 
-    $ python Scout.py --provider aws
+    $ python Scout.py aws
 
 **Note:** EC2 instances with an IAM role fit in this category.
 
 If multiple profiles are configured in your .aws/credentials and .aws/config files, you may specify which credentials
 to use with the following command:
 
-    $ python Scout.py --profile <PROFILE_NAME>
+    $ python Scout.py aws --profile <PROFILE_NAME>
 
 If you have a CSV file containing the API access key ID and secret, you may run Scout with the following command:
 
-    $ python Scout.py --csv-credentials <CREDENTIALS.CSV>
+    $ python Scout.py aws --csv-credentials <CREDENTIALS.CSV>
 
 #### Google Cloud Platform
 
 Using a computer already configured to use gcloud command-line tool, you may use Scout using the following command:
 
-    $ python Scout.py --provider gcp --user-account
+    $ python Scout.py gcp --user-account
 
 To run Scout using Service Account keys, using the following command:
 
+<<<<<<< HEAD
     $ python Scout.py --provider gcp --service-account --key-file </PATH/TO/KEY_FILE.JSON>
 By default, using the `--service-account` argument will audit only the inferred project that is part of its credentials key file. To scan all projects that a service account has access to, use the `--all` flag to override. If you only want to scan a single project, include the `--project-id` argument.
+=======
+    $ python Scout.py gcp --service-account </PATH/TO/KEY_FILE.JSON>
+By default, using the `--service-account` argument will audit all the projects that the provided service account has access to. If you only want to scan a single project, include the `--project-id` argument.
+>>>>>>> upstream/refactor/127-cli-refactoring
 
 To scan a GCP ...
 - Organization, use the `organization-id <ORGANIZATION ID>` argument
@@ -207,6 +225,7 @@ To scan a GCP ...
 
 Using a computer already configured to use azure-cli, you may use Scout using the following command:
 
+<<<<<<< HEAD
     $ python Scout.py --provider azure --azure-cli
 
 When using Scout in an Azure virtual machine with the Reader role, you may use
@@ -222,6 +241,34 @@ When using Scout with an authentication file, you may run Scout using the follow
 
     $ python Scout.py --provider azure --azure-file-auth path/to/auth/file
 
+=======
+    $ python Scout.py azure --cli
+    
+When using Scout in an Azure virtual machine with the Reader role, you may use 
+Scout using the following command:
+
+    $ python Scout.py azure --msi
+    
+When using Scout with a Service Principal, you may run Scout using the following command:
+
+    $ python Scout.py azure --service-principal
+
+You can also pass the credentials you want directly with command line arguments. The remaining ones will be asked
+interactively:
+
+    $ python Scout.py azure --service-principal --tenant <TENANT_ID> --subscription <SUBSCRIPTION_ID> --client-id <CLIENT_ID>
+    --client-secret <CLIENT_SECRET>
+    
+When using Scout with an authentication file, you may run Scout using the following command:
+
+    $ python Scout.py azure --file-auth </PATH/TO/KEY_FILE.JSON>
+  
+>>>>>>> upstream/refactor/127-cli-refactoring
 When using Scout against your user account, you may run Scout using the following command:
 
-    $ python Scout.py --provider azure --azure-user-credentials
+    $ python Scout.py azure --user-account
+
+You can also pass the credentials you want directly with command line arguments. The remaining ones will be asked
+interactively:
+
+    $ python Scout.py azure --username <USERNAME> --password <PASSWORD>

--- a/README.md
+++ b/README.md
@@ -119,12 +119,7 @@ There are five ways to run scout against an Azure organization.
 3.  Service Principal
     1. Set up a service principal on the Azure portal(you can refer to
     https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal)
-<<<<<<< HEAD
-    2. Run Scout with the `--azure-service-principal` flag. Scout will prompt you for the
-=======
-    2. Run Scout with the `--service-principal` flag. Scout will prompt you for the 
->>>>>>> upstream/refactor/127-cli-refactoring
-    required information.
+    2. Run Scout with the `--service-principal` flag. Scout will prompt you for the required information.
 4.  File-based Authentication
     1. Create a Service Principal for azure SDK. You can do this with azure-cli using
     `az ad sp create-for-rbac --sdk-auth > mycredentials.json`.
@@ -207,48 +202,26 @@ Using a computer already configured to use gcloud command-line tool, you may use
 
 To run Scout using Service Account keys, using the following command:
 
-<<<<<<< HEAD
     $ python Scout.py --provider gcp --service-account --key-file </PATH/TO/KEY_FILE.JSON>
-By default, using the `--service-account` argument will audit only the inferred project that is part of its credentials key file. To scan all projects that a service account has access to, use the `--all` flag to override. If you only want to scan a single project, include the `--project-id` argument.
-=======
-    $ python Scout.py gcp --service-account </PATH/TO/KEY_FILE.JSON>
-By default, using the `--service-account` argument will audit all the projects that the provided service account has access to. If you only want to scan a single project, include the `--project-id` argument.
->>>>>>> upstream/refactor/127-cli-refactoring
+By default, using the `--service-account` argument will audit only the inferred project that is part of its credentials key file. To scan all projects that a service account has access to, use the `--gcp-scan-all` flag to override. If you only want to scan a single project, include the `--project-id` argument.
 
 To scan a GCP ...
 - Organization, use the `organization-id <ORGANIZATION ID>` argument
 - Folder, use the `folder-id <FOLDER ID>` argument.
 - Project, use the `project-id <PROJECT ID>` argument
-- All projects that a user/service account has access to, use the `--all` flags.
+- All projects that a user/service account has access to, use the `--gcp-scan-all` flags.
 
 #### Azure
 
 Using a computer already configured to use azure-cli, you may use Scout using the following command:
 
-<<<<<<< HEAD
-    $ python Scout.py --provider azure --azure-cli
+    $ python Scout.py azure --cli
 
 When using Scout in an Azure virtual machine with the Reader role, you may use
 Scout using the following command:
 
-    $ python Scout.py --provider azure --azure-msi
-
-When using Scout with a Service Principal, you may run Scout using the following command:
-
-    $ python Scout.py --provider azure --azure-service-principal
-
-When using Scout with an authentication file, you may run Scout using the following command:
-
-    $ python Scout.py --provider azure --azure-file-auth path/to/auth/file
-
-=======
-    $ python Scout.py azure --cli
-    
-When using Scout in an Azure virtual machine with the Reader role, you may use 
-Scout using the following command:
-
     $ python Scout.py azure --msi
-    
+
 When using Scout with a Service Principal, you may run Scout using the following command:
 
     $ python Scout.py azure --service-principal
@@ -258,12 +231,11 @@ interactively:
 
     $ python Scout.py azure --service-principal --tenant <TENANT_ID> --subscription <SUBSCRIPTION_ID> --client-id <CLIENT_ID>
     --client-secret <CLIENT_SECRET>
-    
+
 When using Scout with an authentication file, you may run Scout using the following command:
 
     $ python Scout.py azure --file-auth </PATH/TO/KEY_FILE.JSON>
-  
->>>>>>> upstream/refactor/127-cli-refactoring
+
 When using Scout against your user account, you may run Scout using the following command:
 
     $ python Scout.py azure --user-account

--- a/Scout.py
+++ b/Scout.py
@@ -1,8 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from ScoutSuite.__main__ import main
 import sys
 
-if __name__ == '__main__':
-    sys.exit(main())
+from ScoutSuite.__listall__ import main as listall
+from ScoutSuite.__rules_generator__ import main as rules_generator
+from ScoutSuite.__main__ import main as scout
+
+from ScoutSuite.cli_parser import ScoutSuiteArgumentParser
+
+modules = {
+    "listall": listall,
+    "ruleset": rules_generator,
+}
+
+if __name__ == "__main__":
+    parser = ScoutSuiteArgumentParser()
+    args = parser.parse_args()
+
+    sys.exit(modules.get(args.module, scout)(args))

--- a/Scout2Listall.py
+++ b/Scout2Listall.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-from ScoutSuite.__listall__ import main
-import sys
-
-if __name__ == '__main__':
-    sys.exit(main())

--- a/ScoutRulesGenerator.py
+++ b/ScoutRulesGenerator.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
-from ScoutSuite.__rules_generator__ import main
-import sys
-
-if __name__ == '__main__':
-    sys.exit(main())

--- a/ScoutSuite/__listall__.py
+++ b/ScoutSuite/__listall__.py
@@ -5,7 +5,6 @@ import json
 import os
 import sys
 
-
 try:
     from opinel.utils.globals import check_requirements
     from opinel.utils.console import configPrintException, printError, printException, printInfo
@@ -17,7 +16,6 @@ except Exception as e:
 
 from ScoutSuite import AWSCONFIG
 from ScoutSuite.providers import get_provider
-from ScoutSuite.cli_parser import ListallArgumentParser
 from ScoutSuite.core.ruleset import TmpRuleset
 from ScoutSuite.core.processingengine import ProcessingEngine
 from ScoutSuite.output.console import format_listall_output, generate_listall_output
@@ -28,11 +26,7 @@ from ScoutSuite.output.html import Scout2Report
 ##### Main
 ########################################
 
-def main():
-    # Parse arguments
-    parser = ListallArgumentParser()
-    args = parser.parse_args()
-
+def main(args):
     # Configure the debug level
     configPrintException(args.debug)
 
@@ -46,7 +40,7 @@ def main():
 
         # Load the config
         try:
-            #FIXME this is specific to AWS
+            # FIXME this is specific to AWS
             report_file_name = 'aws-%s' % profile_name
             report = Scout2Report('aws', report_file_name, args.report_dir, args.timestamp)
             aws_config = report.jsrw.load_from_file(AWSCONFIG)

--- a/ScoutSuite/__main__.py
+++ b/ScoutSuite/__main__.py
@@ -50,7 +50,8 @@ def main(args):
                                   timestamp=args.get('timestamp'),
                                   services=args.get('services'),
                                   skipped_services=args.get('skipped_services'),
-                                  thread_config=args.get('thread_config'))
+                                  thread_config=args.get('thread_config'),
+                                  gcp_scan_all=args.get('gcp_scan_all'))
 
     report_file_name = generate_report_name(cloud_provider.provider_code, args)
 

--- a/ScoutSuite/__main__.py
+++ b/ScoutSuite/__main__.py
@@ -97,6 +97,7 @@ def main(passed_args=None):
                                                     key_file=args.key_file,
                                                     user_account=args.user_account,
                                                     service_account=args.service_account,
+                                                    all=args.all,
                                                     azure_cli=args.azure_cli,
                                                     azure_msi=args.azure_msi,
                                                     azure_service_principal=args.azure_service_principal,

--- a/ScoutSuite/__rules_generator__.py
+++ b/ScoutSuite/__rules_generator__.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import webbrowser
+
+try:
+    from opinel.utils.console import configPrintException, printInfo
+    from opinel.utils.globals import check_requirements
+except Exception as e:
+    print('Error: Scout2 depends on the opinel package. Install all the requirements with the following command:')
+    print('  $ pip install -r requirements.txt')
+    print(e)
+    sys.exit(42)
+
+from ScoutSuite.providers import get_provider
+from ScoutSuite.core.ruleset import Ruleset
+from ScoutSuite.output.html import RulesetGenerator
+
+
+########################################
+##### Main
+########################################
+
+def main(args):
+    # Configure the debug level
+    configPrintException(args.debug)
+
+    # FIXME check that all requirements are installed
+    # # Check version of opinel
+    # if not check_requirements(os.path.realpath(__file__)):
+    #     return 42
+
+    # Load ruleset
+    ruleset = Ruleset(filename=args.base_ruleset, name=args.ruleset_name, rules_dir=args.rules_dir,
+                      ruleset_generator=True)
+
+    # Generate the HTML generator
+    ruleset_generator = RulesetGenerator(args.ruleset_name, args.generator_dir)
+
+    # FIXME is broken in Scout Suite, only handles AWS
+    cloud_provider = get_provider(provider='aws',
+                                  profile='default')
+
+    ruleset.ruleset_generator_metadata = cloud_provider.metadata
+
+    ruleset_generator_path = ruleset_generator.save(ruleset, args.force_write, args.debug)
+
+    # Open the HTML ruleset generator in a browser
+    if not args.no_browser:
+        printInfo('Starting the HTML ruleset generator...')
+        url = 'file://%s' % os.path.abspath(ruleset_generator_path)
+        webbrowser.open(url, new=2)

--- a/ScoutSuite/cli_parser.py
+++ b/ScoutSuite/cli_parser.py
@@ -1,270 +1,338 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 import argparse
-
-from opinel.utils.cli_parser import OpinelArgumentParser
+import os
 
 from ScoutSuite import DEFAULT_REPORT_DIR
 
+class ScoutSuiteArgumentParser:
 
-class SharedArgumentParser(OpinelArgumentParser):
+    def __init__(self):
+        self.parser = argparse.ArgumentParser()
 
-    def __init__(self, default_args=None):
-        super(SharedArgumentParser, self).__init__()
-        self.add_argument('debug', default_args)
-        self.add_argument('force', default_args)
+        self.base_args_parser = argparse.ArgumentParser(add_help=False)
+        self.base_args_parser.add_argument('--debug',
+                                           dest='debug',
+                                           default=False,
+                                           action='store_true',
+                                           help='Print the stack trace when exception occurs')
+        self.base_args_parser.add_argument('--force',
+                                           dest='force_write',
+                                           default=False,
+                                           action='store_true',
+                                           help='Overwrite existing files')
+        self.common_providers_args_parser = argparse.ArgumentParser(add_help=False, parents=[self.base_args_parser])
 
-    def add_argument(self, argument_name, default_args=None):
-        if argument_name == 'services':
-            self.parser.add_argument('--services',
-                                     dest='services',
-                                     default=[],
-                                     nargs='+',
-                                     help='Name of in-scope services.')
-        elif argument_name == 'skip':
-            self.parser.add_argument('--skip',
-                                     dest='skipped_services',
-                                     default=[],
-                                     nargs='+',
-                                     help='Name of out-of-scope services.')
-        elif argument_name == 'timestamp':
-            self.parser.add_argument('--timestamp',
-                                     dest='timestamp',
-                                     default=False,
-                                     nargs='?',
-                                     help='Timestamp added to the name of the report (default is current time in UTC).')
-        elif argument_name == 'report-dir':
-            self.parser.add_argument('--report-dir',
-                                     dest='report_dir',
-                                     default=DEFAULT_REPORT_DIR,
-                                     help='Path of the Scout2 report.')
-        elif argument_name == 'exceptions':
-            self.parser.add_argument('--exceptions',
-                                     dest='exceptions',
-                                     default=[None],
-                                     nargs='+',
-                                     help='Exception file to use during analysis.')
-        else:
-            super(SharedArgumentParser, self).add_argument(argument_name, default_args)
+        self.subparsers = self.parser.add_subparsers(title="The module you want to run",
+                                                     dest="module")
 
+        self._init_common_args_parser()
 
-class RulesArgumentParser(SharedArgumentParser):
+        self._init_rules_generator_parser()
+        self._init_listall_parser()
 
-    def __init__(self, default_args=None):
-        super(RulesArgumentParser, self).__init__()
-        self.parser.add_argument('--ruleset-name',
-                                 dest='ruleset_name',
-                                 default=None,
-                                 required=True,
-                                 help='Name of the ruleset to be generated.')
-        self.parser.add_argument('--base-ruleset',
-                                 dest='base_ruleset',
-                                 default='default',
-                                 help='Ruleset to be used as the baseline.')
-        self.parser.add_argument('--rules-dir',
-                                 dest='rules_dir',
-                                 default=[],
-                                 nargs='+',
-                                 help='Path to directories where custom rules are defined.')
-        self.parser.add_argument('--generator-dir',
-                                 dest='generator_dir',
-                                 default=DEFAULT_REPORT_DIR,
-                                 help='Path of the Scout2 rules generator.')
-        self.parser.add_argument('--no-browser',
-                                 dest='no_browser',
-                                 default=False,
-                                 action='store_true',
-                                 help='Do not automatically open the report in the browser.')
+        self._init_aws_parser()
+        self._init_gcp_parser()
+        self._init_azure_parser()
 
+    def _init_rules_generator_parser(self):
+        parser = self.subparsers.add_parser("ruleset",
+                                            parents=[self.base_args_parser],
+                                            help="Run the Scout rules generator")
+        parser.add_argument('--ruleset-name',
+                            dest='ruleset_name',
+                            default=None,
+                            required=True,
+                            help='Name of the ruleset to be generated.')
+        parser.add_argument('--base-ruleset',
+                            dest='base_ruleset',
+                            default='default',
+                            help='Ruleset to be used as the baseline.')
+        parser.add_argument('--rules-dir',
+                            dest='rules_dir',
+                            default=[],
+                            nargs='+',
+                            help='Path to directories where custom rules are defined.')
+        parser.add_argument('--generator-dir',
+                            dest='generator_dir',
+                            default=DEFAULT_REPORT_DIR,
+                            help='Path of the Scout rules generator.')
+        parser.add_argument('--no-browser',
+                            dest='no_browser',
+                            default=False,
+                            action='store_true',
+                            help='Do not automatically open the report in the browser.')
 
-class ListallArgumentParser(SharedArgumentParser):
+    def _init_listall_parser(self):
+        parser = self.subparsers.add_parser("listall",
+                                            parents=[self.base_args_parser],
+                                            help="Run the Scout CSV exporter")
 
-    def __init__(self, default_args=None):
-        super(ListallArgumentParser, self).__init__()
-        self.add_argument('profile', default_args)
-        self.add_argument('report-dir', default_args)
-        self.add_argument('ip-ranges', default_args)
-        self.add_argument('timestamp', default_args)
-        self.add_argument('exceptions', default_args)
-        self.parser.add_argument('--format',
-                                 dest='format',
-                                 default=['csv'],
-                                 nargs='+',
-                                 help='Listall output format.')
-        self.parser.add_argument('--format-file',
-                                 dest='format_file',
-                                 default=None,
-                                 nargs='+',
-                                 help='Listall output format file')
-        self.parser.add_argument('--config',
-                                 dest='config',
-                                 default=None,
-                                 help='Config file that sets the path and keys to be listed.')
-        self.parser.add_argument('--config-args',
-                                 dest='config_args',
-                                 default=[],
-                                 nargs='+',
-                                 help='Arguments to be passed to the config file.')
-        self.parser.add_argument('--path',
-                                 dest='path',
-                                 default=[],
-                                 nargs='+',
-                                 help='Path of the resources to list (e.g. iam.users.id or ec2.regions.id.vpcs.id)')
-        self.parser.add_argument('--keys',
-                                 dest='keys',
-                                 default=[],
-                                 nargs='+',
-                                 help='Keys to be printed for the given object.')
-        self.parser.add_argument('--keys-from-file',
-                                 dest='keys_file',
-                                 default=[],
-                                 nargs='+',
-                                 help='Keys to be printed for the given object (read values from file.')
+        default = os.environ.get('AWS_PROFILE', 'default')
+        default_origin = " (from AWS_PROFILE)." if 'AWS_PROFILE' in os.environ else "."
+        parser.add_argument('--profile',
+                            dest='profile',
+                            default=[default],
+                            nargs='+',
+                            help='Name of the profile. Defaults to %(default)s' + default_origin)
+        parser.add_argument('--report-dir',
+                            dest='report_dir',
+                            default=DEFAULT_REPORT_DIR,
+                            help='Path of the Scout report.')
+        parser.add_argument('--ip-ranges',
+                            dest='ip_ranges',
+                            default=[],
+                            nargs='+',
+                            help='Config file(s) that contain your known IP ranges')
+        parser.add_argument('--timestamp',
+                            dest='timestamp',
+                            default=False,
+                            nargs='?',
+                            help='Timestamp added to the name of the report (default is current time in UTC).')
+        parser.add_argument('--exceptions',
+                            dest='exceptions',
+                            default=[None],
+                            nargs='+',
+                            help='Exception file to use during analysis.')
+        parser.add_argument('--format',
+                            dest='format',
+                            default=['csv'],
+                            nargs='+',
+                            help='Listall output format.')
+        parser.add_argument('--format-file',
+                            dest='format_file',
+                            default=None,
+                            nargs='+',
+                            help='Listall output format file')
+        parser.add_argument('--config',
+                            dest='config',
+                            default=None,
+                            help='Config file that sets the path and keys to be listed.')
+        parser.add_argument('--config-args',
+                            dest='config_args',
+                            default=[],
+                            nargs='+',
+                            help='Arguments to be passed to the config file.')
+        parser.add_argument('--path',
+                            dest='path',
+                            default=[],
+                            nargs='+',
+                            help='Path of the resources to list (e.g. iam.users.id or ec2.regions.id.vpcs.id)')
+        parser.add_argument('--keys',
+                            dest='keys',
+                            default=[],
+                            nargs='+',
+                            help='Keys to be printed for the given object.')
+        parser.add_argument('--keys-from-file',
+                            dest='keys_file',
+                            default=[],
+                            nargs='+',
+                            help='Keys to be printed for the given object (read values from file.')
 
+    def _init_aws_parser(self):
+        parser = self.subparsers.add_parser("aws",
+                                            parents=[self.common_providers_args_parser],
+                                            help="Run Scout against an Amazon web Services account")
 
-class ScoutSuiteArgumentParser(SharedArgumentParser):
+        parser = parser.add_argument_group('AWS parameters')
 
-    def __init__(self, default_args=None):
-        super(ScoutSuiteArgumentParser, self).__init__()
-        self.add_argument('profile', default_args)
-        self.add_argument('regions', default_args)
-        self.add_argument('vpc', default_args)
-        self.add_argument('ip-ranges', default_args)
-        self.add_argument('ip-ranges-name-key', default_args)
-        self.add_argument('mfa-serial')
-        self.add_argument('mfa-code')
-        self.add_argument('csv-credentials')
-        self.add_argument('report-dir', default_args)
-        self.add_argument('timestamp', default_args)
-        self.add_argument('exceptions', default_args)
-        self.add_argument('services', default_args)
-        self.add_argument('skip', default_args)
-        self.parser.add_argument('-l', '--local',
-                                 dest='fetch_local',
-                                 default=False,
-                                 action='store_true',
-                                 help='Use local data previously fetched and re-run the analysis.')
-        self.parser.add_argument('--resume',
-                                 dest='resume',
-                                 default=False,
-                                 action='store_true',
-                                 help='Complete a partial (throttled) run')
-        self.parser.add_argument('--update',
-                                 dest='update',
-                                 default=False,
-                                 action='store_true',
-                                 help='Reload all the existing data and only overwrite data in scope for this run')
-        self.parser.add_argument('--ruleset',
-                                 dest='ruleset',
-                                 default='default.json',
-                                 nargs='?',
-                                 help='Set of rules to be used during the analysis.')
-        self.parser.add_argument('--no-browser',
-                                 dest='no_browser',
-                                 default=False,
-                                 action='store_true',
-                                 help='Do not automatically open the report in the browser.')
-        self.parser.add_argument('--thread-config',
-                                 dest='thread_config',
-                                 type=int,
-                                 default=4,
-                                 help='Level of multi-threading wanted [1-5]; defaults to 4.')
+        default_profile = os.environ.get('AWS_PROFILE', 'default')
+        default_profile_origin = " (from AWS_PROFILE)." if 'AWS_PROFILE' in os.environ else "."
+        parser.add_argument('--profile',
+                            dest='profile',
+                            default=[default_profile],
+                            nargs='+',
+                            help='Name of the profile. Defaults to %(default)s' + default_profile_origin)
+        parser.add_argument('--regions',
+                            dest='regions',
+                            default=[],
+                            nargs='+',
+                            help='Name of regions to run the tool in, defaults to all')
+        parser.add_argument('--vpc',
+                            dest='vpc',
+                            default=[],
+                            nargs='+',
+                            help='Name of VPC to run the tool in, defaults to all')
+        parser.add_argument('--ip-ranges',
+                            dest='ip_ranges',
+                            default=[],
+                            nargs='+',
+                            help='Config file(s) that contain your known IP ranges')
+        parser.add_argument('--ip-ranges-name-key',
+                            dest='ip_ranges_name_key',
+                            default='name',
+                            help='Name of the key containing the display name of a known CIDR')
+        parser.add_argument('--mfa-serial',
+                            dest='mfa_serial',
+                            default=None,
+                            help='ARN of the user\'s MFA device')
+        parser.add_argument('--mfa-code',
+                            dest='mfa_code',
+                            default=None,
+                            help='Six-digit code displayed on the MFA device.')
+        parser.add_argument('--csv-credentials',
+                            dest='csv_credentials',
+                            default=None,
+                            help='Path to a CSV file containing the access key ID and secret key')
 
-        # TODO this probably shouldn't be here
-        self.parser.add_argument('--provider',
-                                 required=True,
-                                 action='store',
-                                 choices=['aws', 'gcp', 'azure'],
-                                 help='The cloud provider to scan (currently supports AWS (\'aws\'), \
-                                        GCP (\'gcp\') and Azure (\'azure\'))')
+    def _init_gcp_parser(self):
+        parser = self.subparsers.add_parser("gcp",
+                                            parents=[self.common_providers_args_parser],
+                                            help="Run Scout against a Google Cloud Platform account")
 
-        self.parser.add_argument('--user-account',
-                                 action='store_true',
-                                 required='gcp' in sys.argv and '--service-account' not in sys.argv,
-                                 help='Run Scout Suite with a Google Account')
+        parser = parser.add_argument_group('GCP parameters')
 
-        self.parser.add_argument('--service-account',
-                                 action='store_true',
-                                 required='gcp' in sys.argv and '--user-account' not in sys.argv,
-                                 help='Run Scout Suite with a Google Service Account')
+        gcp_auth_modes = parser.add_mutually_exclusive_group(required=True)
 
-        self.parser.add_argument('--key-file',
-                                 action='store',
-                                 required='--service-account' in sys.argv,
-                                 help='Path of the Google Service Account Application Credentials file')
+        gcp_auth_modes.add_argument('--user-account',
+                                    action='store_true',
+                                    dest="auth_file",
+                                    help='Run Scout with a Google Account')
 
-        self.parser.add_argument('--project-id',
-                                 action='store',
-                                 required='--all' not in sys.argv,
-                                 help='ID of the GCP Project to analyze')
-        self.parser.add_argument('--folder-id',
-                                 action='store',
-                                 required='--all' not in sys.argv,
-                                 help='ID of the GCP Folder to analyze')
-        self.parser.add_argument('--organization-id',
-                                 action='store',
-                                 required='--all' not in sys.argv,
-                                 help='ID of the GCP Organization to analyze')
-        self.parser.add_argument('--all',
-                                 action='store_true',
-                                 help='flag to determine if ScoutSuite should scan all projects a user/service account has access to')
+        gcp_auth_modes.add_argument('--service-account',
+                                    action='store',
+                                    help='Run Scout with a Google Service Account with the specified '
+                                         'Google Service Account Application Credentials file')
 
-        azure_parser = self.parser.add_argument_group('Azure authentication modes')
-        azure_auth_params = self.parser.add_argument_group('Azure authentication parameters')
+        gcp_scope = parser.add_mutually_exclusive_group(required=False)
 
-        azure_auth_modes = azure_parser.add_mutually_exclusive_group(required="azure" in sys.argv)
+        gcp_scope.add_argument('--project-id',
+                               action='store',
+                               help='ID of the GCP Project to analyze')
 
-        azure_auth_modes.add_argument('--azure-cli',
+        gcp_scope.add_argument('--folder-id',
+                               action='store',
+                               help='ID of the GCP Folder to analyze')
+
+        gcp_scope.add_argument('--organization-id',
+                               action='store',
+                               help='ID of the GCP Organization to analyze')
+
+    def _init_azure_parser(self):
+        parser = self.subparsers.add_parser("azure",
+                                            parents=[self.common_providers_args_parser],
+                                            help="Run Scout against a Microsoft Azure account")
+
+        azure_parser = parser.add_argument_group('Authentication modes')
+        azure_auth_params = parser.add_argument_group('Authentication parameters')
+
+        azure_auth_modes = azure_parser.add_mutually_exclusive_group(required=True)
+
+        azure_auth_modes.add_argument('--cli',
                                       action='store_true',
-                                      help='Run Scout Suite using configured azure-cli credentials')
-        azure_auth_modes.add_argument('--azure-msi',
-                                      action='store_true',
-                                      help='Run Scout Suite with Managed Service Identity')
-        azure_auth_modes.add_argument('--azure-service-principal',
-                                      action='store_true',
-                                      help='Run Scout Suite with an Azure Service Principal')
-        azure_auth_modes.add_argument('--azure-file-auth',
-                                      action='store',
-                                      type=argparse.FileType('r'),
-                                      metavar="FILE",
-                                      help='Run Scout Suite with the specified credential file')
-        azure_auth_modes.add_argument('--azure-user-credentials',
-                                      action='store_true',
-                                      help='Run Scout Suite with user credentials')
+                                      help='Run Scout using configured azure-cli credentials')
 
+        azure_auth_modes.add_argument('--msi',
+                                      action='store_true',
+                                      help='Run Scout with Managed Service Identity')
+
+        azure_auth_modes.add_argument('--service-principal',
+                                      action='store_true',
+                                      help='Run Scout with an Azure Service Principal')
         azure_auth_params.add_argument('--tenant',
                                        action='store',
                                        dest='tenant_id',
-                                       help='Tenant ID of the Azure service principal')
+                                       help='Tenant ID of the service principal')
         azure_auth_params.add_argument('--subscription',
                                        action='store',
                                        dest='subscription_id',
-                                       help='Subscription ID of the Azure service principal')
+                                       help='Subscription ID of the service principal')
         azure_auth_params.add_argument('--client-id',
                                        action='store',
                                        dest='client_id',
-                                       help='Client ID of the Azure service principal')
+                                       help='Client ID of the service principal')
         azure_auth_params.add_argument('--client-secret',
                                        action='store',
                                        dest='client_secret',
-                                       help='Client secret of the Azure service principal')
+                                       help='Client of the service principal')
 
-        azure_auth_params.add_argument('--azure-username',
+        azure_auth_modes.add_argument('--file-auth',
+                                      action='store',
+                                      type=argparse.FileType('r'),
+                                      dest='file_auth',
+                                      metavar="FILE",
+                                      help='Run Scout with the specified credential file')
+
+        azure_auth_modes.add_argument('--user-account',
+                                      action='store_true',
+                                      help='Run Scout with user credentials')
+        azure_auth_params.add_argument('--username',
                                        action='store',
                                        default=None,
-                                       dest='azure_username',
+                                       dest='username',
                                        help='Username of the Azure account')
-        azure_auth_params.add_argument('--azure-password',
+        azure_auth_params.add_argument('--password',
                                        action='store',
                                        default=None,
-                                       dest='azure_password',
+                                       dest='password',
                                        help='Password of the Azure account')
+
+    def _init_common_args_parser(self):
+        parser = self.common_providers_args_parser.add_argument_group('Scout Arguments')
+
+        parser.add_argument('-l', '--local',
+                            dest='fetch_local',
+                            default=False,
+                            action='store_true',
+                            help='Use local data previously fetched and re-run the analysis.')
+        parser.add_argument('--resume',
+                            dest='resume',
+                            default=False,
+                            action='store_true',
+                            help='Complete a partial (throttled) run')
+        parser.add_argument('--update',
+                            dest='update',
+                            default=False,
+                            action='store_true',
+                            help='Reload all the existing data and only overwrite data in scope for this run')
+        parser.add_argument('--ruleset',
+                            dest='ruleset',
+                            default='default.json',
+                            nargs='?',
+                            help='Set of rules to be used during the analysis.')
+        parser.add_argument('--no-browser',
+                            dest='no_browser',
+                            default=False,
+                            action='store_true',
+                            help='Do not automatically open the report in the browser.')
+        parser.add_argument('--thread-config',
+                            dest='thread_config',
+                            type=int,
+                            default=4,
+                            help='Level of multi-threading wanted [1-5]; defaults to 4.')
+        parser.add_argument('--report-dir',
+                            dest='report_dir',
+                            default=DEFAULT_REPORT_DIR,
+                            help='Path of the Scout report.')
+        parser.add_argument('--timestamp',
+                            dest='timestamp',
+                            default=False,
+                            nargs='?',
+                            help='Timestamp added to the name of the report (default is current time in UTC).')
+        parser.add_argument('--services',
+                            dest='services',
+                            default=[],
+                            nargs='+',
+                            help='Name of in-scope services.')
+        parser.add_argument('--skip',
+                            dest='skipped_services',
+                            default=[],
+                            nargs='+',
+                            help='Name of out-of-scope services.')
+        parser.add_argument('--exceptions',
+                            dest='exceptions',
+                            default=[None],
+                            nargs='+',
+                            help='Exception file to use during analysis.')
 
     def parse_args(self, args=None):
         args = self.parser.parse_args(args)
+
+        # Cannot simply use required for backward compatibility
+        if not args.module:
+            self.parser.error('You need to input a module')
         # If local analysis, overwrite results
-        if args.fetch_local:
+        if args.__dict__.get('fetch_local'):
             args.force_write = True
         return args

--- a/ScoutSuite/cli_parser.py
+++ b/ScoutSuite/cli_parser.py
@@ -209,6 +209,10 @@ class ScoutSuiteArgumentParser:
                                action='store',
                                help='ID of the GCP Organization to analyze')
 
+        gcp_scope.add_argument('--gcp-scan-all',
+                               action='store_true',
+                               help='ID of the GCP Organization to analyze')
+
     def _init_azure_parser(self):
         parser = self.subparsers.add_parser("azure",
                                             parents=[self.common_providers_args_parser],

--- a/ScoutSuite/cli_parser.py
+++ b/ScoutSuite/cli_parser.py
@@ -197,13 +197,19 @@ class ScoutSuiteArgumentParser(SharedArgumentParser):
 
         self.parser.add_argument('--project-id',
                                  action='store',
+                                 required='--all' not in sys.argv,
                                  help='ID of the GCP Project to analyze')
         self.parser.add_argument('--folder-id',
                                  action='store',
+                                 required='--all' not in sys.argv,
                                  help='ID of the GCP Folder to analyze')
         self.parser.add_argument('--organization-id',
                                  action='store',
+                                 required='--all' not in sys.argv,
                                  help='ID of the GCP Organization to analyze')
+        self.parser.add_argument('--all',
+                                 action='store_true',
+                                 help='flag to determine if ScoutSuite should scan all projects a user/service account has access to')
 
         azure_parser = self.parser.add_argument_group('Azure authentication modes')
         azure_auth_params = self.parser.add_argument_group('Azure authentication parameters')

--- a/ScoutSuite/providers/__init__.py
+++ b/ScoutSuite/providers/__init__.py
@@ -13,7 +13,7 @@ providers_dict = {'aws': 'AWSProvider',
 def get_provider(provider,
                  profile=None,
                  project_id=None, folder_id=None, organization_id=None,
-                 report_dir=None, timestamp=None, services=None, skipped_services=None, thread_config=4):
+                 report_dir=None, timestamp=None, services=None, skipped_services=None, thread_config=4, **kwargs):
     """
     Returns an instance of the requested provider.
 
@@ -33,6 +33,7 @@ def get_provider(provider,
                                         timestamp=timestamp,
                                         services=services,
                                         skipped_services=skipped_services,
-                                        thread_config=thread_config)
+                                        thread_config=thread_config,
+                                        **kwargs)
 
     return provider_instance

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -31,7 +31,7 @@ class AWSProvider(BaseProvider):
     Implements provider for AWS
     """
 
-    def __init__(self, profile='default', report_dir=None, timestamp=None, services=None, skipped_services=None, thread_config=4, **kwargs):
+    def __init__(self, profile=None, report_dir=None, timestamp=None, services=None, skipped_services=None, thread_config=4, **kwargs):
         services = [] if services is None else services
         skipped_services = [] if skipped_services is None else skipped_services
 
@@ -40,7 +40,7 @@ class AWSProvider(BaseProvider):
         self.sg_map = {}
         self.subnet_map = {}
 
-        self.profile = profile
+        self.profile = profile[0] if profile else 'default'
         self.aws_account_id = None
         self.services_config = AWSServicesConfig
 
@@ -54,7 +54,7 @@ class AWSProvider(BaseProvider):
         Implement authentication for the AWS provider
         :return:
         """
-        self.credentials = read_creds(profile, csv_credentials, mfa_serial, mfa_code)
+        self.credentials = read_creds(profile[0], csv_credentials, mfa_serial, mfa_code)
         self.aws_account_id = get_aws_account_id(self.credentials)
 
         if self.credentials['AccessKeyId'] is None:

--- a/ScoutSuite/providers/azure/provider.py
+++ b/ScoutSuite/providers/azure/provider.py
@@ -43,10 +43,9 @@ class AzureProvider(BaseProvider):
 
         super(AzureProvider, self).__init__(report_dir, timestamp, services, skipped_services, thread_config)
 
-    def authenticate(self, key_file=None, user_account=None, service_account=None, azure_cli=None, azure_msi=None,
-                     azure_service_principal=None, azure_file_auth=None, azure_user_credentials=None,
-                     azure_tenant_id=None, azure_subscription_id=None, azure_client_id=None, azure_client_secret=None,
-                     azure_username=None, azure_password=None, **kargs):
+    def authenticate(self, cli=None, msi=None, service_principal=None, file_auth=None, user_account=None,
+                     tenant_id=None, subscription_id=None, client_id=None, client_secret=None, username=None,
+                     password=None, **kargs):
         """
         Implements authentication for the Azure provider using azure-cli.
         Refer to https://docs.microsoft.com/en-us/python/azure/python-sdk-azure-authenticate?view=azure-python.
@@ -55,11 +54,11 @@ class AzureProvider(BaseProvider):
         """
 
         try:
-            if azure_cli:
+            if cli:
                 cli_credentials, self.aws_account_id = get_azure_cli_credentials()  # TODO: Remove aws_account_id
                 self.credentials = AzureCredentials(cli_credentials, self.aws_account_id)
                 return True
-            elif azure_msi:
+            elif msi:
                 credentials = MSIAuthentication()
 
                 # Get the subscription ID
@@ -74,8 +73,8 @@ class AzureProvider(BaseProvider):
 
                 self.credentials = AzureCredentials(credentials, self.aws_account_id)
                 return True
-            elif azure_file_auth:
-                data = json.loads(azure_file_auth.read())
+            elif file_auth:
+                data = json.loads(file_auth.read())
                 subscription_id = data.get('subscriptionId')
                 tenant_id = data.get('tenantId')
                 client_id = data.get('clientId')
@@ -92,31 +91,31 @@ class AzureProvider(BaseProvider):
                 self.credentials = AzureCredentials(credentials, subscription_id)
 
                 return True
-            elif azure_service_principal:
-                azure_subscription_id = azure_subscription_id if azure_subscription_id else input("Subscription ID: ")
-                azure_tenant_id = azure_tenant_id if azure_tenant_id else input("Tenant ID: ")
-                azure_client_id = azure_client_id if azure_client_id else input("Client ID: ")
-                azure_client_secret = azure_client_secret if azure_client_secret else getpass("Client secret: ")
+            elif service_principal:
+                subscription_id = subscription_id if subscription_id else input("Subscription ID: ")
+                tenant_id = tenant_id if tenant_id else input("Tenant ID: ")
+                client_id = client_id if client_id else input("Client ID: ")
+                client_secret = client_secret if client_secret else getpass("Client secret: ")
 
-                self.aws_account_id = azure_subscription_id  # TODO this is for AWS
+                self.aws_account_id = tenant_id  # TODO this is for AWS
 
                 credentials = ServicePrincipalCredentials(
-                    client_id=azure_client_id,
-                    secret=azure_client_secret,
-                    tenant=azure_tenant_id
+                    client_id=client_id,
+                    secret=client_secret,
+                    tenant=tenant_id
                 )
 
-                self.credentials = AzureCredentials(credentials, azure_subscription_id)
+                self.credentials = AzureCredentials(credentials, subscription_id)
 
                 return True
-            elif azure_user_credentials:
-                azure_username = azure_username if azure_username else input("Username: ")
-                azure_password = azure_password if azure_password else getpass("Password: ")
+            elif user_account:
+                username = username if username else input("Username: ")
+                password = password if password else getpass("Password: ")
 
-                credentials = UserPassCredentials(azure_username, azure_password)
+                credentials = UserPassCredentials(username, password)
 
-                if azure_subscription_id:
-                    self.aws_account_id = azure_subscription_id
+                if subscription_id:
+                    self.aws_account_id = subscription_id
                 else:
                     # Get the subscription ID
                     subscription_client = SubscriptionClient(credentials)

--- a/ScoutSuite/providers/gcp/provider.py
+++ b/ScoutSuite/providers/gcp/provider.py
@@ -211,7 +211,7 @@ class GCPProvider(BaseProvider):
 
 
 
-        printInfo("We found {} projects to scan.".format(len(projects)))
+        printInfo("We found {} project(s) to scan.".format(len(projects)))
         return projects
 
     def _match_instances_and_snapshots(self):

--- a/ScoutSuite/providers/gcp/provider.py
+++ b/ScoutSuite/providers/gcp/provider.py
@@ -5,7 +5,7 @@ import warnings
 
 import google.auth
 import googleapiclient
-from opinel.utils.console import printError, printException
+from opinel.utils.console import printError, printException, printInfo
 
 from ScoutSuite.providers.base.provider import BaseProvider
 from ScoutSuite.providers.gcp.configs.services import GCPServicesConfig
@@ -52,8 +52,7 @@ class GCPProvider(BaseProvider):
 
         :return:
         """
-        print("value of all")
-        print(all)
+
         if user_account:
             # disable GCP warning about using User Accounts
             warnings.filterwarnings("ignore", "Your application has authenticated using end user credentials")
@@ -207,6 +206,9 @@ class GCPProvider(BaseProvider):
                 for folder in folder_response['folders']:
                     projects.extend(self._get_projects("folder", folder['name'].strip(u'folders/')))
 
+
+
+        printInfo("We found {} projects to scan.".format(len(projects)))
         return projects
 
     def _match_instances_and_snapshots(self):

--- a/ScoutSuite/providers/gcp/provider.py
+++ b/ScoutSuite/providers/gcp/provider.py
@@ -41,15 +41,14 @@ class GCPProvider(BaseProvider):
         self.folder_id = folder_id
         self.organization_id = organization_id
 
+        # GCP Project Scope
+        self.gcp_scan_all = kwargs.get('gcp_scan_all', False)
+
         self.services_config = GCPServicesConfig
 
         super(GCPProvider, self).__init__(report_dir, timestamp, services, skipped_services, thread_config)
 
-<<<<<<< HEAD
-    def authenticate(self, key_file=None, user_account=None, service_account=None, all=False, **kargs):
-=======
     def authenticate(self, user_account=None, service_account=None, **kargs):
->>>>>>> upstream/refactor/127-cli-refactoring
         """
         Implement authentication for the GCP provider
         Refer to https://google-auth.readthedocs.io/en/stable/reference/google.auth.html.
@@ -74,7 +73,7 @@ class GCPProvider(BaseProvider):
             if self.credentials:
 
                 # all flag passed through the CLI. All projects to which the user / Service Account has access to
-                if all:
+                if self.gcp_scan_all:
                     self.projects = self._get_projects(parent_type='all',
                                                        parent_id=None)
                     if service_account and hasattr(self.credentials, 'service_account_email'):

--- a/ScoutSuite/providers/gcp/provider.py
+++ b/ScoutSuite/providers/gcp/provider.py
@@ -45,7 +45,11 @@ class GCPProvider(BaseProvider):
 
         super(GCPProvider, self).__init__(report_dir, timestamp, services, skipped_services, thread_config)
 
+<<<<<<< HEAD
     def authenticate(self, key_file=None, user_account=None, service_account=None, all=False, **kargs):
+=======
+    def authenticate(self, user_account=None, service_account=None, **kargs):
+>>>>>>> upstream/refactor/127-cli-refactoring
         """
         Implement authentication for the GCP provider
         Refer to https://google-auth.readthedocs.io/en/stable/reference/google.auth.html.
@@ -58,7 +62,7 @@ class GCPProvider(BaseProvider):
             warnings.filterwarnings("ignore", "Your application has authenticated using end user credentials")
             pass  # Nothing more to do
         elif service_account:
-            client_secrets_path = os.path.abspath(key_file)  # TODO this is probably wrong
+            client_secrets_path = os.path.abspath(service_account)  # TODO this is probably wrong
             os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = client_secrets_path
         else:
             printError('Failed to authenticate to GCP - no supported account type')

--- a/tests/test-listall.py
+++ b/tests/test-listall.py
@@ -10,7 +10,7 @@ class TestListAllClass:
     # Make sure that ListAll does not crash with --help
     #
     def test_listall_help(self):
-        command = './Scout2ListAll.py --help'
+        command = './Scout.py listall --help'
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
         process.wait()
         assert process.returncode == 0

--- a/tests/test-main.py
+++ b/tests/test-main.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from mock import MagicMock, patch
 
 from ScoutSuite.__main__ import main
+from ScoutSuite.cli_parser import ScoutSuiteArgumentParser
 
 
 class TestMainClass(TestCase):
@@ -38,15 +39,17 @@ class TestMainClass(TestCase):
 
         with patch("sys.stderr", return_value=MagicMock()):
             with self.assertRaises(SystemExit):
-                code = main(passed_args=args)
+                args = ScoutSuiteArgumentParser().parse_args(args)
+                code = main(args)
 
         assert (code is None)
 
     def test_aws_provider(self):
-        args = ["--provider", "aws"]
+        args = ['aws']
         self.mocked_provider.provider_code = "aws"
 
-        code = main(passed_args=args)
+        args = ScoutSuiteArgumentParser().parse_args(args)
+        code = main(args)
 
         success_code = 0
         assert (code == success_code)
@@ -57,10 +60,11 @@ class TestMainClass(TestCase):
         assert (report_init_args[2] == "scoutsuite-report")  # report_dir
 
     def test_gcp_provider(self):
-        args = ["--provider", "gcp"]
+        args = ["gcp", "--service-account", "fakecredentials"]
         self.mocked_provider.provider_code = "gcp"
 
-        code = main(passed_args=args)
+        args = ScoutSuiteArgumentParser().parse_args(args)
+        code = main(args)
 
         success_code = 0
         assert (code == success_code)
@@ -71,10 +75,11 @@ class TestMainClass(TestCase):
         assert (report_init_args[2] == "scoutsuite-report")  # report_dir
 
     def test_azure_provider(self):
-        args = ["--provider", "azure"]
+        args = ["azure", "--cli"]
         self.mocked_provider.provider_code = "azure"
 
-        code = main(passed_args=args)
+        args = ScoutSuiteArgumentParser().parse_args(args)
+        code = main(args)
 
         success_code = 0
         assert (code == success_code)
@@ -85,17 +90,18 @@ class TestMainClass(TestCase):
         assert (report_init_args[2] == "scoutsuite-report")  # report_dir
 
     def test_unauthenticated(self):
-        args = ["--provider", "aws"]
+        args = ["aws"]
         self.mocked_provider.provider_code = "aws"
         self.mocked_provider.authenticate = MagicMock(return_value=False)
 
-        code = main(passed_args=args)
+        args = ScoutSuiteArgumentParser().parse_args(args)
+        code = main(args)
 
         unauthenticated_code = 42
         assert (code == unauthenticated_code)
 
     def test_keyboardinterrupted(self):
-        args = ["--provider", "aws"]
+        args = ["aws"]
         self.mocked_provider.provider_code = "aws"
 
         def _raise(e):
@@ -103,7 +109,8 @@ class TestMainClass(TestCase):
 
         self.mocked_provider.fetch = MagicMock(side_effect=_raise(KeyboardInterrupt))
 
-        code = main(passed_args=args)
+        args = ScoutSuiteArgumentParser().parse_args(args)
+        code = main(args)
 
         keyboardinterrupted_code = 130
         assert (code == keyboardinterrupted_code)

--- a/tests/test-rulesgenerator.py
+++ b/tests/test-rulesgenerator.py
@@ -10,7 +10,7 @@ class TestRulesGeneratorClass:
     # Make sure that RulesGenerator does not crash with --help
     #
     def test_rulesgenerator_help(self):
-        command = './ScoutRulesGenerator.py --help'
+        command = './Scout.py ruleset --help'
         process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
         process.wait()
         assert process.returncode == 0

--- a/tests/test-scoutsuite.py
+++ b/tests/test-scoutsuite.py
@@ -23,13 +23,13 @@ class TestScoutSuiteClass:
 
     def call_scout_suite(self, args):
         args = ['./Scout.py'] + args
+
+        args.append('aws')
+
         if TestScoutSuiteClass.profile_name:
             args.append('--profile')
             args.append(TestScoutSuiteClass.profile_name)
         #FIXME this only tests AWS
-
-        args.append('--provider')
-        args.append('aws')
 
         args.append('--force')
         args.append('--debug')


### PR DESCRIPTION
Extending this featuring a little more.
Add --all CLI arg to explicitly allow for scanning of all projects a service account or user has access to.
Change `else` clause in gcp/provider.py to raise Exception if unable to determine default project id or project id/folder id/organization id is not provided on CLI.
README.md documentation