### PR TITLE
Move document.ready() functionality to separate function

### DIFF
--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -96,7 +96,6 @@ function onPageLoad() {
 
     });
 
-    hidePleaseWait();
 };
 
 /**
@@ -704,6 +703,8 @@ function load_metadata() {
             };
         };
     };
+
+    hidePleaseWait();
 };
 
 
@@ -721,7 +722,7 @@ function showAbout() {
 };
 
 /**
- * Hides About Scout Suite modal
+ * Hides Please Wait modal
  */
 function hidePleaseWait() {
     $('#please-wait-modal').fadeOut(500, () => { });

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -6,6 +6,13 @@ var run_results;
  * Event handlers
  */
 $(document).ready(function () {
+    onPageLoad();
+});
+
+/**
+ * Implements page load functionality
+ */
+function onPageLoad() {
     showPageFromHash();
 
     // when button is clicked, return CSV with finding
@@ -90,7 +97,7 @@ $(document).ready(function () {
     });
 
     hidePleaseWait();
-});
+};
 
 /**
  * Display the account ID -- use of the generic function + templates result in the div not being at the top of the page
@@ -666,6 +673,7 @@ function showPopup(content) {
  * Set up dashboards and dropdown menus
  */
 function load_metadata() {
+
     run_results = get_scoutsuite_results();
 
     // Set title dynamically


### PR DESCRIPTION
This is a small PR, all it does is move the content of `$(document).ready()` to a separate function. It also moves `hidePleaseWait()` to the end of `load_metadata()`.

This is required for the managed service, because the JSON/JS is loaded asynchronously, so we need to call the content of `$(document).ready()` once the JS has been loaded.

