### PR TITLE
Make the fetching of azure resources really concurrent

### DIFF
--- a/ScoutSuite/providers/azure/facade/keyvault.py
+++ b/ScoutSuite/providers/azure/facade/keyvault.py
@@ -7,4 +7,6 @@ class KeyVaultFacade:
         self._client = KeyVaultManagementClient(credentials, subscription_id)
 
     async def get_key_vaults(self):
-        return await run_concurrently(self._client.vaults.list_by_subscription)
+        return await run_concurrently(
+            lambda: list(self._client.vaults.list_by_subscription())
+        )

--- a/ScoutSuite/providers/azure/facade/network.py
+++ b/ScoutSuite/providers/azure/facade/network.py
@@ -7,7 +7,11 @@ class NetworkFacade:
         self._client = NetworkManagementClient(credentials, subscription_id)
 
     async def get_network_watchers(self):
-        return await run_concurrently(self._client.network_watchers.list_all)
+        return await run_concurrently(
+            lambda: list(self._client.network_watchers.list_all())
+        )
 
     async def get_network_security_groups(self):
-        return await run_concurrently(self._client.network_security_groups.list_all)
+        return await run_concurrently(
+            lambda: list(self._client.network_security_groups.list_all())
+        )

--- a/ScoutSuite/providers/azure/facade/securitycenter.py
+++ b/ScoutSuite/providers/azure/facade/securitycenter.py
@@ -7,10 +7,16 @@ class SecurityCenterFacade:
         self._client = SecurityCenter(credentials, subscription_id, '')
 
     async def get_pricings(self):
-        return await run_concurrently(self._client.pricings.list)
+        return await run_concurrently(
+            lambda: list(self._client.pricings.list())
+        )
 
     async def get_security_contacts(self):
-        return await run_concurrently(self._client.security_contacts.list)
+        return await run_concurrently(
+            lambda: list(self._client.security_contacts.list())
+        )
 
     async def get_auto_provisioning_settings(self):
-        return await run_concurrently(self._client.auto_provisioning_settings.list)
+        return await run_concurrently(
+            lambda: list(self._client.auto_provisioning_settings.list())
+        )

--- a/ScoutSuite/providers/azure/facade/sqldatabase.py
+++ b/ScoutSuite/providers/azure/facade/sqldatabase.py
@@ -8,19 +8,19 @@ class SQLDatabaseFacade:
 
     async def get_database_blob_auditing_policies(self, resource_group_name, server_name, database_name):
         return await run_concurrently(
-            lambda: self._client.database_blob_auditing_policies.get(
-                resource_group_name, server_name, database_name)
+            lambda: list(self._client.database_blob_auditing_policies.get(
+                resource_group_name, server_name, database_name))
         )
 
     async def get_database_threat_detection_policies(self, resource_group_name, server_name, database_name):
         return await run_concurrently(
-            lambda: self._client.database_threat_detection_policies.get(
-                resource_group_name, server_name, database_name)
+            lambda: list(self._client.database_threat_detection_policies.get(
+                resource_group_name, server_name, database_name))
         )
 
     async def get_databases(self, resource_group_name, server_name):
         return await run_concurrently(
-            lambda: self._client.databases.list_by_server(resource_group_name, server_name)
+            lambda: list(self._client.databases.list_by_server(resource_group_name, server_name))
         )
 
     async def get_database_replication_links(self, resource_group_name, server_name, database_name):
@@ -31,7 +31,7 @@ class SQLDatabaseFacade:
 
     async def get_server_azure_ad_administrators(self, resource_group_name, server_name):
         return await run_concurrently(
-            lambda: self._client.server_azure_ad_administrators.get(resource_group_name, server_name)
+            lambda: list(self._client.server_azure_ad_administrators.get(resource_group_name, server_name))
         )
 
     async def get_server_blob_auditing_policies(self, resource_group_name, server_name):
@@ -45,10 +45,12 @@ class SQLDatabaseFacade:
         )
 
     async def get_servers(self):
-        return await run_concurrently(self._client.servers.list)
+        return await run_concurrently(
+            lambda: list(self._client.servers.list())
+        )
 
     async def get_database_transparent_data_encryptions(self, resource_group_name, server_name, database_name):
         return await run_concurrently(
-            lambda: self._client.transparent_data_encryptions.get(
-                resource_group_name, server_name, database_name)
+            lambda: list(self._client.transparent_data_encryptions.get(
+                resource_group_name, server_name, database_name))
         )

--- a/ScoutSuite/providers/azure/facade/storageaccounts.py
+++ b/ScoutSuite/providers/azure/facade/storageaccounts.py
@@ -7,9 +7,11 @@ class StorageAccountsFacade:
         self._client = StorageManagementClient(credentials, subscription_id)
 
     async def get_storage_accounts(self):
-        return await run_concurrently(self._client.storage_accounts.list)
+        return await run_concurrently(
+            lambda: list(self._client.storage_accounts.list())
+        )
 
     async def get_blob_containers(self, resource_group_name, storage_account_name):
         return await run_concurrently(
-            lambda: self._client.blob_containers.list(resource_group_name, storage_account_name).value
+            lambda: list(self._client.blob_containers.list(resource_group_name, storage_account_name).value)
         )


### PR DESCRIPTION
I just discovered that the azure python sdk that we use in our azure facades always return a custom iterator when the result of an API request is a collection of items. In fact, this custom iterator wraps a custom paginator that enables to fetch resources in a "lazy" way, making API calls only when necessary (e.g. only when truly iterating over that custom iterator).
Since our azure facades were always returning this kind of custom iterator, it means that all the API calls made for fetching the resources were actually done sequentially, outside the thread pool...

This PR fixes that, making the fetching of azure resources really concurrent (by simply enforcing iteration over those custom iterators, using python builtin `list()`).

Same PR applies to the [proprietary repository](https://github.com/nccgroup/ScoutSuite-Proprietary/pull/119).