### PR TITLE
[Azure/Bugfix] Using a _ instead of . in modal templates

### DIFF
--- a/ScoutSuite/output/data/html/partials/azure/services.securitycenter.auto_provisioning_settings.html
+++ b/ScoutSuite/output/data/html/partials/azure/services.securitycenter.auto_provisioning_settings.html
@@ -17,7 +17,7 @@
 
 <!-- Single Pricings template -->
 <script id="single_securitycenter_auto_provisioning_settings-template" type="text/x-handlebars-template">
-    {{> modal.template template='services.securitycenter.auto_provisioning_settings'}}
+    {{> modal_template template='services.securitycenter.auto_provisioning_settings'}}
 </script>
 <script>
     var single_securitycenter_auto_provisioning_settings_template = Handlebars.compile($("#single_securitycenter_auto_provisioning_settings-template").html());

--- a/ScoutSuite/output/data/html/partials/azure/services.securitycenter.pricings.html
+++ b/ScoutSuite/output/data/html/partials/azure/services.securitycenter.pricings.html
@@ -17,7 +17,7 @@
 
 <!-- Single Pricings template -->
 <script id="single_securitycenter_pricing-template" type="text/x-handlebars-template">
-    {{> modal.template template='services.securitycenter.pricings'}}
+    {{> modal_template template='services.securitycenter.pricings'}}
 </script>
 <script>
     var single_securitycenter_pricing_template = Handlebars.compile($("#single_securitycenter_pricing-template").html());

--- a/ScoutSuite/output/data/html/partials/azure/services.securitycenter.security_contacts.html
+++ b/ScoutSuite/output/data/html/partials/azure/services.securitycenter.security_contacts.html
@@ -20,7 +20,7 @@
 
 <!-- Single Pricings template -->
 <script id="single_securitycenter_security_contacts-template" type="text/x-handlebars-template">
-    {{> modal.template template='services.securitycenter.security_contacts'}}
+    {{> modal_template template='services.securitycenter.security_contacts'}}
 </script>
 <script>
     var single_securitycenter_security_contacts_template = Handlebars.compile($("#single_securitycenter_security_contacts-template").html());


### PR DESCRIPTION
Changed modal.template for modal_template in Azure SecurityCenter