### PR TITLE
Optimize fetching Monitor logs

### DIFF
--- a/ScoutSuite/output/data/html/partials/azure/services.storageaccounts.storage_accounts.html
+++ b/ScoutSuite/output/data/html/partials/azure/services.storageaccounts.storage_accounts.html
@@ -8,7 +8,7 @@
         <h4 class="list-group-item-heading">Information</h4>
         <div class="list-group-item-text item-margin">Storage Account Name: <span id="storageaccounts.storage_accounts.{{@key}}.name">{{name}}</span></div>
         <div class="list-group-item-text item-margin">Public traffic: <span id="storageaccounts.storage_accounts.{{@key}}.public_traffic_allowed">{{ convert_bool_to_enabled public_traffic_allowed }}</span></div>
-        <div class="list-group-item-text item-margin">Access Key Rotated: <span id="monitor.activity_logs.storage_accounts.{{@key}}.access_keys_rotated">{{ get_value_at 'services' 'monitor' 'activity_logs' 'storage_accounts' @key 'access_keys_rotated' }}</span></div>
+        <div class="list-group-item-text item-margin">Last Access Key Rotation: <span id="monitor.activity_logs.storage_accounts.{{@key}}.access_keys_last_rotation_date">{{ get_value_at 'services' 'monitor' 'activity_logs' 'storage_accounts' @key 'access_keys_last_rotation_date' }}</span></div>
     </div>
 
     <div class="list-group-item">

--- a/ScoutSuite/providers/azure/rules/findings/storageaccount-access-keys-not-rotated.json
+++ b/ScoutSuite/providers/azure/rules/findings/storageaccount-access-keys-not-rotated.json
@@ -1,10 +1,12 @@
 {
     "dashboard_name": "Storage Accounts",
     "description": "Access Keys Not Rotated",
-    "rationale": "The access keys of your storage accounts should be rotated at least every 90 days. See CIS 3.3.",
+    "rationale": "The access keys of your storage accounts should be rotated at least every _ARG_0_ days. See CIS 3.3.",
     "path": "storageaccounts.storage_accounts.id",
-    "conditions": [ "and",
-        [ "monitor.activity_logs.storage_accounts._GET_VALUE_AT_(storageaccounts.storage_accounts.id).access_keys_rotated", "false", "" ]
+    "conditions": [ "or",
+        [ "monitor.activity_logs.storage_accounts", "withoutKey", "_GET_VALUE_AT_(storageaccounts.storage_accounts.id)"],
+        [ "monitor.activity_logs.storage_accounts._GET_VALUE_AT_(storageaccounts.storage_accounts.id).access_keys_last_rotation_date", "olderThan", ["_ARG_0_", "days"] ]
     ],
-    "id_suffix": "access_keys_rotated"
+
+    "id_suffix": "access_keys_last_rotation_date"
 }

--- a/ScoutSuite/providers/azure/rules/rulesets/default.json
+++ b/ScoutSuite/providers/azure/rules/rulesets/default.json
@@ -56,6 +56,9 @@
     ],
     "storageaccount-access-keys-not-rotated.json": [
       {
+        "args": [
+          "90"
+        ],
         "enabled": true,
         "level": "warning"
       }


### PR DESCRIPTION
This PR optimizes fetching logs to filter for the only resource provider that's currently being used (`Microsoft.Storage`).

In the test subscription, this brings the log count from 3895 to 176, so it's a significant improvement. Nonetheless, I'm still finding that for production accounts, `resourceProvider` still includes a lot (too many) logs. Ideally we'd have to filter by `resourceURI`, which is the `resource_id` in the `activity_log` object (e.g. `/subscriptions/<subscription ID>/resourceGroups/<resource_group_name>/providers/Microsoft.Storage/storageAccounts/<storage account`). @misg do you think this is possible, as the info would have to be fetched from the Storage Accounts service...