### PR TITLE
Fetching termination-protection.

### DIFF
--- a/ScoutSuite/output/data/html/partials/aws/services.cloudformation.regions.id.stacks.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.cloudformation.regions.id.stacks.html
@@ -19,6 +19,7 @@
         None
       {{/if}}
     </div>
+    <div class="list-group-item-text item-margin">Termination protection enabled: {{termination_protection}}</div>
   </div>
   <div class="list-group-item">
     <h4 class="list-group-item-heading">Capabilities <span class="badge float-right">{{#if Capabilities}}{{Capabilities.length}}{{else}}0{{/if}}</span></h4>

--- a/ScoutSuite/providers/aws/services/cloudformation.py
+++ b/ScoutSuite/providers/aws/services/cloudformation.py
@@ -25,7 +25,11 @@ class CloudFormationRegionConfig(RegionConfig):
         """
         stack['id'] = stack.pop('StackId')
         stack['name'] = stack.pop('StackName')
-        stack_policy = api_clients[region].get_stack_policy(StackName = stack['name'])
+        
+        stack_description = api_clients[region].describe_stacks(StackName=stack['name'])
+        stack['termination_protection'] = stack_description['Stacks'][0]['EnableTerminationProtection']
+
+        stack_policy = api_clients[region].get_stack_policy(StackName=stack['name'])
         if 'StackPolicyBody' in stack_policy:
             stack['policy'] = json.loads(stack_policy['StackPolicyBody'])
         self.stacks[stack['name']] = stack


### PR DESCRIPTION
Added 2 rules to CloudFormation service on AWS for issue : https://github.com/nccgroup/ScoutSuite-Proprietary/issues/3 In this public part all that has been added is that I am fetching the value for EnabledTerminationProtection, which was not initially available.

Please see the proprietary part : https://github.com/nccgroup/ScoutSuite-Proprietary/pull/73

![image](https://user-images.githubusercontent.com/17322874/52588329-2f528a80-2e0a-11e9-8fc5-7fac6c49ddc3.png)
