### PR TITLE
Fix for https://github.com/nccgroup/ScoutSuite/issues/104

### DIFF
--- a/ScoutSuite/providers/base/provider.py
+++ b/ScoutSuite/providers/base/provider.py
@@ -111,6 +111,16 @@ class BaseProvider(object):
 
     @staticmethod
     def _build_services_list(supported_services, services, skipped_services):
+
+        # Ensure services and skipped services exist, otherwise log exception
+        error = False
+        for service in services+skipped_services:
+            if service not in supported_services:
+                print_exception('Service \"{}\" does not exist, skipping.'.format(service))
+                error = True
+        if error:
+            print_exception('Available services are: {}'.format(str(list(supported_services)).strip('[]')))
+
         return [s for s in supported_services if (services == [] or s in services) and s not in skipped_services]
 
     def _update_last_run(self, current_time, ruleset):


### PR DESCRIPTION
This is a fix for https://github.com/nccgroup/ScoutSuite/issues/104. 

I've put the path at the `ScoutSuite/providers/base/provider.py` level so it is dynamic/multi-provider. Ideally this should be done during argument parsing, but we don't know the list of available services at that time (without a hack).

Result:
![sc_2019-03-23_19h10m21s](https://user-images.githubusercontent.com/4206926/54869929-b434aa80-4d9f-11e9-9780-121f27372585.jpg)
