### PR TITLE
Feature/58 google compute engine findings

### DIFF
--- a/ScoutSuite/output/data/html/partials/gcp/services.computeengine.instances.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.computeengine.instances.html
@@ -12,6 +12,10 @@
         <div class="list-group-item-text item-margin">Creation Date: <span id="computeengine.instances.{{@key}}.creation_timestamp">{{creation_timestamp}}</span></div>
         <div class="list-group-item-text item-margin">Status: <span id="computeengine.instances.{{@key}}.status">{{status}}</span></div>
         <div class="list-group-item-text item-margin">Deletion Protection: <span id="computeengine.instances.{{@key}}.deletion_protection_enabled">{{convert_bool_to_enabled deletion_protection_enabled}}</span></div>
+        <div class="list-group-item-text item-margin">Block Project SSH Keys: <span id="computeengine.instances.{{@key}}.block_project_ssh_keys_disabled">{{convert_bool_to_enabled block_project_ssh_keys_enabled}}</span></div>
+        <div class="list-group-item-text item-margin">IP Forwarding: <span id="computeengine.instances.{{@key}}.ip_forwarding_enabled">{{convert_bool_to_enabled ip_forwarding_enabled}}</span></div>
+        <div class="list-group-item-text item-margin">OS Login: <span id="computeengine.instances.{{@key}}.oslogin_disabled">{{convert_bool_to_enabled oslogin_enabled}}</span></div>
+        <div class="list-group-item-text item-margin">Serial Port Connection: <span id="computeengine.instances.{{@key}}.serial_port_enabled">{{convert_bool_to_enabled serial_port_enabled}}</span></div>        
         {{#if tags}}
         <div class="list-group-item-text item-margin">Tags:</div>
         <ul>
@@ -37,7 +41,7 @@
             {{#each disks}}
             <li><samp>{{source_device_name}}</samp></li>
             <ul>
-                <li>Bootable: <samp>{{bootable}}</samp></li>
+                <li>Bootable: <samp>{{bootable}}</samp></li> 
                 <li>Type: <samp>{{type}}</samp></li>
                 <li>Mode: <samp>{{mode}}</samp></li>
                 {{#if latest_snapshot}}
@@ -45,6 +49,7 @@
                 {{else}}
                 <li id="latest_snapshot">Latest snapshot: <samp>None</samp></li>
                 {{/if}}
+                <li>Customer Supplied Encryption: <span>{{convert_bool_to_enabled encrypted_with_csek}}</span></li>
             </ul>
             {{else}}
             <li><samp>None</samp></li>

--- a/ScoutSuite/providers/gcp/services/computeengine.py
+++ b/ScoutSuite/providers/gcp/services/computeengine.py
@@ -210,8 +210,7 @@ class ComputeEngineConfig(GCPBaseConfig):
         return metadata.get('block-project-ssh-keys') == 'true'
 
     def _get_common_instance_metadata_dict(self, project_id):
-        request = self.api_client.projects().get(project=project_id)
-        project = request.execute()
+        project = self.api_client.projects().get(project=project_id).execute()
         return self._metadata_to_dict(project['commonInstanceMetadata'])
 
     def _is_oslogin_enabled(self, instance, project_id):

--- a/ScoutSuite/providers/gcp/services/computeengine.py
+++ b/ScoutSuite/providers/gcp/services/computeengine.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from ScoutSuite.providers.gcp.configs.base import GCPBaseConfig
+from ScoutSuite.providers.gcp.utils import gcp_connect_service
 
 from googleapiclient.errors import HttpError
 import json
@@ -79,9 +80,11 @@ class ComputeEngineConfig(GCPBaseConfig):
     #         return None
 
     def parse_instances(self, instance, params):
+        project_id = self._get_project_id(instance)
+
         instance_dict = {}
         instance_dict['id'] = self.get_non_provider_id(instance['name'])
-        instance_dict['project_id'] = instance['selfLink'].split('/')[-5]
+        instance_dict['project_id'] = project_id
         instance_dict['name'] = instance['name']
         instance_dict['description'] = instance['description'] if 'description' in instance and instance['description'] else 'N/A'
         instance_dict['creation_timestamp'] = instance['creationTimestamp']
@@ -92,6 +95,11 @@ class ComputeEngineConfig(GCPBaseConfig):
         instance_dict['network_interfaces'] = instance['networkInterfaces']
         instance_dict['service_accounts'] = instance['serviceAccounts']
         instance_dict['deletion_protection_enabled'] = instance['deletionProtection']
+        instance_dict['block_project_ssh_keys_enabled'] = self._is_block_project_ssh_keys_enabled(instance)
+        instance_dict['oslogin_enabled'] = self._is_oslogin_enabled(instance, project_id)
+        instance_dict['ip_forwarding_enabled'] = instance['canIpForward']
+        instance_dict['serial_port_enabled'] = self._is_serial_port_enabled(instance)
+        instance_dict['has_full_access_cloud_apis'] = self._has_full_access_to_all_cloud_apis(instance)
 
         # TODO this should be done in it's own getter method and merged with instances during postprocessing
         instance_dict['disks'] = {}
@@ -102,8 +110,9 @@ class ComputeEngineConfig(GCPBaseConfig):
                     'mode': disk['mode'],
                     'source_url': disk['source'],
                     'source_device_name': disk['deviceName'],
-                    'bootable': disk['boot']
-                    }
+                    'bootable': disk['boot'],
+                    'encrypted_with_csek': self._is_encrypted_with_csek(disk)
+                }
 
         self.instances[instance_dict['id']] = instance_dict
 
@@ -188,3 +197,39 @@ class ComputeEngineConfig(GCPBaseConfig):
                                     firewall_dict[direction_string][rule['IPProtocol']] = ['0-65535']
 
         self.firewalls[firewall_dict['id']] = firewall_dict
+
+    def _get_project_id(self, instance):
+        return instance['selfLink'].split('/')[-5]
+
+    def _metadata_to_dict(self, metadata):
+        return dict((item['key'], item['value']) for item in metadata['items']) if 'items' in metadata else {}
+
+    def _is_block_project_ssh_keys_enabled(self, instance):
+        metadata = self._metadata_to_dict(instance['metadata'])
+        return metadata.get('block-project-ssh-keys') == 'true'
+
+    def _get_common_instance_metadata_dict(self, project_id):
+        computeengine_client = gcp_connect_service(service='computeengine')
+        request = computeengine_client.projects().get(project=project_id)
+        project = request.execute()
+        return self._metadata_to_dict(project['commonInstanceMetadata'])
+
+    def _is_oslogin_enabled(self, instance, project_id):
+        instance_metadata = self._metadata_to_dict(instance['metadata'])
+        if instance_metadata.get('enable-oslogin') == 'FALSE':
+            return False
+        elif instance_metadata.get('enable-oslogin') == 'TRUE':
+            return True
+        project_metadata = self._get_common_instance_metadata_dict(project_id)
+        return project_metadata.get('enable-oslogin') == 'TRUE'
+
+    def _is_serial_port_enabled(self, instance):
+        metadata = self._metadata_to_dict(instance['metadata'])
+        return metadata.get('serial-port-enable') == 'true'
+
+    def _has_full_access_to_all_cloud_apis(self, instance):
+        full_access_scope = 'https://www.googleapis.com/auth/cloud-platform'
+        return any(full_access_scope in service_account['scopes'] for service_account in instance['serviceAccounts'])
+
+    def _is_encrypted_with_csek(self, disk):
+        return 'diskEncryptionKey' in disk and 'sha256' in disk['diskEncryptionKey'] and disk['diskEncryptionKey']['sha256'] != ''

--- a/ScoutSuite/providers/gcp/services/computeengine.py
+++ b/ScoutSuite/providers/gcp/services/computeengine.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from ScoutSuite.providers.gcp.configs.base import GCPBaseConfig
-from ScoutSuite.providers.gcp.utils import gcp_connect_service
 
 from googleapiclient.errors import HttpError
 import json
@@ -81,6 +80,8 @@ class ComputeEngineConfig(GCPBaseConfig):
 
     def parse_instances(self, instance, params):
         project_id = self._get_project_id(instance)
+
+        self.api_client = params['api_client']
 
         instance_dict = {}
         instance_dict['id'] = self.get_non_provider_id(instance['name'])
@@ -209,8 +210,7 @@ class ComputeEngineConfig(GCPBaseConfig):
         return metadata.get('block-project-ssh-keys') == 'true'
 
     def _get_common_instance_metadata_dict(self, project_id):
-        computeengine_client = gcp_connect_service(service='computeengine')
-        request = computeengine_client.projects().get(project=project_id)
+        request = self.api_client.projects().get(project=project_id)
         project = request.execute()
         return self._metadata_to_dict(project['commonInstanceMetadata'])
 


### PR DESCRIPTION
Added the checks for the 6 findings for Google Compute Engine defined by the CIS. The PR for the rules themselves can be found on the proprietary repo.

The newly implemented findings are the following:
- Ensure that instances are not configured to use the default service account with full access to all Cloud APIs. (CIS 4.1)
- Ensure "Block Project-wide SSH keys" enabled for VM instances. (CIS 4.2)
- Ensure oslogin is enabled for a Project. (CIS 4.3)
- Ensure 'Enable connecting to serial ports' is not enabled for VM Instance. (CIS 4.4)
- Ensure that IP forwarding is not enabled on Instances. (CIS 4.5)
- Ensure VM disks for critical VMs are encrypted with CustomerSupplied Encryption Keys. (CIS 4.6)