### PR TITLE
bugfix/Single profile instead of array

### DIFF
--- a/ScoutSuite/__main__.py
+++ b/ScoutSuite/__main__.py
@@ -37,7 +37,7 @@ def main(args=None):
 
     # Create a cloud provider object
     cloud_provider = get_provider(provider=args.get('provider'),
-                                  profile=args.get('profile')[0] if args.get('profile') else None,
+                                  profile=args.get('profile'),
                                   project_id=args.get('project_id'),
                                   folder_id=args.get('folder_id'),
                                   organization_id=args.get('organization_id'),
@@ -59,7 +59,7 @@ def main(args=None):
     # Complete run, including pulling data from provider
     if not args.get('fetch_local'):
         # Authenticate to the cloud provider
-        authenticated = cloud_provider.authenticate(profile=args.get('profile')[0] if args.get('profile') else None,
+        authenticated = cloud_provider.authenticate(profile=args.get('profile'),
                                                     csv_credentials=args.get('csv_credentials'),
                                                     mfa_serial=args.get('mfa_serial'),
                                                     mfa_code=args.get('mfa_code'),
@@ -106,7 +106,7 @@ def main(args=None):
     cloud_provider.preprocessing(args.get('ip_ranges'), args.get('ip_ranges_name_key'))
 
     # Analyze config
-    finding_rules = Ruleset(environment_name=args.get('profile')[0] if args.get('profile') else None,
+    finding_rules = Ruleset(environment_name=args.get('profile'),
                             cloud_provider=args.get('provider'),
                             filename=args.get('ruleset'),
                             ip_ranges=args.get('ip_ranges'),
@@ -124,7 +124,7 @@ def main(args=None):
 
     # Handle exceptions
     try:
-        exceptions = RuleExceptions(args.get('profile')[0] if args.get('profile') else None, args.get('exceptions')[0])
+        exceptions = RuleExceptions(args.get('profile'), args.get('exceptions')[0])
         exceptions.process(cloud_provider)
         exceptions = exceptions.exceptions
     except Exception as e:
@@ -167,7 +167,7 @@ def main(args=None):
 def generate_report_name(provider_code, args):
     if provider_code == 'aws':
         if args.get('profile'):
-            report_file_name = 'aws-%s' % args.get('profile')[0]
+            report_file_name = 'aws-%s' % args.get('profile')
         else:
             report_file_name = 'aws'
     if provider_code == 'gcp':

--- a/ScoutSuite/core/cli_parser.py
+++ b/ScoutSuite/core/cli_parser.py
@@ -37,8 +37,7 @@ class ScoutSuiteArgumentParser:
         parser.add_argument('-p',
                             '--profile',
                             dest='profile',
-                            default=[default_profile],
-                            nargs='+',
+                            default=default_profile,
                             help='Name of the profile. Defaults to %(default)s' + default_profile_origin)
         parser.add_argument('-c',
                             '--csv-credentials',


### PR DESCRIPTION
Will require some testing on the profiles, as I don't have the setup to verify AWS profiles.

This small PR aims to make the --profile command line argument into a single variable instead of an array which we only use the first argument. 