### PR TITLE
Enhancement/Additional AWS exception handling

### DIFF
--- a/ScoutSuite/providers/aws/facade/cloudformation.py
+++ b/ScoutSuite/providers/aws/facade/cloudformation.py
@@ -1,9 +1,10 @@
 import json
 
-from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
-from ScoutSuite.providers.utils import run_concurrently
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.utils import get_and_set_concurrently
+from ScoutSuite.providers.utils import run_concurrently
 
 
 class CloudFormation(AWSBaseFacade):
@@ -20,21 +21,32 @@ class CloudFormation(AWSBaseFacade):
 
     async def _get_and_set_description(self, stack: {}, region: str):
         client = AWSFacadeUtils.get_client('cloudformation', self.session, region)
-        stack_description = await run_concurrently(
-            lambda: client.describe_stacks(StackName=stack['StackName'])['Stacks'][0])
-        stack.update(stack_description)
+        try:
+            stack_description = await run_concurrently(
+                lambda: client.describe_stacks(StackName=stack['StackName'])['Stacks'][0])
+        except Exception as e:
+            print_exception('Failed to describe CloudFormation stack: {}'.format(e))
+        else:
+            stack.update(stack_description)
 
     async def _get_and_set_template(self, stack: {}, region: str):
         client = AWSFacadeUtils.get_client('cloudformation', self.session, region)
-        stack['template'] = await run_concurrently(
-            lambda: client.get_template(StackName=stack['StackName'])['TemplateBody'])
+        try:
+            stack['template'] = await run_concurrently(
+                lambda: client.get_template(StackName=stack['StackName'])['TemplateBody'])
+        except Exception as e:
+            print_exception('Failed to get CloudFormation template: {}'.format(e))
 
     async def _get_and_set_policy(self, stack: {}, region: str):
         client = AWSFacadeUtils.get_client('cloudformation', self.session, region)
-        stack_policy = await run_concurrently(
-                    lambda: client.get_stack_policy(StackName=stack['StackName']))
-        if 'StackPolicyBody' in stack_policy:
-            stack['policy'] = json.loads(stack_policy['StackPolicyBody'])
+        try:
+            stack_policy = await run_concurrently(
+                lambda: client.get_stack_policy(StackName=stack['StackName']))
+        except Exception as e:
+            print_exception('Failed to get CloudFormation stack policy: {}'.format(e))
+        else:
+            if 'StackPolicyBody' in stack_policy:
+                stack['policy'] = json.loads(stack_policy['StackPolicyBody'])
 
     @staticmethod
     def _is_stack_deleted(stack):

--- a/ScoutSuite/providers/aws/facade/cloudtrail.py
+++ b/ScoutSuite/providers/aws/facade/cloudtrail.py
@@ -1,26 +1,38 @@
-from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
-from ScoutSuite.providers.utils import run_concurrently
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.utils import get_and_set_concurrently
+from ScoutSuite.providers.utils import run_concurrently
 
 
 class CloudTrailFacade(AWSBaseFacade):
     async def get_trails(self, region):
         client = AWSFacadeUtils.get_client('cloudtrail', self.session, region)
-        trails = await run_concurrently(
-            lambda: client.describe_trails()['trailList'])
-        await get_and_set_concurrently(
-            [self._get_and_set_status, self._get_and_set_selectors], trails, region=region)
-
-        return trails
+        try:
+            trails = await run_concurrently(
+                lambda: client.describe_trails()['trailList'])
+        except Exception as e:
+            print_exception('Failed to describe CloutTrail trail: {}'.format(e))
+            trails = []
+        else:
+            await get_and_set_concurrently(
+                [self._get_and_set_status, self._get_and_set_selectors], trails, region=region)
+        finally:
+            return trails
 
     async def _get_and_set_status(self, trail: {}, region: str):
         client = AWSFacadeUtils.get_client('cloudtrail', self.session, region)
-        trail_status = await run_concurrently(
-            lambda: client.get_trail_status(Name=trail['TrailARN']))
-        trail.update(trail_status)
+        try:
+            trail_status = await run_concurrently(
+                lambda: client.get_trail_status(Name=trail['TrailARN']))
+            trail.update(trail_status)
+        except Exception as e:
+            print_exception('Failed to get CloudTrail trail status: {}'.format(e))
 
     async def _get_and_set_selectors(self, trail: {}, region: str):
         client = AWSFacadeUtils.get_client('cloudtrail', self.session, region)
-        trail['EventSelectors'] = await run_concurrently(
-            lambda: client.get_event_selectors(TrailName=trail['TrailARN'])['EventSelectors'])
+        try:
+            trail['EventSelectors'] = await run_concurrently(
+                lambda: client.get_event_selectors(TrailName=trail['TrailARN'])['EventSelectors'])
+        except Exception as e:
+            print_exception('Failed to get CloudTrail event selectors: {}'.format(e))

--- a/ScoutSuite/providers/aws/facade/directconnect.py
+++ b/ScoutSuite/providers/aws/facade/directconnect.py
@@ -1,9 +1,14 @@
+from ScoutSuite.core.console import print_exception
+from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
 from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.utils import run_concurrently
-from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
 
 
 class DirectConnectFacade(AWSBaseFacade):
     async def get_connections(self, region):
         client = AWSFacadeUtils.get_client('directconnect', self.session, region)
-        return await run_concurrently(lambda: client.describe_connections()['connections'])
+        try:
+            return await run_concurrently(lambda: client.describe_connections()['connections'])
+        except Exception as e:
+            print_exception('Failed to describe Direct Connect connections: {}'.format(e))
+            return []

--- a/ScoutSuite/providers/aws/facade/ec2.py
+++ b/ScoutSuite/providers/aws/facade/ec2.py
@@ -1,10 +1,11 @@
-import base64
 import asyncio
+import base64
 
-from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
-from ScoutSuite.providers.utils import run_concurrently
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.utils import get_and_set_concurrently
+from ScoutSuite.providers.utils import run_concurrently
 
 
 class EC2Facade(AWSBaseFacade):
@@ -13,17 +14,20 @@ class EC2Facade(AWSBaseFacade):
 
     async def get_instance_user_data(self, region: str, instance_id: str):
         ec2_client = AWSFacadeUtils.get_client('ec2', self.session, region)
-        user_data_response = await run_concurrently(
-            lambda: ec2_client.describe_instance_attribute(Attribute='userData', InstanceId=instance_id))
-
-        if 'Value' not in user_data_response['UserData'].keys():
+        try:
+            user_data_response = await run_concurrently(
+                lambda: ec2_client.describe_instance_attribute(Attribute='userData', InstanceId=instance_id))
+        except Exception as e:
+            print_exception('Failed to describe EC2 instance attributes: {}'.format(e))
             return None
-
-        return base64.b64decode(user_data_response['UserData']['Value']).decode('utf-8')
+        else:
+            if 'Value' not in user_data_response['UserData'].keys():
+                return None
+            return base64.b64decode(user_data_response['UserData']['Value']).decode('utf-8')
 
     async def get_instances(self, region: str, vpc: str):
         filters = [{'Name': 'vpc-id', 'Values': [vpc]}]
-        reservations =\
+        reservations = \
             await AWSFacadeUtils.get_all_pages(
                 'ec2', region, self.session, 'describe_instances', 'Reservations', Filters=filters)
 
@@ -42,12 +46,18 @@ class EC2Facade(AWSBaseFacade):
 
     async def get_vpcs(self, region: str):
         ec2_client = AWSFacadeUtils.get_client('ec2', self.session, region)
-        return await run_concurrently(lambda: ec2_client.describe_vpcs()['Vpcs'])
+        try:
+            return await run_concurrently(lambda: ec2_client.describe_vpcs()['Vpcs'])
+        except Exception as e:
+            print_exception('Failed to describe EC2 VPC: {}'.format(e))
 
     async def get_images(self, region: str, owner_id: str):
         filters = [{'Name': 'owner-id', 'Values': [owner_id]}]
         client = AWSFacadeUtils.get_client('ec2', self.session, region)
-        return await run_concurrently(lambda: client.describe_images(Filters=filters)['Images'])
+        try:
+            return await run_concurrently(lambda: client.describe_images(Filters=filters)['Images'])
+        except Exception as e:
+            print_exception('Failed to get EC2 images: {}'.format(e))
 
     async def get_network_interfaces(self, region: str, vpc: str):
         filters = [{'Name': 'vpc-id', 'Values': [vpc]}]
@@ -63,7 +73,12 @@ class EC2Facade(AWSBaseFacade):
         kms_client = AWSFacadeUtils.get_client('kms', self.session, region)
         if 'KmsKeyId' in volume:
             key_id = volume['KmsKeyId']
-            volume['KeyManager'] = await run_concurrently(lambda: kms_client.describe_key(KeyId=key_id)['KeyMetadata']['KeyManager'])
+            try:
+                volume['KeyManager'] = await run_concurrently(
+                    lambda: kms_client.describe_key(KeyId=key_id)['KeyMetadata']['KeyManager'])
+            except Exception as e:
+                print_exception('Failed to describe KMS key: {}'.format(e))
+                volume['KeyManager'] = None
         else:
             volume['KeyManager'] = None
 
@@ -77,9 +92,12 @@ class EC2Facade(AWSBaseFacade):
 
     async def _get_and_set_snapshot_attributes(self, snapshot: {}, region: str):
         ec2_client = AWSFacadeUtils.get_client('ec2', self.session, region)
-        snapshot['CreateVolumePermissions'] = await run_concurrently(lambda: ec2_client.describe_snapshot_attribute(
-            Attribute='createVolumePermission',
-            SnapshotId=snapshot['SnapshotId'])['CreateVolumePermissions'])
+        try:
+            snapshot['CreateVolumePermissions'] = await run_concurrently(lambda: ec2_client.describe_snapshot_attribute(
+                Attribute='createVolumePermission',
+                SnapshotId=snapshot['SnapshotId'])['CreateVolumePermissions'])
+        except Exception as e:
+            print_exception('Failed to describe EC2 snapshot attributes: {}'.format(e))
 
     async def get_network_acls(self, region: str, vpc: str):
         filters = [{'Name': 'vpc-id', 'Values': [vpc]}]
@@ -95,19 +113,23 @@ class EC2Facade(AWSBaseFacade):
             if region in self.flow_logs_cache:
                 return
 
-            self.flow_logs_cache[region] =\
+            self.flow_logs_cache[region] = \
                 await AWSFacadeUtils.get_all_pages('ec2', region, self.session, 'describe_flow_logs', 'FlowLogs')
 
     async def get_subnets(self, region: str, vpc: str):
         ec2_client = AWSFacadeUtils.get_client('ec2', self.session, region)
         filters = [{'Name': 'vpc-id', 'Values': [vpc]}]
-        subnets = await run_concurrently(lambda: ec2_client.describe_subnets(Filters=filters)['Subnets'])
-        await get_and_set_concurrently([self._get_and_set_subnet_flow_logs], subnets, region=region)
-
-        return subnets
+        try:
+            subnets = await run_concurrently(lambda: ec2_client.describe_subnets(Filters=filters)['Subnets'])
+        except Exception as e:
+            print_exception('Failed to describe EC2 subnets: {}'.format(e))
+            return None
+        else:
+            await get_and_set_concurrently([self._get_and_set_subnet_flow_logs], subnets, region=region)
+            return subnets
 
     async def _get_and_set_subnet_flow_logs(self, subnet: {}, region: str):
         await self.cache_flow_logs(region)
-        subnet['flow_logs'] =\
+        subnet['flow_logs'] = \
             [flow_log for flow_log in self.flow_logs_cache[region]
              if flow_log['ResourceId'] == subnet['SubnetId'] or flow_log['ResourceId'] == subnet['VpcId']]

--- a/ScoutSuite/providers/aws/facade/efs.py
+++ b/ScoutSuite/providers/aws/facade/efs.py
@@ -1,6 +1,7 @@
+from ScoutSuite.core.console import print_exception
+from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
 from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.utils import run_concurrently, get_and_set_concurrently
-from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
 
 
 class EFSFacade(AWSBaseFacade):
@@ -14,8 +15,11 @@ class EFSFacade(AWSBaseFacade):
 
     async def _get_and_set_tags(self, file_system: {}, region: str):
         client = AWSFacadeUtils.get_client('efs', self.session, region)
-        file_system['Tags'] = await run_concurrently(
-            lambda: client.describe_tags(FileSystemId=file_system['FileSystemId'])['Tags'])
+        try:
+            file_system['Tags'] = await run_concurrently(
+                lambda: client.describe_tags(FileSystemId=file_system['FileSystemId'])['Tags'])
+        except Exception as e:
+            print_exception('Failed to describe EFS tags: {}'.format(e))
 
     async def _get_and_set_mount_targets(self, file_system: {}, region: str):
         file_system['MountTargets'] = {}
@@ -35,5 +39,8 @@ class EFSFacade(AWSBaseFacade):
 
     async def _get_and_set_mount_target_security_groups(self, mount_target: {}, region: str):
         client = AWSFacadeUtils.get_client('efs', self.session, region)
-        mount_target['SecurityGroups'] = run_concurrently(lambda: client.describe_mount_target_security_groups(
+        try:
+            mount_target['SecurityGroups'] = run_concurrently(lambda: client.describe_mount_target_security_groups(
                 MountTargetId=mount_target['MountTargetId'])['SecurityGroups'])
+        except Exception as e:
+            print_exception('Failed to describe EFS mount target security groups: {}'.format(e))

--- a/ScoutSuite/providers/aws/facade/elb.py
+++ b/ScoutSuite/providers/aws/facade/elb.py
@@ -1,7 +1,8 @@
 import asyncio
 
-from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.aws.utils import ec2_classic
 from ScoutSuite.providers.utils import run_concurrently, get_and_set_concurrently
 
@@ -19,12 +20,12 @@ class ELBFacade(AWSBaseFacade):
             if region in self.load_balancers_cache:
                 return
 
-            self.load_balancers_cache[region] =\
+            self.load_balancers_cache[region] = \
                 await AWSFacadeUtils.get_all_pages('elb', region, self.session,
                                                    'describe_load_balancers', 'LoadBalancerDescriptions')
 
             for load_balancer in self.load_balancers_cache[region]:
-                load_balancer['VpcId'] =\
+                load_balancer['VpcId'] = \
                     load_balancer['VPCId'] if 'VPCId' in load_balancer and load_balancer['VPCId'] else ec2_classic
 
             await get_and_set_concurrently(
@@ -32,7 +33,10 @@ class ELBFacade(AWSBaseFacade):
 
     async def _get_and_set_load_balancer_attributes(self, load_balancer: {}, region: str):
         elb_client = AWSFacadeUtils.get_client('elb', self.session, region)
-        load_balancer['attributes'] = await run_concurrently(
-            lambda: elb_client.describe_load_balancer_attributes(
-                LoadBalancerName=load_balancer['LoadBalancerName'])['LoadBalancerAttributes']
-        )
+        try:
+            load_balancer['attributes'] = await run_concurrently(
+                lambda: elb_client.describe_load_balancer_attributes(
+                    LoadBalancerName=load_balancer['LoadBalancerName'])['LoadBalancerAttributes']
+            )
+        except Exception as e:
+            print_exception('Failed to describe ELB load balancer attributes: {}'.format(e))

--- a/ScoutSuite/providers/aws/facade/elbv2.py
+++ b/ScoutSuite/providers/aws/facade/elbv2.py
@@ -1,7 +1,8 @@
 import asyncio
 
-from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.aws.utils import ec2_classic
 from ScoutSuite.providers.utils import run_concurrently, get_and_set_concurrently
 
@@ -19,12 +20,12 @@ class ELBv2Facade(AWSBaseFacade):
             if region in self.load_balancers_cache:
                 return
 
-            self.load_balancers_cache[region] =\
+            self.load_balancers_cache[region] = \
                 await AWSFacadeUtils.get_all_pages('elbv2', region, self.session,
                                                    'describe_load_balancers', 'LoadBalancers')
 
             for load_balancer in self.load_balancers_cache[region]:
-                load_balancer['VpcId'] =\
+                load_balancer['VpcId'] = \
                     load_balancer['VpcId'] if 'VpcId' in load_balancer and load_balancer['VpcId'] else ec2_classic
 
             await get_and_set_concurrently(
@@ -32,10 +33,13 @@ class ELBv2Facade(AWSBaseFacade):
 
     async def _get_and_set_load_balancer_attributes(self, load_balancer: dict, region: str):
         elbv2_client = AWSFacadeUtils.get_client('elbv2', self.session, region)
-        load_balancer['attributes'] = await run_concurrently(
-            lambda: elbv2_client.describe_load_balancer_attributes(
-                LoadBalancerArn=load_balancer['LoadBalancerArn'])['Attributes']
-        )
+        try:
+            load_balancer['attributes'] = await run_concurrently(
+                lambda: elbv2_client.describe_load_balancer_attributes(
+                    LoadBalancerArn=load_balancer['LoadBalancerArn'])['Attributes']
+            )
+        except Exception as e:
+            print_exception('Failed to describe ELBv2 attributes: {}'.format(e))
 
     async def get_listeners(self, region: str, load_balancer_arn: str):
         return await AWSFacadeUtils.get_all_pages(

--- a/ScoutSuite/providers/aws/facade/emr.py
+++ b/ScoutSuite/providers/aws/facade/emr.py
@@ -1,5 +1,6 @@
-from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.utils import map_concurrently, run_concurrently
 
 
@@ -9,7 +10,11 @@ class EMRFacade(AWSBaseFacade):
         cluster_ids = [cluster['Id'] for cluster in cluster_list]
         client = AWSFacadeUtils.get_client('emr', self.session, region)
 
-        return await map_concurrently(
-            lambda cluster_id: run_concurrently(
-                lambda: client.describe_cluster(ClusterId=cluster_id)['Cluster']),
-            cluster_ids)
+        try:
+            return await map_concurrently(
+                lambda cluster_id: run_concurrently(
+                    lambda: client.describe_cluster(ClusterId=cluster_id)['Cluster']),
+                cluster_ids)
+        except Exception as e:
+            print_exception('Failed to describe EMR cluster: {}'.format(e))
+            return []

--- a/ScoutSuite/providers/aws/facade/iam.py
+++ b/ScoutSuite/providers/aws/facade/iam.py
@@ -1,11 +1,11 @@
 import asyncio
 import functools
 
-from botocore.utils import ClientError
+from botocore.exceptions import ClientError
 
-from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
-from ScoutSuite.core.console import print_error
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.utils import get_non_provider_id, run_concurrently, get_and_set_concurrently
 
 
@@ -22,13 +22,13 @@ class IAMFacade(AWSBaseFacade):
                     report_generated = True
                 else:
                     n_attempts -= 1
-                    await asyncio.sleep(0.1) # Wait for 100ms before doing a new attempt.
-        except ClientError:
-            print_error('Failed to generate credential report.')
+                    await asyncio.sleep(0.1)  # Wait for 100ms before doing a new attempt.
+        except Exception as e:
+            print_exception('Failed to generate credential report: {}'.format(e))
             return []
         finally:
             if not report_generated and n_attempts == 0:
-                print_error('Failed to complete credential report generation in {} attempts.'.format(n_attempts))
+                print_exception('Failed to complete credential report generation in {} attempts'.format(n_attempts))
                 return []
 
         try:
@@ -49,8 +49,8 @@ class IAMFacade(AWSBaseFacade):
                 credential_reports.append(credential_report)
 
             return credential_reports
-        except ClientError:
-            print_error('Failed to download credential report.')
+        except Exception as e:
+            print_exception('Failed to download credential report: {}'.format(e))
             return []
 
     async def get_groups(self):
@@ -68,28 +68,31 @@ class IAMFacade(AWSBaseFacade):
 
     async def _get_and_set_policy_details(self, policy):
         client = AWSFacadeUtils.get_client('iam', self.session)
-        policy_version = await run_concurrently(
-            lambda: client.get_policy_version(PolicyArn=policy['Arn'], VersionId=policy['DefaultVersionId']))
-        policy['PolicyDocument'] = policy_version['PolicyVersion']['Document']
+        try:
+            policy_version = await run_concurrently(
+                lambda: client.get_policy_version(PolicyArn=policy['Arn'], VersionId=policy['DefaultVersionId']))
+            policy['PolicyDocument'] = policy_version['PolicyVersion']['Document']
+        except Exception as e:
+            print_exception('Failed to get policy version: {}'.format(e))
+        else:
+            policy['attached_to'] = {}
+            attached_entities = await AWSFacadeUtils.get_multiple_entities_from_all_pages(
+                'iam', None, self.session, 'list_entities_for_policy', ['PolicyGroups', 'PolicyRoles', 'PolicyUsers'],
+                PolicyArn=policy['Arn'])
 
-        policy['attached_to'] = {}
-        attached_entities = await AWSFacadeUtils.get_multiple_entities_from_all_pages(
-            'iam', None, self.session, 'list_entities_for_policy',  ['PolicyGroups', 'PolicyRoles', 'PolicyUsers'],
-            PolicyArn=policy['Arn'])
+            for entity_type in attached_entities:
+                resource_type = entity_type.replace('Policy', '').lower()
+                if len(attached_entities[entity_type]):
+                    policy['attached_to'][resource_type] = []
 
-        for entity_type in attached_entities:
-            resource_type = entity_type.replace('Policy', '').lower()
-            if len(attached_entities[entity_type]):
-                policy['attached_to'][resource_type] = []
-
-            for entity in attached_entities[entity_type]:
-                name_field = entity_type.replace('Policy', '')[
-                    :-1] + 'Name'
-                resource_name = entity[name_field]
-                id_field = entity_type.replace('Policy', '')[:-1] + 'Id'
-                resource_id = entity[id_field]
-                policy['attached_to'][resource_type].append(
-                    {'name': resource_name, 'id': resource_id})
+                for entity in attached_entities[entity_type]:
+                    name_field = entity_type.replace('Policy', '')[
+                                 :-1] + 'Name'
+                    resource_name = entity[name_field]
+                    id_field = entity_type.replace('Policy', '')[:-1] + 'Id'
+                    resource_id = entity[id_field]
+                    policy['attached_to'][resource_type].append(
+                        {'name': resource_name, 'id': resource_id})
 
     async def get_users(self):
         users = await AWSFacadeUtils.get_all_pages('iam', None, self.session, 'list_users', 'Users')
@@ -107,12 +110,18 @@ class IAMFacade(AWSBaseFacade):
         try:
             user['LoginProfile'] = await run_concurrently(
                 lambda: client.get_login_profile(UserName=user['UserName'])['LoginProfile'])
-        except Exception:
-            pass
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "NoSuchEntity":
+                #  If the user has not been assigned a password, the operation returns a 404 (NoSuchEntity ) error.
+                pass
+            else:
+                print_exception('Failed to get login profile: {}'.format(e))
+        except Exception as e:
+            print_exception('Failed to get login profile: {}'.format(e))
 
     async def _get_and_set_user_groups(self, user: {}):
         groups = await AWSFacadeUtils.get_all_pages(
-            'iam', None, self.session, 'list_groups_for_user', 'Groups',UserName=user['UserName'])
+            'iam', None, self.session, 'list_groups_for_user', 'Groups', UserName=user['UserName'])
         user['groups'] = [group['GroupName'] for group in groups]
 
     async def get_roles(self):
@@ -144,22 +153,35 @@ class IAMFacade(AWSBaseFacade):
 
     async def get_password_policy(self):
         client = AWSFacadeUtils.get_client('iam', self.session)
-        return (await run_concurrently(client.get_account_password_policy))['PasswordPolicy']
+        try:
+            return (await run_concurrently(client.get_account_password_policy))['PasswordPolicy']
+        except Exception as e:
+            print_exception('Failed to get account password policy: {}'.format(e))
+            return []
 
     async def _get_and_set_user_acces_keys(self, user: {}):
         client = AWSFacadeUtils.get_client('iam', self.session)
-        user['AccessKeys'] = await run_concurrently(
-            lambda: client.list_access_keys(UserName=user['UserName'])['AccessKeyMetadata'])
+        try:
+            user['AccessKeys'] = await run_concurrently(
+                lambda: client.list_access_keys(UserName=user['UserName'])['AccessKeyMetadata'])
+        except Exception as e:
+            print_exception('Failed to list access keys: {}'.format(e))
 
     async def _get_and_set_user_mfa_devices(self, user: {}):
         client = AWSFacadeUtils.get_client('iam', self.session)
-        user['MFADevices'] = await run_concurrently(
-            lambda: client.list_mfa_devices(UserName=user['UserName'])['MFADevices'])
+        try:
+            user['MFADevices'] = await run_concurrently(
+                lambda: client.list_mfa_devices(UserName=user['UserName'])['MFADevices'])
+        except Exception as e:
+            print_exception('Failed to list MFA devices: {}'.format(e))
 
     async def _get_and_set_group_users(self, group: {}):
         client = AWSFacadeUtils.get_client('iam', self.session)
-        users = await run_concurrently(lambda: client.get_group(GroupName=group['GroupName'])['Users'])
-        group['Users'] = [user['UserId'] for user in users]
+        try:
+            users = await run_concurrently(lambda: client.get_group(GroupName=group['GroupName'])['Users'])
+            group['Users'] = [user['UserId'] for user in users]
+        except Exception as e:
+            print_exception('Failed to get IAM group {}: {}'.format(group['GroupName'], e))
 
     async def _get_and_set_inline_policies(self, resource, iam_resource_type):
         client = AWSFacadeUtils.get_client('iam', self.session)
@@ -168,28 +190,35 @@ class IAMFacade(AWSBaseFacade):
         args = {iam_resource_type.title() + 'Name': resource_name}
 
         resource['inline_policies'] = {}
-        policy_names = await run_concurrently(lambda: list_policy_method(**args)['PolicyNames'])
-        if len(policy_names) == 0:
-            resource['inline_policies_count'] = 0
-            return
 
-        get_policy_method = getattr(client, 'get_' + iam_resource_type + '_policy')
-        tasks = {
-            asyncio.ensure_future(
-                run_concurrently(lambda: get_policy_method(**dict(args, PolicyName=policy_name)))
-            ) for policy_name in policy_names
-        }
-        for task in asyncio.as_completed(tasks):
-            policy = await task
-            policy_name = policy['PolicyName']
-            policy_id = get_non_provider_id(policy_name)
-            policy_document = policy['PolicyDocument']
+        try:
+            policy_names = await run_concurrently(lambda: list_policy_method(**args)['PolicyNames'])
+            if len(policy_names) == 0:
+                resource['inline_policies_count'] = 0
+        except Exception as e:
+            print_exception('Failed to list IAM policy: {}'.format(e))
+        else:
+            get_policy_method = getattr(client, 'get_' + iam_resource_type + '_policy')
+            try:
+                tasks = {
+                    asyncio.ensure_future(
+                        run_concurrently(lambda: get_policy_method(**dict(args, PolicyName=policy_name)))
+                    ) for policy_name in policy_names
+                }
+            except Exception as e:
+                print_exception('Failed to get policy methods: {}'.format(e))
+            else:
+                for task in asyncio.as_completed(tasks):
+                    policy = await task
+                    policy_name = policy['PolicyName']
+                    policy_id = get_non_provider_id(policy_name)
+                    policy_document = policy['PolicyDocument']
 
-            resource['inline_policies'][policy_id] = {}
-            resource['inline_policies'][policy_id]['PolicyDocument'] = self._normalize_statements(
-                policy_document)
-            resource['inline_policies'][policy_id]['name'] = policy_name
-        resource['inline_policies_count'] = len(resource['inline_policies'])
+                    resource['inline_policies'][policy_id] = {}
+                    resource['inline_policies'][policy_id]['PolicyDocument'] = self._normalize_statements(
+                        policy_document)
+                    resource['inline_policies'][policy_id]['name'] = policy_name
+                resource['inline_policies_count'] = len(resource['inline_policies'])
 
     def _normalize_statements(self, policy_document):
         for statement in policy_document['Statement']:

--- a/ScoutSuite/providers/aws/facade/s3.py
+++ b/ScoutSuite/providers/aws/facade/s3.py
@@ -1,57 +1,70 @@
 import json
+
 from botocore.exceptions import ClientError
 
-from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
-from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
-from ScoutSuite.providers.utils import run_concurrently, get_and_set_concurrently
 from ScoutSuite.core.console import print_exception
+from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
+from ScoutSuite.providers.utils import run_concurrently, get_and_set_concurrently
 
 
 class S3Facade(AWSBaseFacade):
     async def get_buckets(self):
         client = AWSFacadeUtils.get_client('s3', self.session)
-        buckets = await run_concurrently(lambda: client.list_buckets()['Buckets'])
+        try:
+            buckets = await run_concurrently(lambda: client.list_buckets()['Buckets'])
+        except Exception as e:
+            print_exception('Failed to list buckets: {}'.format(e))
+            return []
+        else:
+            # We need first to retrieve bucket locations before retrieving bucket details:
+            await get_and_set_concurrently([self._get_and_set_s3_bucket_location], buckets)
 
-        # We need first to retrieve bucket locations before retrieving bucket details:
-        await get_and_set_concurrently([self._get_and_set_s3_bucket_location], buckets)
+            # Then we can retrieve bucket details concurrently:
+            await get_and_set_concurrently(
+                [self._get_and_set_s3_bucket_logging,
+                 self._get_and_set_s3_bucket_versioning,
+                 self._get_and_set_s3_bucket_webhosting,
+                 self._get_and_set_s3_bucket_default_encryption,
+                 self._get_and_set_s3_acls,
+                 self._get_and_set_s3_bucket_policy],
+                buckets)
 
-        # Then we can retrieve bucket details concurrently:
-        await get_and_set_concurrently(
-            [self._get_and_set_s3_bucket_logging,
-             self._get_and_set_s3_bucket_versioning,
-             self._get_and_set_s3_bucket_webhosting,
-             self._get_and_set_s3_bucket_default_encryption,
-             self._get_and_set_s3_acls,
-             self._get_and_set_s3_bucket_policy],
-            buckets)
+            # Non-async post-processing:
+            for bucket in buckets:
+                self._set_s3_bucket_secure_transport(bucket)
 
-        # Non-async post-processing:
-        for bucket in buckets:
-            self._set_s3_bucket_secure_transport(bucket)
-
-        return buckets
+            return buckets
 
     async def _get_and_set_s3_bucket_location(self, bucket: {}):
         client = AWSFacadeUtils.get_client('s3', self.session)
-        location = await run_concurrently(lambda: client.get_bucket_location(Bucket=bucket['Name']))
-        region = location['LocationConstraint'] if location['LocationConstraint'] else 'us-east-1'
+        try:
+            location = await run_concurrently(lambda: client.get_bucket_location(Bucket=bucket['Name']))
+        except Exception as e:
+            print_exception('Failed to get bucket location for %s: {}'.format(bucket['Name'], e))
+            location = None
 
-        # Fixes issue #59: location constraint can be either EU or eu-west-1 for Ireland...
-        if region == 'EU':
-            region = 'eu-west-1'
+        if location:
+            region = location['LocationConstraint'] if location['LocationConstraint'] else 'us-east-1'
+
+            # Fixes issue #59: location constraint can be either EU or eu-west-1 for Ireland...
+            if region == 'EU':
+                region = 'eu-west-1'
+        else:
+            region = None
 
         bucket['region'] = region
 
     async def _get_and_set_s3_bucket_logging(self, bucket):
-        client = AWSFacadeUtils.get_client('s3', self.session, bucket['region'],)
+        client = AWSFacadeUtils.get_client('s3', self.session, bucket['region'], )
         try:
             logging = await run_concurrently(lambda: client.get_bucket_logging(Bucket=bucket['Name']))
         except Exception as e:
-            bucket['logging'] = 'Unknown'
             print_exception('Failed to get logging configuration for %s: %s' % (bucket['Name'], e))
+            bucket['logging'] = 'Unknown'
 
         if 'LoggingEnabled' in logging:
-            bucket['logging'] =\
+            bucket['logging'] = \
                 logging['LoggingEnabled']['TargetBucket'] + '/' + logging['LoggingEnabled']['TargetPrefix']
         else:
             bucket['logging'] = 'Disabled'
@@ -62,7 +75,8 @@ class S3Facade(AWSBaseFacade):
             versioning = await run_concurrently(lambda: client.get_bucket_versioning(Bucket=bucket['Name']))
             bucket['versioning_status_enabled'] = self._status_to_bool(versioning.get('Status'))
             bucket['version_mfa_delete_enabled'] = self._status_to_bool(versioning.get('MFADelete'))
-        except Exception:
+        except Exception as e:
+            print_exception('Failed to get versioning configuration for %s: %s' % (bucket['Name'], e))
             bucket['versioning_status_enabled'] = None
             bucket['version_mfa_delete_enabled'] = None
 
@@ -71,9 +85,11 @@ class S3Facade(AWSBaseFacade):
         try:
             result = await run_concurrently(lambda: client.get_bucket_website(Bucket=bucket['Name']))
             bucket['web_hosting_enabled'] = 'IndexDocument' in result
-        except Exception:
-            # TODO: distinguish permission denied from 'NoSuchWebsiteConfiguration' errors
-            bucket['web_hosting_enabled'] = False
+        except Exception as e:
+            if "NoSuchWebsiteConfiguration" in str(e):
+                bucket['web_hosting_enabled'] = False
+            else:
+                print_exception('Failed to get web hosting configuration for %s: %s' % (bucket['Name'], e))
 
     async def _get_and_set_s3_bucket_default_encryption(self, bucket):
         bucket_name = bucket['Name']
@@ -88,8 +104,8 @@ class S3Facade(AWSBaseFacade):
                 bucket['default_encryption_enabled'] = None
                 print_exception('Failed to get encryption configuration for %s: %s' % (bucket_name, e))
         except Exception as e:
-            bucket['default_encryption'] = 'Unknown'
             print_exception('Failed to get encryption configuration for %s: %s' % (bucket_name, e))
+            bucket['default_encryption'] = 'Unknown'
 
     async def _get_and_set_s3_acls(self, bucket, key_name=None):
         bucket_name = bucket['Name']
@@ -119,8 +135,8 @@ class S3Facade(AWSBaseFacade):
                 self._set_s3_permissions(grantees[grantee]['permissions'], permission)
             bucket['grantees'] = grantees
         except Exception as e:
-            bucket['grantees'] = {}
             print_exception('Failed to get ACL configuration for %s: %s' % (bucket_name, e))
+            bucket['grantees'] = {}
 
     async def _get_and_set_s3_bucket_policy(self, bucket):
         client = AWSFacadeUtils.get_client('s3', self.session, bucket['region'])
@@ -130,6 +146,9 @@ class S3Facade(AWSBaseFacade):
         except ClientError as e:
             if e.response['Error']['Code'] != 'NoSuchBucketPolicy':
                 print_exception('Failed to get bucket policy for %s: %s' % (bucket['Name'], e))
+        except Exception as e:
+            print_exception('Failed to get bucket policy for %s: %s' % (bucket['Name'], e))
+            bucket['grantees'] = {}
 
     def _set_s3_bucket_secure_transport(self, bucket):
         try:
@@ -142,14 +161,14 @@ class S3Facade(AWSBaseFacade):
                             'Bool' in statement['Condition'] and \
                             'aws:SecureTransport' in statement['Condition']['Bool'] and \
                             ((statement['Condition']['Bool']['aws:SecureTransport'] == 'false' and
-                            statement['Effect'] == 'Deny') or
-                            (statement['Condition']['Bool']['aws:SecureTransport'] == 'true' and
-                            statement['Effect'] == 'Allow')):
+                              statement['Effect'] == 'Deny') or
+                             (statement['Condition']['Bool']['aws:SecureTransport'] == 'true' and
+                              statement['Effect'] == 'Allow')):
                         bucket['secure_transport_enabled'] = True
             else:
                 bucket['secure_transport_enabled'] = False
         except Exception as e:
-            print_exception('Failed to get evaluate bucket policy for %s: %s' % (bucket['Name'], e))
+            print_exception('Failed to evaluate bucket policy for %s: %s' % (bucket['Name'], e))
             bucket['secure_transport'] = None
 
     @staticmethod
@@ -167,7 +186,7 @@ class S3Facade(AWSBaseFacade):
             permissions['read_acp'] = True
         if name == 'WRITE_ACP' or name == 'FULL_CONTROL':
             permissions['write_acp'] = True
-        
+
     @staticmethod
     def _s3_group_to_string(uri):
         if uri == 'http://acs.amazonaws.com/groups/global/AuthenticatedUsers':

--- a/ScoutSuite/providers/aws/facade/ses.py
+++ b/ScoutSuite/providers/aws/facade/ses.py
@@ -1,7 +1,8 @@
-from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
-from ScoutSuite.providers.utils import run_concurrently
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.utils import map_concurrently
+from ScoutSuite.providers.utils import run_concurrently
 
 
 class SESFacade(AWSBaseFacade):
@@ -13,20 +14,33 @@ class SESFacade(AWSBaseFacade):
 
     async def _get_identity_dkim_attributes(self, identity_name: str, region: str):
         ses_client = AWSFacadeUtils.get_client('ses', self.session, region)
-        dkim_attributes = await run_concurrently(
-            lambda: ses_client.get_identity_dkim_attributes(Identities=[identity_name])['DkimAttributes'][identity_name]
-        )
+        try:
+            dkim_attributes = await run_concurrently(
+                lambda: ses_client.get_identity_dkim_attributes(Identities=[identity_name])['DkimAttributes'][
+                    identity_name]
+            )
+        except Exception as e:
+            print_exception('Failed to get SES DKIM attributes: {}'.format(e))
+            dkim_attributes = None
         return identity_name, dkim_attributes
 
     async def get_identity_policies(self, region: str, identity_name: str):
         ses_client = AWSFacadeUtils.get_client('ses', self.session, region)
-        policy_names = await run_concurrently(
-            lambda: ses_client.list_identity_policies(Identity=identity_name)['PolicyNames']
-        )
+        try:
+            policy_names = await run_concurrently(
+                lambda: ses_client.list_identity_policies(Identity=identity_name)['PolicyNames']
+            )
+        except Exception as e:
+            print_exception('Failed to list SES policies: {}'.format(e))
+            policy_names = []
 
         if len(policy_names) == 0:
             return {}
 
-        return await run_concurrently(
-            lambda: ses_client.get_identity_policies(Identity=identity_name, PolicyNames=policy_names)['Policies']
-        )
+        try:
+            return await run_concurrently(
+                lambda: ses_client.get_identity_policies(Identity=identity_name, PolicyNames=policy_names)['Policies']
+            )
+        except Exception as e:
+            print_exception('Failed to get SES policies: {}'.format(e))
+            return None

--- a/ScoutSuite/providers/aws/facade/sqs.py
+++ b/ScoutSuite/providers/aws/facade/sqs.py
@@ -1,3 +1,4 @@
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
 from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.utils import run_concurrently, map_concurrently
@@ -6,19 +7,28 @@ from ScoutSuite.providers.utils import run_concurrently, map_concurrently
 class SQSFacade(AWSBaseFacade):
     async def get_queues(self, region: str, attribute_names: []):
         sqs_client = AWSFacadeUtils.get_client('sqs', self.session, region)
-        raw_queues = await run_concurrently(sqs_client.list_queues)
-
-        if 'QueueUrls' not in raw_queues:
+        try:
+            raw_queues = await run_concurrently(sqs_client.list_queues)
+        except Exception as e:
+            print_exception('Failed to list SQS queues: {}'.format(e))
             return []
-        queue_urls = raw_queues['QueueUrls']
+        else:
+            if 'QueueUrls' not in raw_queues:
+                return []
+            queue_urls = raw_queues['QueueUrls']
 
-        return await map_concurrently(
-            self._get_queue_attributes, queue_urls, region=region, attribute_names=attribute_names)
+            return await map_concurrently(
+                self._get_queue_attributes, queue_urls, region=region, attribute_names=attribute_names)
 
     async def _get_queue_attributes(self, queue_url: str, region: str, attribute_names: []):
         sqs_client = AWSFacadeUtils.get_client('sqs', self.session, region)
-        queue_attributes = await run_concurrently(
-            lambda: sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=attribute_names)['Attributes']
-        )
+        try:
+            queue_attributes = await run_concurrently(
+                lambda: sqs_client.get_queue_attributes(QueueUrl=queue_url, AttributeNames=attribute_names)[
+                    'Attributes']
+            )
+        except Exception as e:
+            print_exception('Failed to get SQS queue attributes: {}'.format(e))
+            queue_attributes = None
 
         return queue_url, queue_attributes

--- a/ScoutSuite/providers/aws/facade/utils.py
+++ b/ScoutSuite/providers/aws/facade/utils.py
@@ -1,6 +1,7 @@
 import boto3
 
 from ScoutSuite.providers.utils import run_concurrently
+from ScoutSuite.core.conditions import print_exception
 
 
 class AWSFacadeUtils:
@@ -23,9 +24,12 @@ class AWSFacadeUtils:
         """
 
         results = await AWSFacadeUtils.get_multiple_entities_from_all_pages(
-            service, region, session, paginator_name,[entity], **paginator_args)
+            service, region, session, paginator_name, [entity], **paginator_args)
 
-        return results[entity]
+        if len(results) > 0:
+            return results[entity]
+        else:
+            return []
 
     @staticmethod
     async def get_multiple_entities_from_all_pages(service: str, region: str, session: boto3.session.Session,
@@ -49,7 +53,12 @@ class AWSFacadeUtils:
             paginator_name).paginate(**paginator_args)
 
         # Getting all pages from a paginator requires API calls so we need to do it concurrently:
-        return await run_concurrently(lambda: AWSFacadeUtils._get_all_pages_from_paginator(paginator, entities))
+        try:
+            return await run_concurrently(lambda: AWSFacadeUtils._get_all_pages_from_paginator(paginator, entities))
+        except Exception as e:
+            print_exception('Failed to get all pages from paginator for the {} service: {}'.format(service, e))
+
+            return []
 
     @staticmethod
     def _get_all_pages_from_paginator(paginator, entities: list):
@@ -74,6 +83,10 @@ class AWSFacadeUtils:
         :return:
         """
 
-        return AWSFacadeUtils._clients.setdefault(
-            (service, region),
-            session.client(service, region_name=region) if region else session.client(service))
+        try:
+            return AWSFacadeUtils._clients.setdefault(
+                (service, region),
+                session.client(service, region_name=region) if region else session.client(service))
+        except Exception as e:
+            print_exception('Failed to create client for the {} service: {}'.format(service, e))
+            return None

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -702,6 +702,8 @@ class AWSProvider(BaseProvider):
                         elif port == 'ALL':
                             port_min = 0
                             port_max = 65535
+                        elif p == 'ICMP':
+                            port_min = port_max = None
                         else:
                             port_min = port_max = int(port)
                         for listener in listeners:

--- a/ScoutSuite/providers/aws/resources/directconnect/base.py
+++ b/ScoutSuite/providers/aws/resources/directconnect/base.py
@@ -6,9 +6,10 @@ from ScoutSuite.providers.aws.resources.base import AWSResources
 class Connections(AWSResources):
     async def fetch_all(self, **kwargs):
         raw_connections = await self.facade.directconnect.get_connections(self.scope['region'])
-        for raw_connection in raw_connections:
-            name, resource = self._parse_function(raw_connection)
-            self[name] = resource
+        if raw_connections:
+            for raw_connection in raw_connections:
+                name, resource = self._parse_function(raw_connection)
+                self[name] = resource
 
     def _parse_function(self, raw_connection):
         raw_connection['id'] = raw_connection.pop('connectionId')

--- a/ScoutSuite/providers/aws/resources/ec2/ami.py
+++ b/ScoutSuite/providers/aws/resources/ec2/ami.py
@@ -4,9 +4,10 @@ from ScoutSuite.providers.aws.resources.base import AWSResources
 class AmazonMachineImages(AWSResources):
     async def fetch_all(self, **kwargs):
         raw_images = await self.facade.ec2.get_images(self.scope['region'], self.scope['owner_id'])
-        for raw_image in raw_images:
-            name, resource = self._parse_image(raw_image)
-            self[name] = resource
+        if raw_images:
+            for raw_image in raw_images:
+                name, resource = self._parse_image(raw_image)
+                self[name] = resource
 
     def _parse_image(self, raw_image):
         raw_image['id'] = raw_image['ImageId']

--- a/ScoutSuite/providers/aws/resources/vpcs.py
+++ b/ScoutSuite/providers/aws/resources/vpcs.py
@@ -1,3 +1,4 @@
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.resources.base import AWSCompositeResources
 
 
@@ -12,16 +13,25 @@ class Vpcs(AWSCompositeResources):
         self.add_ec2_classic = add_ec2_classic
 
     async def fetch_all(self, **kwargs):
-        raw_vpcs = await self.facade.ec2.get_vpcs(self.scope['region'])
-        for raw_vpc in raw_vpcs:
-            vpc_id, vpc = self._parse_vpc(raw_vpc)
-            self[vpc_id] = vpc
 
-        await self._fetch_children_of_all_resources(
-            resources=self,
-            scopes={vpc_id: {'region': self.scope['region'], 'vpc': vpc_id}
-                    for vpc_id in self}
-        )
+        try:
+            raw_vpcs = await self.facade.ec2.get_vpcs(self.scope['region'])
+        except Exception as e:
+            print_exception('Failed to get VPCs for region {}: {}'.format(self.scope['region'], e))
+        else:
+            if raw_vpcs:
+                for raw_vpc in raw_vpcs:
+                    vpc_id, vpc = self._parse_vpc(raw_vpc)
+                    self[vpc_id] = vpc
+
+                try:
+                    await self._fetch_children_of_all_resources(
+                        resources=self,
+                        scopes={vpc_id: {'region': self.scope['region'], 'vpc': vpc_id}
+                                for vpc_id in self}
+                    )
+                except Exception as e:
+                    print_exception('Failed to fetch resources for VPC {}: {}'.format(vpc_id, e))
 
     def _parse_vpc(self, vpc):
         return vpc['VpcId'], {}

--- a/ScoutSuite/providers/base/provider.py
+++ b/ScoutSuite/providers/base/provider.py
@@ -3,15 +3,14 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import copy
 import json
 import sys
-import copy
-
-from ScoutSuite.core.console import print_exception, print_info
 
 from ScoutSuite import __version__ as scout_version
-from ScoutSuite.providers.base.configs.browser import get_object_at
+from ScoutSuite.core.console import print_exception, print_info
 from ScoutSuite.output.html import ScoutReport
+from ScoutSuite.providers.base.configs.browser import get_object_at
 
 
 class BaseProvider(object):
@@ -25,7 +24,8 @@ class BaseProvider(object):
     all cloud providers
     """
 
-    def __init__(self, report_dir=None, timestamp=None, services=None, skipped_services=None, thread_config=4, **kwargs):
+    def __init__(self, report_dir=None, timestamp=None, services=None, skipped_services=None, thread_config=4,
+                 **kwargs):
         """
 
         :account_id         account ID
@@ -111,7 +111,7 @@ class BaseProvider(object):
 
         # Ensure services and skipped services exist, otherwise log exception
         error = False
-        for service in services+skipped_services:
+        for service in services + skipped_services:
             if service not in supported_services:
                 print_exception('Service \"{}\" does not exist, skipping.'.format(service))
                 error = True
@@ -250,7 +250,7 @@ class BaseProvider(object):
                         if 'callbacks' in self.metadata[service_group][service]['summaries'][summary]:
                             current_path = ['services', service]
                             for callback in self.metadata[service_group][service]['summaries'][summary][
-                                    'callbacks']:
+                                'callbacks']:
                                 callback_name = callback[0]
                                 callback_args = copy.deepcopy(callback[1])
                                 target_path = callback_args.pop('path').replace('.id', '').split('.')[2:]
@@ -297,7 +297,6 @@ class BaseProvider(object):
         Recursively go to a target and execute a callback
         """
         try:
-
             key = path.pop(0)
             if not current_config:
                 current_config = self.config
@@ -345,7 +344,6 @@ class BaseProvider(object):
         Recursively go to a target and execute a callback
         """
         try:
-
             key = path.pop(0)
             if not current_config:
                 current_config = self.config
@@ -365,19 +363,29 @@ class BaseProvider(object):
                     if len(path) == 0:
                         for callback_info in callbacks:
                             callback_name = callback_info[0]
+                            try:
+                                # callback = globals()[callback_name]
+                                callback = getattr(self, callback_name)
 
-                            # callback = globals()[callback_name]
-                            callback = getattr(self, callback_name)
-
-                            callback_args = callback_info[1]
-                            if type(current_config[key] == dict) and type(value) != dict and type(value) != list:
-                                callback(current_config[key][value],
-                                         path,
-                                         current_path,
-                                         value,
-                                         callback_args)
-                            else:
-                                callback(current_config, path, current_path, value, callback_args)
+                                callback_args = callback_info[1]
+                                if type(current_config[key] == dict) and type(value) != dict and type(value) != list:
+                                    callback(current_config[key][value],
+                                             path,
+                                             current_path,
+                                             value,
+                                             callback_args)
+                                else:
+                                    callback(current_config, path, current_path, value, callback_args)
+                            except Exception as e:
+                                print_exception(e, {'callback': callback_name,
+                                                    'callback arguments': callback_args,
+                                                    'current path': '{}'.format(current_path),
+                                                    'key': '{}'.format(key if 'key' in locals() else 'not defined'),
+                                                    'value': '{}'.format(
+                                                        value if 'value' in locals() else 'not defined'),
+                                                    'path': '{}'.format(path),
+                                                    }
+                                                )
                     else:
                         tmp = copy.deepcopy(current_path)
                         try:

--- a/ScoutSuite/providers/base/provider.py
+++ b/ScoutSuite/providers/base/provider.py
@@ -364,7 +364,6 @@ class BaseProvider(object):
                         for callback_info in callbacks:
                             callback_name = callback_info[0]
                             try:
-                                # callback = globals()[callback_name]
                                 callback = getattr(self, callback_name)
 
                                 callback_args = callback_info[1]

--- a/ScoutSuite/providers/utils.py
+++ b/ScoutSuite/providers/utils.py
@@ -1,6 +1,7 @@
 import asyncio
-
 from hashlib import sha1
+
+from ScoutSuite.core.console import print_exception
 
 
 def get_non_provider_id(name):
@@ -45,12 +46,15 @@ async def get_and_set_concurrently(get_and_set_funcs: [], entities: [], **kwargs
     if len(entities) == 0:
         return
 
-    tasks = {
-        asyncio.ensure_future(
-            get_and_set_func(entity, **kwargs)
-        ) for entity in entities for get_and_set_func in get_and_set_funcs
-    }
-    await asyncio.wait(tasks)
+    try:
+        tasks = {
+            asyncio.ensure_future(
+                get_and_set_func(entity, **kwargs)
+            ) for entity in entities for get_and_set_func in get_and_set_funcs
+        }
+        await asyncio.wait(tasks)
+    except Exception as e:
+        print_exception('Failed to run function concurrently: {}'.format(e))
 
 
 async def map_concurrently(coro, entities, **kwargs):
@@ -68,13 +72,16 @@ async def map_concurrently(coro, entities, **kwargs):
         return []
 
     results = []
-    tasks = {
-        asyncio.ensure_future(
-            coro(entity, **kwargs)
-        ) for entity in entities
-    }
-    for task in asyncio.as_completed(tasks):
-        result = await task
-        results.append(result)
+    try:
+        tasks = {
+            asyncio.ensure_future(
+                coro(entity, **kwargs)
+            ) for entity in entities
+        }
+        for task in asyncio.as_completed(tasks):
+            result = await task
+            results.append(result)
+    except Exception as e:
+        print_exception('Failed to map concurrently: {}'.format(e))
 
     return results


### PR DESCRIPTION
After running Scout against a production account for which I didn't have sufficient IAM privileges, I realized that **none** of the exceptions were being handled (which resulted in an empty errors file).

I've added exception handling to all the API calls made in the facades and a few more files.

@misg & @Remi05 can you please ensure something similar is implemented for Azure / GCP? It's pretty easy to test, just run scout with a user that doesn't have any privileges and see where it fails!
I just looked for all the instances of an API client and added try/catch clauses. 