### PR TITLE
Feature/4 sqs queues without server side encryption prop

### DIFF
--- a/ScoutSuite/output/data/html/partials/aws/services.sqs.regions.id.queues.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.sqs.regions.id.queues.html
@@ -8,6 +8,9 @@
           <h4 class="list-group-item-heading">Information</h4>
           <div class="list-group-item-text item-margin">Region: {{region}}</div>
           <div class="list-group-item-text item-margin">ARN: {{arn}}</div>
+          <div class="list-group-item-text item-margin">KMS master key id: <span id="sqs.regions.{{region}}.queues.{{@key}}.server-side-encryption-disabled">
+              {{#if kms_master_key_id}} {{kms_master_key_id}} {{else}} None {{/if}}
+            </span></div>
           <div class="list-group-item-text item-margin">Created on: {{CreatedTimestamp}}</div>
         </div>
         {{#if Policy.Statement.length}}

--- a/ScoutSuite/providers/aws/services/sqs.py
+++ b/ScoutSuite/providers/aws/services/sqs.py
@@ -24,10 +24,11 @@ class SQSRegionConfig(RegionConfig):
         :param queue_url:               URL of the AWS queue
         """
         queue = {'QueueUrl': queue_url}
-        attributes = api_clients[region].get_queue_attributes(QueueUrl = queue_url, AttributeNames = ['CreatedTimestamp', 'Policy', 'QueueArn'])['Attributes']
+        attributes = api_clients[region].get_queue_attributes(QueueUrl = queue_url, AttributeNames = ['CreatedTimestamp', 'Policy', 'QueueArn', 'KmsMasterKeyId'])['Attributes']
         queue['arn'] = attributes.pop('QueueArn')
-        for k in ['CreatedTimestamp']:
-            queue[k] = attributes[k] if k in attributes else None
+        queue['kms_master_key_id'] = attributes.pop('KmsMasterKeyId', None)
+        queue['CreatedTimestamp'] = attributes.pop('CreatedTimestamp', None)
+
         if 'Policy' in attributes:
             queue['Policy'] = json.loads(attributes['Policy'])
         else:


### PR DESCRIPTION
This is the public portion of a PR on the proprietary repo ([related issue](https://github.com/nccgroup/ScoutSuite-Proprietary/issues/4)). It adds the kms master key ID to the queue model. It was tested both with an encrypted queue and a nonencrypted queue.

Please also review the [proprietary portion](https://github.com/nccgroup/ScoutSuite-Proprietary/pull/78).