### PR TITLE
Fixed the super() call to work with python2

### DIFF
--- a/ScoutSuite/providers/aws/configs/regions.py
+++ b/ScoutSuite/providers/aws/configs/regions.py
@@ -260,7 +260,7 @@ class RegionConfig(BaseConfig):
     """
 
     def __init__(self, region_name, resource_types=None, **kwargs):
-        super().__init__(**kwargs)
+        super(RegionConfig, self).__init__(**kwargs)
         resource_types = {} if resource_types is None else resource_types
         self.region = region_name
         self.name = region_name

--- a/ScoutSuite/providers/aws/configs/services.py
+++ b/ScoutSuite/providers/aws/configs/services.py
@@ -53,7 +53,7 @@ class AWSServicesConfig(BaseServicesConfig):
 
     def __init__(self, metadata=None, thread_config=4, **kwargs):
 
-        super().__init__(metadata, thread_config)
+        super(AWSServicesConfig, self).__init__(metadata, thread_config)
         self.cloudformation = CloudFormationConfig(metadata['management']['cloudformation'], thread_config)
         self.cloudtrail = CloudTrailConfig(metadata['management']['cloudtrail'], thread_config)
         self.cloudwatch = CloudWatchConfig(metadata['management']['cloudwatch'], thread_config)


### PR DESCRIPTION
This PR aims to fix the compatibility issue in Python 2 raised when trying the package before the 4.3.0 release. See https://github.com/nccgroup/ScoutSuite/pull/218