### PR TITLE
ELBv2 findings

### DIFF
--- a/ScoutSuite/output/data/html/partials/aws/services.elbv2.regions.id.vpcs.id.lbs.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.elbv2.regions.id.vpcs.id.lbs.html
@@ -9,7 +9,7 @@
             <ul>
                 <li class="list-group-item-text">VPC: {{get_value_at 'services.elbv2.regions' region 'vpcs' vpc 'name'}} ({{vpc}})</li>
                 <li class="list-group-item-text">DNS: {{DNSName}}</li>
-                <li class="list-group-item-text">Scheme: {{Scheme}}</li>
+                <li class="list-group-item-text"><span id="elbv2.regions.{{region}}.vpcs.{{vpc}}.lbs.{{@key}}.load_balancer_scheme">Scheme: {{Scheme}}</span></li>
                 <li class="list-group-item-text">Type: {{Type}}</li>
                 <li class="list-group-item-text">Availability zones:</li>
                 <ul>

--- a/ScoutSuite/output/data/html/partials/aws/services.elbv2.regions.id.vpcs.id.lbs.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.elbv2.regions.id.vpcs.id.lbs.html
@@ -22,11 +22,13 @@
         <div class="list-group-item">
             <h4>Listeners</h4>
             <ul>
+                <span id="elbv2.regions.{{region}}.vpcs.{{vpc}}.lbs.{{@key}}.has_secure_protocol">
                 {{#each listeners}}
                     <li class="list-group-item-text">
                         {{@key}} ({{Protocol}}{{#if SslPolicy}}, {{SslPolicy}}{{/if}})
                     </li>
                 {{/each}}
+                </span>
             </ul>
         </div>
         <div class="list-group-item">

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -114,11 +114,14 @@ class AWSProvider(BaseProvider):
                 for lb in elbv2_config['regions'][region]['vpcs'][vpc]['lbs']:
                     for i in range(0, len(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'])):
                         for sg in ec2_config['regions'][region]['vpcs'][vpc]['security_groups']:
-                            if 'GroupId' in elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i] \
-                                    and elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
-                                    'GroupId'] == sg:
+                            group_id = elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
+                                    'GroupId']
+                            if 'GroupId' in elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][
+                                    i] and group_id == sg:
                                 elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i] = \
                                     ec2_config['regions'][region]['vpcs'][vpc]['security_groups'][sg]
+                                elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
+                                    'GroupId'] = group_id
 
                         check_security_group_rules(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb], i, 'ingress')
                         check_security_group_rules(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb], i, 'egress')

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -107,7 +107,6 @@ class AWSProvider(BaseProvider):
                            {'AWSAccountId': self.aws_account_id})
 
     def _add_security_group_data_to_elbv2(self):
-        none = 'N/A'
         ec2_config = self.services['ec2']
         elbv2_config = self.services['elbv2']
         for region in elbv2_config['regions']:
@@ -115,13 +114,12 @@ class AWSProvider(BaseProvider):
                 for lb in elbv2_config['regions'][region]['vpcs'][vpc]['lbs']:
                     for i in range(0, len(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'])):
                         for sg in ec2_config['regions'][region]['vpcs'][vpc]['security_groups']:
-                            try:
-                                if elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
-                                        'GroupId'] == sg:
-                                    elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i] = \
-                                        ec2_config['regions'][region]['vpcs'][vpc]['security_groups'][sg]
-                            except KeyError:
-                                pass
+                            if 'GroupId' in elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i] \
+                                    and elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
+                                    'GroupId'] == sg:
+                                elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i] = \
+                                    ec2_config['regions'][region]['vpcs'][vpc]['security_groups'][sg]
+
                         check_security_group_rules(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb], i, 'ingress')
                         check_security_group_rules(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb], i, 'egress')
 

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -121,24 +121,21 @@ class AWSProvider(BaseProvider):
                                         ec2_config['regions'][region]['vpcs'][vpc]['security_groups'][sg]
                             except KeyError:
                                 pass
-                        for protocol in elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
-                                'rules']['ingress']['protocols']:
-                            for port in elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
-                                    'rules']['ingress']['protocols'][protocol]['ports']:
-                                elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
-                                    'valid_inbound_rules'] = True
-                                if port not in elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['listeners'] \
-                                        and port != none:
-                                    elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
-                                        'valid_inbound'] = False
-                            for port in elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
-                                    'rules']['egress']['protocols'][protocol]['ports']:
-                                elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
-                                    'valid_outbound_rules'] = True
-                                if port not in elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['listeners'] \
-                                        and port != none:
-                                    elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i][
-                                        'valid_outbound_rules'] = False
+                        self.check_sg_rules(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb], i, 'ingress')
+                        self.check_sg_rules(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb], i, 'egress')
+
+    @staticmethod
+    def check_sg_rules(lb, index, traffic_type):
+        none = 'N/A'
+        if traffic_type == 'ingress':
+            output = 'valid_inbound_rules'
+        elif traffic_type == 'egress':
+            output = 'valid_outbound_rules'
+        for protocol in lb['security_groups'][index]['rules'][traffic_type]['protocols']:
+            for port in lb['security_groups'][index]['rules'][traffic_type]['protocols'][protocol]['ports']:
+                lb['security_groups'][index][output] = True
+                if port not in lb['listeners'] and port != none:
+                    lb['security_groups'][index][output] = False
 
     def _check_ec2_zone_distribution(self):
         regions = self.services['ec2']['regions'].values()

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -8,6 +8,7 @@ from ScoutSuite.core.console import print_debug, print_error, print_exception, p
 from ScoutSuite.providers.aws.aws import get_aws_account_id
 from ScoutSuite.providers.aws.configs.services import AWSServicesConfig
 from ScoutSuite.providers.aws.services.vpc import put_cidr_name
+from ScoutSuite.providers.aws.services.elbv2 import check_security_group_rules
 from ScoutSuite.providers.base.configs.browser import combine_paths, get_object_at, get_value_at
 from ScoutSuite.providers.base.provider import BaseProvider
 from ScoutSuite.utils import manage_dictionary
@@ -121,21 +122,8 @@ class AWSProvider(BaseProvider):
                                         ec2_config['regions'][region]['vpcs'][vpc]['security_groups'][sg]
                             except KeyError:
                                 pass
-                        self.check_sg_rules(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb], i, 'ingress')
-                        self.check_sg_rules(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb], i, 'egress')
-
-    @staticmethod
-    def check_sg_rules(lb, index, traffic_type):
-        none = 'N/A'
-        if traffic_type == 'ingress':
-            output = 'valid_inbound_rules'
-        elif traffic_type == 'egress':
-            output = 'valid_outbound_rules'
-        for protocol in lb['security_groups'][index]['rules'][traffic_type]['protocols']:
-            for port in lb['security_groups'][index]['rules'][traffic_type]['protocols'][protocol]['ports']:
-                lb['security_groups'][index][output] = True
-                if port not in lb['listeners'] and port != none:
-                    lb['security_groups'][index][output] = False
+                        check_security_group_rules(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb], i, 'ingress')
+                        check_security_group_rules(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb], i, 'egress')
 
     def _check_ec2_zone_distribution(self):
         regions = self.services['ec2']['regions'].values()

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -111,13 +111,11 @@ class AWSProvider(BaseProvider):
         for region in elbv2_config['regions']:
             for vpc in elbv2_config['regions'][region]['vpcs']:
                 for lb in elbv2_config['regions'][region]['vpcs'][vpc]['lbs']:
-                    security_groups = ec2_config['regions'][region]['vpcs'][vpc]['security_groups']
                     for i in range(0, len(elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'])):
-                        for security_group in security_groups:
-                            if elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i]['GroupId'] \
-                                    is security_group['id']:
+                        for sg in ec2_config['regions'][region]['vpcs'][vpc]['security_groups']:
+                            if elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i]['GroupId'] == sg:
                                 elbv2_config['regions'][region]['vpcs'][vpc]['lbs'][lb]['security_groups'][i] = \
-                                    security_group
+                                    ec2_config['regions'][region]['vpcs'][vpc]['security_groups'][sg]
 
     def _check_ec2_zone_distribution(self):
         regions = self.services['ec2']['regions'].values()

--- a/ScoutSuite/providers/aws/services/elbv2.py
+++ b/ScoutSuite/providers/aws/services/elbv2.py
@@ -79,3 +79,16 @@ class ELBv2Config(RegionalServiceConfig):
 
     def __init__(self, service_metadata, thread_config=4):
         super(ELBv2Config, self).__init__(service_metadata, thread_config)
+
+
+def check_security_group_rules(lb, index, traffic_type):
+    none = 'N/A'
+    if traffic_type == 'ingress':
+        output = 'valid_inbound_rules'
+    elif traffic_type == 'egress':
+        output = 'valid_outbound_rules'
+    for protocol in lb['security_groups'][index]['rules'][traffic_type]['protocols']:
+        for port in lb['security_groups'][index]['rules'][traffic_type]['protocols'][protocol]['ports']:
+            lb['security_groups'][index][output] = True
+            if port not in lb['listeners'] and port != none:
+                lb['security_groups'][index][output] = False

--- a/ScoutSuite/providers/aws/services/elbv2.py
+++ b/ScoutSuite/providers/aws/services/elbv2.py
@@ -44,6 +44,7 @@ class ELBv2RegionConfig(RegionConfig):
         except Exception as e:
             # Network load balancers do not have security groups
             pass
+        lb['has_secure_protocol'] = False
         lb['listeners'] = {}
         # Get listeners
         listeners = handle_truncated_response(api_clients[region].describe_listeners, {'LoadBalancerArn': lb['arn']},
@@ -53,6 +54,9 @@ class ELBv2RegionConfig(RegionConfig):
             listener.pop('LoadBalancerArn')
             port = listener.pop('Port')
             lb['listeners'][port] = listener
+            if listener['Protocol'] is 'HTTPS':
+                lb['has_secure_protocol'] = True
+
         # Get attributes
         lb['attributes'] = api_clients[region].describe_load_balancer_attributes(LoadBalancerArn=lb['arn'])[
             'Attributes']


### PR DESCRIPTION
PR for [this issue](https://github.com/nccgroup/ScoutSuite-Proprietary/issues/108).
Please also check out the [private PR](https://github.com/nccgroup/ScoutSuite-Proprietary/pull/113).

Added the following findings, the third one being split into 3 findings so that the user doesn't have to investigate by himself what's wrong. I had to copy EC2's data about security groups into ELBv2 since the API call [`describe_security_groups()`](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_security_groups) isn't available on the ELBv2 service.

- [Review AWS Internet Facing Load Balancers](https://www.cloudconformity.com/conformity-rules/ELBv2/internet-facing-load-balancers.html)
- [AWS ALB (ELBv2) Listener Security](https://www.cloudconformity.com/conformity-rules/ELBv2/listener-security.html)
- [AWS ELBv2 Security Groups](https://www.cloudconformity.com/conformity-rules/ELBv2/security-group.html) 
    * VPC's Default security group
    * Inbound rules do not match listeners
    * Outbound rules do not match listeners

![image](https://user-images.githubusercontent.com/17322874/54212310-1c8aae80-44b9-11e9-99e2-b5a40eb6da87.png)

P.S. I know there are quite a few layers of `for` loops, if you have a concrete idea on how to improve this please feel free to tell me so. 