### PR TITLE
Bugfix - CloudFormation deletion policy

### DIFF
--- a/ScoutSuite/providers/aws/metadata.json
+++ b/ScoutSuite/providers/aws/metadata.json
@@ -43,7 +43,7 @@
                 }
             }
         },
-            "cloudwatch": {
+        "cloudwatch": {
             "resources": {
                 "alarms": {
                     "api_call": "describe_alarms",

--- a/ScoutSuite/providers/aws/metadata.json
+++ b/ScoutSuite/providers/aws/metadata.json
@@ -43,7 +43,7 @@
                 }
             }
         },
-        "cloudwatch": {
+            "cloudwatch": {
             "resources": {
                 "alarms": {
                     "api_call": "describe_alarms",

--- a/ScoutSuite/providers/aws/services/cloudformation.py
+++ b/ScoutSuite/providers/aws/services/cloudformation.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import json
+import re
 
 from ScoutSuite.providers.aws.configs.regions import RegionalServiceConfig, RegionConfig, api_clients
 
@@ -30,17 +31,39 @@ class CloudFormationRegionConfig(RegionConfig):
         stack['termination_protection'] = stack_description['Stacks'][0]['EnableTerminationProtection']
         stack['drifted'] = stack.pop('DriftInformation')['StackDriftStatus'] == 'DRIFTED'
 
-        template = api_clients[region].get_template(StackName=stack['name'])['TemplateBody']['Resources']
-        stack['deletion_policy'] = 'Delete'
-        for group in template.keys():
-            if 'DeletionPolicy' in template[group]:
-                stack['deletion_policy'] = template[group]['DeletionPolicy']
-                break
+        template = api_clients[region].get_template(StackName=stack['name'])['TemplateBody']
+        stack['deletion_policy'] = self.has_deletion_policy(template)
 
         stack_policy = api_clients[region].get_stack_policy(StackName=stack['name'])
         if 'StackPolicyBody' in stack_policy:
             stack['policy'] = json.loads(stack_policy['StackPolicyBody'])
         self.stacks[stack['name']] = stack
+
+    @staticmethod
+    def has_deletion_policy(template):
+        """
+            Return region to be used for global calls such as list bucket and get bucket location
+
+            :param template:                    The api response containing the stack's template
+            :return:
+            """
+        has_dp = True
+        # If a ressource is found to not have a deletion policy or have it to delete, the boolean is switched to
+        # false to indicate that the ressource will be deleted once the stack is deleted
+        if isinstance(template, dict):
+            template = template['Resources']
+            for group in template.keys():
+                if 'DeletionPolicy' in template[group]:
+                    if template[group]['DeletionPolicy'] is 'Delete':
+                        has_dp = False
+                else:
+                    has_dp = False
+        if isinstance(template, str):
+            if re.match(r'\"DeletionPolicy\"\s*:\s*\"Delete\"', template):
+                has_dp = False
+            elif not re.match(r'\"DeletionPolicy\"', template):
+                has_dp = False
+        return has_dp
 
 
 ########################################


### PR DESCRIPTION
It turns out that when calling the method get_template boto3 sometimes returns the TemplateBody as a dict, but other times as a string (because why be consistent). Also made the overall process for checking the rule more thorough.

Please also verify the [private PR](https://github.com/nccgroup/ScoutSuite-Proprietary/pull/107).