### PR TITLE
Refactoring/aws/dynamodb

### DIFF
--- a/ScoutSuite/providers/aws/configs/services.py
+++ b/ScoutSuite/providers/aws/configs/services.py
@@ -24,11 +24,11 @@ from ScoutSuite.providers.base.configs.services import BaseServicesConfig
 
 try:
     from ScoutSuite.providers.aws.services.config_private import ConfigConfig
-    from ScoutSuite.providers.aws.services.dynamodb_private import DynamoDBConfig
+    from ScoutSuite.providers.aws.resources.dynamodb.service_private import DynamoDB
     from ScoutSuite.providers.aws.services.kms_private import KMSConfig
 except ImportError:
     ConfigConfig = None
-    DynamoDBConfig = None
+    DynamoDB = None
     KMSConfig = None
 
 
@@ -79,8 +79,7 @@ class AWSServicesConfig(BaseServicesConfig):
         try:
             self.config = ConfigConfig(
                 metadata['management']['config'], thread_config)
-            self.dynamodb = DynamoDBConfig(
-                metadata['database']['dynamodb'], thread_config)
+            self.dynamodb = DynamoDB()
             self.kms = KMSConfig(metadata['security']['kms'], thread_config)
         except (NameError, TypeError):
             pass

--- a/ScoutSuite/providers/aws/facade/facade.py
+++ b/ScoutSuite/providers/aws/facade/facade.py
@@ -16,22 +16,15 @@ from ScoutSuite.providers.aws.facade.redshift import RedshiftFacade
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
 from ScoutSuite.providers.utils import run_concurrently
 
+try:
+    from ScoutSuite.providers.aws.facade.dynamodb_private import DynamoDBFacade
+except:
+    pass
+
 
 class AWSFacade(AWSBaseFacade):
     def __init__(self, credentials: dict = None):
         self._set_session(credentials)
-
-        self.ec2 = EC2Facade(self.session)
-        self.awslambda = LambdaFacade(self.session)
-        self.cloudformation = CloudFormation(self.session)
-        self.cloudtrail = CloudTrailFacade(self.session)
-        self.cloudwatch = CloudWatch(self.session)
-        self.directconnect = DirectConnectFacade(self.session)
-        self.efs = EFSFacade(self.session)
-        self.elasticache = ElastiCacheFacade(self.session)
-        self.emr = EMRFacade(self.session)
-        self.elbv2 = ELBv2Facade(self.session)
-        self.redshift = RedshiftFacade(self.session)
 
     async def build_region_list(self, service: str, chosen_regions=None, partition_name='aws'):
         service = 'ec2containerservice' if service == 'ecs' else service
@@ -61,6 +54,9 @@ class AWSFacade(AWSBaseFacade):
 
         # TODO: This should only be done in the constructor. I put this here for now, because this method is currently
         # called from outside, but it should not happen.
+        self._instantiate_facades()
+
+    def _instantiate_facades(self):
         self.ec2 = EC2Facade(self.session)
         self.awslambda = LambdaFacade(self.session)
         self.cloudformation = CloudFormation(self.session)
@@ -72,3 +68,8 @@ class AWSFacade(AWSBaseFacade):
         self.emr = EMRFacade(self.session)
         self.elbv2 = ELBv2Facade(self.session)
         self.redshift = RedshiftFacade(self.session)
+
+        try:
+            self.dynamodb = DynamoDBFacade(self.session)
+        except:
+            pass


### PR DESCRIPTION
This PR migrates DynamoDB to the new architecture, see #183 . This is part of a proprietary feature, please also review the [proprietary PR](https://github.com/nccgroup/ScoutSuite-Proprietary/pull/116).

**Interesting stuff:**
~The get for one table requires 3 API calls (getting the table info, the manual backups info and the continuous backups). I batched the requests instead of just parallelizing all the requests. This will mitigate the risk of being throttled.~
EDIT: The batching was actually reverted. We realized the number of concurrent requests was already limited by the number of threads, so this became superfluous.