### PR TITLE
Exceptions thrown when refusing to overwrite report

### DIFF
--- a/ScoutSuite/output/js.py
+++ b/ScoutSuite/output/js.py
@@ -69,6 +69,9 @@ class JavaScriptReaderWriter(object):
                 if first_line:
                     print('%s' % first_line, file=f)
                 print('%s' % json.dumps(config, indent=4 if debug else None, separators=(',', ': '), sort_keys=True, cls=Scout2Encoder), file=f)
+        except AttributeError as e:
+            # __open_file returned None
+            pass
         except Exception as e:
             print_exception(e)
 


### PR DESCRIPTION
When generating a report and saying `n` to "overwrite?", got the following error:
```
File 'scoutsuite-report/scoutsuite-results/scoutsuite_results-azure.js' already exists. Do you want to overwrite it (y/n)? n
Traceback (most recent call last):
  File "/home/j4v/Downloads/release/ScoutSuite/ScoutSuite/output/js.py", line 68, in save_to_file
    with self.__open_file(config_path, force_write, False) as f:
AttributeError: __enter__

Saving data to scoutsuite-report/scoutsuite-results/scoutsuite_exceptions-azure.js
Saving config...
File 'scoutsuite-report/scoutsuite-results/scoutsuite_exceptions-azure.js' already exists. Do you want to overwrite it (y/n)? n
Traceback (most recent call last):
  File "/home/j4v/Downloads/release/ScoutSuite/ScoutSuite/output/js.py", line 68, in save_to_file
    with self.__open_file(config_path, force_write, False) as f:
AttributeError: __enter__

Creating scoutsuite-report/report-azure.html ...
```

This is due to `__open_file()` returning `None` when saying `no` to "overwrite?", which threw an exception when using `with x as f`. I'm not sure why this wasn't previously the case as not much has changed (appart from the change from `printException` to `print_exception`).