### PR TITLE
Cleanup/warnings core

### DIFF
--- a/ScoutSuite/core/__init__.py
+++ b/ScoutSuite/core/__init__.py
@@ -2,10 +2,10 @@
 
 import os
 
-condition_operators = [ 'and', 'or' ]
+condition_operators = ['and', 'or']
 
-awsscout2_rules_data_dir  = os.path.join(os.path.dirname(__file__), 'data')
-awsscout2_conditions_dir  = os.path.join(awsscout2_rules_data_dir, 'conditions')
-awsscout2_filters_dir     = os.path.join(awsscout2_rules_data_dir, 'filters')
-awsscout2_findings_dir    = os.path.join(awsscout2_rules_data_dir, 'findings')
-awsscout2_rulesets_dir    = os.path.join(awsscout2_rules_data_dir, 'rulesets')
+awsscout2_rules_data_dir = os.path.join(os.path.dirname(__file__), 'data')
+awsscout2_conditions_dir = os.path.join(awsscout2_rules_data_dir, 'conditions')
+awsscout2_filters_dir = os.path.join(awsscout2_rules_data_dir, 'filters')
+awsscout2_findings_dir = os.path.join(awsscout2_rules_data_dir, 'findings')
+awsscout2_rulesets_dir = os.path.join(awsscout2_rules_data_dir, 'rulesets')

--- a/ScoutSuite/core/cli_parser.py
+++ b/ScoutSuite/core/cli_parser.py
@@ -6,6 +6,7 @@ import os
 
 from ScoutSuite import DEFAULT_REPORT_DIR
 
+
 class ScoutSuiteArgumentParser:
 
     def __init__(self):

--- a/ScoutSuite/core/conditions.py
+++ b/ScoutSuite/core/conditions.py
@@ -120,7 +120,7 @@ def pass_condition(b, test, a):
     elif test == 'withKey':
         result = (a in b)
     elif test == 'withoutKey':
-        result = (not a in b)
+        result = a not in b
 
     # List tests
     elif test == 'containAtLeastOneOf':
@@ -142,7 +142,7 @@ def pass_condition(b, test, a):
         if not type(a) == list:
             a = [a]
         for c in b:
-            if c != None and c != '' and c not in a:
+            if c and c != '' and c not in a:
                 result = True
                 break
     elif test == 'containNoneOf':

--- a/ScoutSuite/core/console.py
+++ b/ScoutSuite/core/console.py
@@ -123,7 +123,8 @@ def prompt_overwrite(filename, force_write, test_input=None):
     """
     if not os.path.exists(filename) or force_write:
         return True
-    return prompt_yes_no('File \'{}\' already exists. Do you want to overwrite it'.format(filename), test_input=test_input)
+    return prompt_yes_no('File \'{}\' already exists. Do you want to overwrite it'.format(filename),
+                         test_input=test_input)
 
 
 def prompt_value(question, choices=None, default=None, display_choices=True, display_indices=False,
@@ -144,7 +145,8 @@ def prompt_value(question, choices=None, default=None, display_choices=True, dis
     :param regex:                       TODO
     :param regex_format                 TODO
     :param max_laps:                    Exit after N laps
-    :param test_input:                       Used for unit testing
+    :param test_input:                  Used for unit testing
+    :param return_index                 TODO
 
     :return:
     """

--- a/ScoutSuite/core/processingengine.py
+++ b/ScoutSuite/core/processingengine.py
@@ -5,6 +5,7 @@ from ScoutSuite.utils import manage_dictionary
 
 from ScoutSuite.core.utils import recurse
 
+
 class ProcessingEngine(object):
     """
 
@@ -24,8 +25,7 @@ class ProcessingEngine(object):
                 except Exception as e:
                     print_error('Failed to create rule %s: %s' % (rule.path, e))
 
-
-    def run(self, cloud_provider, skip_dashboard = False):
+    def run(self, cloud_provider, skip_dashboard=False):
         # Clean up existing findings
         for service in cloud_provider.services:
             cloud_provider.services[service][self.ruleset.rule_type] = {}
@@ -33,7 +33,7 @@ class ProcessingEngine(object):
         # Process each rule
         for finding_path in self._filter_rules(self.rules, cloud_provider.service_list):
             for rule in self.rules[finding_path]:
-                
+
                 if not rule.enabled:  # or rule.service not in []: # TODO: handle this...
                     continue
 
@@ -50,14 +50,19 @@ class ProcessingEngine(object):
                         cloud_provider.services[service][self.ruleset.rule_type][rule.key][attr] = getattr(rule, attr)
                 try:
                     setattr(rule, 'checked_items', 0)
-                    cloud_provider.services[service][self.ruleset.rule_type][rule.key]['items'] = recurse(cloud_provider.services, cloud_provider.services, path, [], rule, True)
+                    cloud_provider.services[service][self.ruleset.rule_type][rule.key]['items'] = recurse(
+                        cloud_provider.services, cloud_provider.services, path, [], rule, True)
                     if skip_dashboard:
                         continue
-                    cloud_provider.services[service][self.ruleset.rule_type][rule.key]['dashboard_name'] = rule.dashboard_name
-                    cloud_provider.services[service][self.ruleset.rule_type][rule.key]['checked_items'] = rule.checked_items
-                    cloud_provider.services[service][self.ruleset.rule_type][rule.key]['flagged_items'] = len(cloud_provider.services[service][self.ruleset.rule_type][rule.key]['items'])
+                    cloud_provider.services[service][self.ruleset.rule_type][rule.key][
+                        'dashboard_name'] = rule.dashboard_name
+                    cloud_provider.services[service][self.ruleset.rule_type][rule.key][
+                        'checked_items'] = rule.checked_items
+                    cloud_provider.services[service][self.ruleset.rule_type][rule.key]['flagged_items'] = len(
+                        cloud_provider.services[service][self.ruleset.rule_type][rule.key]['items'])
                     cloud_provider.services[service][self.ruleset.rule_type][rule.key]['service'] = rule.service
-                    cloud_provider.services[service][self.ruleset.rule_type][rule.key]['rationale'] = rule.rationale if hasattr(rule, 'rationale') else 'No description available.'
+                    cloud_provider.services[service][self.ruleset.rule_type][rule.key][
+                        'rationale'] = rule.rationale if hasattr(rule, 'rationale') else 'No description available.'
                 except Exception as e:
                     print_exception(e)
                     print_error('Failed to process rule defined in %s' % rule.filename)
@@ -65,5 +70,6 @@ class ProcessingEngine(object):
                     cloud_provider.services[service][self.ruleset.rule_type][rule.key]['checked_items'] = 0
                     cloud_provider.services[service][self.ruleset.rule_type][rule.key]['flagged_items'] = 0
 
-    def _filter_rules(self, rules, services):
-        return { rule_name: rule for rule_name, rule in rules.items() if rule_name.split('.')[0] in services }
+    @staticmethod
+    def _filter_rules(rules, services):
+        return {rule_name: rule for rule_name, rule in rules.items() if rule_name.split('.')[0] in services}

--- a/ScoutSuite/core/rule.py
+++ b/ScoutSuite/core/rule.py
@@ -8,7 +8,6 @@ from ScoutSuite.core.console import print_error
 
 from ScoutSuite.utils import format_service_name
 
-
 ip_ranges_from_args = 'ip-ranges-from-args'
 
 re_aws_account_id = re.compile(r'_AWS_ACCOUNT_ID_')
@@ -31,11 +30,12 @@ testcases = [
     }
 ]
 
+
 class Rule(object):
 
     def to_string(self):
-        return (str(vars(self)))
-    
+        return str(vars(self))
+
     def __init__(self, data_path, filename, rule_type, rule):
         self.data_path = data_path
         self.filename = filename
@@ -46,18 +46,18 @@ class Rule(object):
         self.conditions = self.get_attribute('conditions', rule, [])
         self.key_suffix = self.get_attribute('key_suffix', rule, None)
 
-
-    def get_attribute(self, name, rule, default_value):
+    @staticmethod
+    def get_attribute(name, rule, default_value):
         return rule[name] if name in list(rule.keys()) else default_value
 
-
-    def set_definition(self, rule_definitions, attributes = None, ip_ranges = None, params = None):
+    def set_definition(self, rule_definitions, attributes=None, ip_ranges=None, params=None):
         """
         Update every attribute of the rule by setting the argument values as necessary
 
-        :param parameterized_input:
-        :param arg_values:
-        :param convert:
+        :param rule_definitions:            TODO
+        :param attributes:                  TODO
+        :param ip_ranges:                   TODO
+        :param params:                      TODO
         :return:
         """
         attributes = [] if attributes is None else attributes
@@ -72,7 +72,7 @@ class Rule(object):
             for condition in definition['conditions']:
                 if condition[0].startswith('_INCLUDE_('):
                     include = re.findall(r'_INCLUDE_\((.*?)\)', condition[0])[0]
-                    #new_conditions = load_data(include, key_name = 'conditions')
+                    # new_conditions = load_data(include, key_name = 'conditions')
                     rules_path = '%s/%s' % (self.data_path, include)
                     with open(rules_path, 'rt') as f:
                         new_conditions = f.read()
@@ -106,21 +106,23 @@ class Rule(object):
                     continue
                 for testcase in testcases:
                     result = testcase['regex'].match(condition[2])
-                    if result and (testcase['name'] == 'ip_ranges_from_file' or testcase['name'] == 'ip_ranges_from_local_file'):
+                    if result and (testcase['name'] == 'ip_ranges_from_file'
+                                   or testcase['name'] == 'ip_ranges_from_local_file'):
                         filename = result.groups()[0]
                         conditions = result.groups()[1] if len(result.groups()) > 1 else []
                         # TODO :: handle comma here...
                         if filename == ip_ranges_from_args:
                             prefixes = []
                             for filename in ip_ranges:
-                                prefixes += read_ip_ranges(filename, local_file = True, ip_only = True, conditions = conditions)
+                                prefixes += read_ip_ranges(filename, local_file=True, ip_only=True,
+                                                           conditions=conditions)
                             condition[2] = prefixes
                             break
                         else:
                             local_file = True if testcase['name'] == 'ip_ranges_from_local_file' else False
-                            condition[2] = read_ip_ranges(filename, local_file = local_file, ip_only = True, conditions = conditions)
+                            condition[2] = read_ip_ranges(filename, local_file=local_file, ip_only=True,
+                                                          conditions=conditions)
                             break
-                        break
                     elif result:
                         condition[2] = params[testcase['name']]
                         break

--- a/ScoutSuite/core/rule_definition.py
+++ b/ScoutSuite/core/rule_definition.py
@@ -48,7 +48,7 @@ class RuleDefinition(object):
             try:
                 file_path = os.path.join(rule_dir, self.file_name) if rule_dir else self.file_name
             except Exception as e:
-                print_error('Failed to load file %s: %e' % (self.file_name, e))
+                print_error('Failed to load file %s: %s' % (self.file_name, str(e)))
             if os.path.isfile(file_path):
                 self.file_path = file_path
                 file_name_valid = True
@@ -78,7 +78,7 @@ class RuleDefinition(object):
                     self.string_definition = f.read()
                     self.load_from_string_definition()
             except Exception as e:
-                print_error('Failed to load rule defined in %s: %s' % (self.file_name, e))
+                print_error('Failed to load rule defined in %s: %s' % (self.file_name, str(e)))
 
     def load_from_string_definition(self):
         try:
@@ -86,4 +86,4 @@ class RuleDefinition(object):
             for attr in definition:
                 setattr(self, attr, definition[attr])
         except Exception as e:
-            print_error('Failed to load string definition %s: %e' % (self.string_definition, e))
+            print_error('Failed to load string definition %s: %s' % (self.string_definition, str(e)))

--- a/ScoutSuite/core/rule_definition.py
+++ b/ScoutSuite/core/rule_definition.py
@@ -8,7 +8,7 @@ from ScoutSuite.core.console import print_error
 
 class RuleDefinition(object):
 
-    def __init__(self, data_path, file_name = None, rule_dirs = None, string_definition = None):
+    def __init__(self, data_path, file_name=None, rule_dirs=None, string_definition=None):
         rule_dirs = [] if rule_dirs is None else rule_dirs
         self.rules_data_path = data_path
         self.file_name = file_name
@@ -23,17 +23,16 @@ class RuleDefinition(object):
         else:
             print_error('Error')
 
-
     def __str__(self):
         desription = getattr(self, 'description')
         dlen = len(desription)
         padding = (80 - dlen) // 2 if dlen < 80 else 0
         value = '-' * 80 + '\n' + ' ' * padding + ' %s' % getattr(self, 'description') + '\n' + '-' * 80 + '\n'
         quiet_list = ['descriptions', 'rule_dirs', 'rule_types', 'rules_data_path', 'string_definition']
-        value += '\n'.join(('%s: %s') % (attr, str(getattr(self, attr))) for attr in vars(self) if attr not in quiet_list)
+        value += '\n'.join(
+            '%s: %s' % (attr, str(getattr(self, attr))) for attr in vars(self) if attr not in quiet_list)
         value += '\n'
         return value
-
 
     def load(self):
         """
@@ -80,7 +79,6 @@ class RuleDefinition(object):
                     self.load_from_string_definition()
             except Exception as e:
                 print_error('Failed to load rule defined in %s: %s' % (self.file_name, e))
-
 
     def load_from_string_definition(self):
         try:

--- a/ScoutSuite/core/ruleset.py
+++ b/ScoutSuite/core/ruleset.py
@@ -41,7 +41,7 @@ class Ruleset:
         self.environment_name = environment_name
         self.rule_type = rule_type
         # Ruleset filename
-        self.filename = self.find_file(filename, provider=cloud_provider)
+        self.filename = self.find_file(filename)
         if not self.filename:
             self.search_ruleset(environment_name)
         print_debug('Loading ruleset %s' % self.filename)
@@ -83,7 +83,7 @@ class Ruleset:
                         self.rules[filename] = []
                         for rule in ruleset['rules'][filename]:
                             self.handle_rule_versions(filename, rule_type, rule)
-            except Exception as e:
+            except Exception:
                 print_error('Error: ruleset file %s contains malformed JSON.' % self.filename)
                 self.rules = []
                 self.about = ''
@@ -92,7 +92,7 @@ class Ruleset:
             if not quiet:
                 print_error('Error: the file %s does not exist.' % self.filename)
 
-    def load_rules(self, file, rule_type, quiet=False):
+    def load_rules(self, file, rule_type):
         file.seek(0)
         ruleset = json.load(file)
         self.about = ruleset['about']
@@ -221,6 +221,6 @@ class TmpRuleset(Ruleset):
         self.rules_data_path = os.path.dirname(
             os.path.dirname(os.path.abspath(__file__))) + '/providers/%s/rules' % cloud_provider
 
-        self.load_rules(file=tmp_ruleset_file, rule_type='findings', quiet=False)
+        self.load_rules(file=tmp_ruleset_file, rule_type='findings')
 
         self.shared_init(False, rule_dirs, '', [])

--- a/ScoutSuite/core/ruleset.py
+++ b/ScoutSuite/core/ruleset.py
@@ -50,7 +50,7 @@ class Ruleset:
         self.shared_init(ruleset_generator, rules_dir, aws_account_id, ip_ranges)
 
     def to_string(self):
-        return (str(vars(self)))
+        return str(vars(self))
 
     def shared_init(self, ruleset_generator, rule_dirs, aws_account_id, ip_ranges):
 
@@ -59,8 +59,7 @@ class Ruleset:
             self.load_rule_definitions(ruleset_generator, rule_dirs)
 
         # Prepare the rules
-        params = {}
-        params['aws_account_id'] = aws_account_id
+        params = {'aws_account_id': aws_account_id}
         if ruleset_generator:
             self.prepare_rules(attributes=['description', 'key', 'rationale'], params=params)
         else:
@@ -70,7 +69,8 @@ class Ruleset:
         """
         Open a JSON file definiting a ruleset and load it into a Ruleset object
 
-        :param quiet:
+        :param rule_type:           TODO
+        :param quiet:               TODO
         :return:
         """
         if self.filename and os.path.exists(self.filename):
@@ -139,10 +139,8 @@ class Ruleset:
         """
         Load definition of rules declared in the ruleset
 
-        :param services:
-        :param ip_ranges:
-        :param aws_account_id:
-        :param generator:
+        :param ruleset_generator:
+        :param rule_dirs:
         :return:
         """
         rule_dirs = [] if rule_dirs is None else rule_dirs
@@ -171,6 +169,7 @@ class Ruleset:
         """
 
         :param environment_name:
+        :param no_prompt:
         :return:
         """
         ruleset_found = False
@@ -179,13 +178,14 @@ class Ruleset:
             ruleset_file_path = os.path.join(self.rules_data_path, 'rulesets/%s' % ruleset_file_name)
             if os.path.exists(ruleset_file_path):
                 if no_prompt or prompt_yes_no(
-                        "A ruleset whose name matches your environment name was found in %s. Would you like to use it instead of the default one" % ruleset_file_name):
+                        "A ruleset whose name matches your environment name was found in %s. "
+                        "Would you like to use it instead of the default one" % ruleset_file_name):
                     ruleset_found = True
                     self.filename = ruleset_file_path
         if not ruleset_found:
             self.filename = os.path.join(self.rules_data_path, 'rulesets/default.json')
 
-    def find_file(self, filename, filetype='rulesets', provider=None):
+    def find_file(self, filename, filetype='rulesets'):
         """
 
         :param filename:
@@ -224,5 +224,3 @@ class TmpRuleset(Ruleset):
         self.load_rules(file=tmp_ruleset_file, rule_type='findings', quiet=False)
 
         self.shared_init(False, rule_dirs, '', [])
-
-


### PR DESCRIPTION
This small PR aims to remove all the easy-to-remove warnings in the core/ folder. This includes PEP8 format, arguments not in docstrings, unused variables, etc.