### PR TITLE
Enhancement/Additional AWS exception handling take 2

### DIFF
--- a/ScoutSuite/providers/aws/facade/emr.py
+++ b/ScoutSuite/providers/aws/facade/emr.py
@@ -8,13 +8,13 @@ class EMRFacade(AWSBaseFacade):
     async def get_clusters(self, region):
         cluster_list = await AWSFacadeUtils.get_all_pages('emr', region, self.session, 'list_clusters', 'Clusters')
         cluster_ids = [cluster['Id'] for cluster in cluster_list]
-        client = AWSFacadeUtils.get_client('emr', self.session, region)
 
+        return await map_concurrently(self._get_cluster, cluster_ids, region=region)
+
+    async def _get_cluster(self, cluster_id: str, region: str):
+        client = AWSFacadeUtils.get_client('emr', self.session, region)
         try:
-            return await map_concurrently(
-                lambda cluster_id: run_concurrently(
-                    lambda: client.describe_cluster(ClusterId=cluster_id)['Cluster']),
-                cluster_ids)
+            return await run_concurrently(lambda: client.describe_cluster(ClusterId=cluster_id)['Cluster'])
         except Exception as e:
             print_exception('Failed to describe EMR cluster: {}'.format(e))
-            return []
+            raise

--- a/ScoutSuite/providers/aws/facade/ses.py
+++ b/ScoutSuite/providers/aws/facade/ses.py
@@ -21,7 +21,7 @@ class SESFacade(AWSBaseFacade):
             )
         except Exception as e:
             print_exception('Failed to get SES DKIM attributes: {}'.format(e))
-            dkim_attributes = None
+            raise
         return identity_name, dkim_attributes
 
     async def get_identity_policies(self, region: str, identity_name: str):

--- a/ScoutSuite/providers/aws/facade/sqs.py
+++ b/ScoutSuite/providers/aws/facade/sqs.py
@@ -29,6 +29,6 @@ class SQSFacade(AWSBaseFacade):
             )
         except Exception as e:
             print_exception('Failed to get SQS queue attributes: {}'.format(e))
-            queue_attributes = None
+            raise
 
         return queue_url, queue_attributes

--- a/ScoutSuite/providers/aws/resources/directconnect/base.py
+++ b/ScoutSuite/providers/aws/resources/directconnect/base.py
@@ -6,10 +6,9 @@ from ScoutSuite.providers.aws.resources.base import AWSResources
 class Connections(AWSResources):
     async def fetch_all(self, **kwargs):
         raw_connections = await self.facade.directconnect.get_connections(self.scope['region'])
-        if raw_connections:
-            for raw_connection in raw_connections:
-                name, resource = self._parse_function(raw_connection)
-                self[name] = resource
+        for raw_connection in raw_connections:
+            name, resource = self._parse_function(raw_connection)
+            self[name] = resource
 
     def _parse_function(self, raw_connection):
         raw_connection['id'] = raw_connection.pop('connectionId')

--- a/ScoutSuite/providers/aws/resources/ec2/ami.py
+++ b/ScoutSuite/providers/aws/resources/ec2/ami.py
@@ -4,10 +4,9 @@ from ScoutSuite.providers.aws.resources.base import AWSResources
 class AmazonMachineImages(AWSResources):
     async def fetch_all(self, **kwargs):
         raw_images = await self.facade.ec2.get_images(self.scope['region'], self.scope['owner_id'])
-        if raw_images:
-            for raw_image in raw_images:
-                name, resource = self._parse_image(raw_image)
-                self[name] = resource
+        for raw_image in raw_images:
+            name, resource = self._parse_image(raw_image)
+            self[name] = resource
 
     def _parse_image(self, raw_image):
         raw_image['id'] = raw_image['ImageId']

--- a/ScoutSuite/providers/utils.py
+++ b/ScoutSuite/providers/utils.py
@@ -17,16 +17,16 @@ def get_non_provider_id(name):
     return name_hash.hexdigest()
 
 
-def run_concurrently(func):
+def run_concurrently(function):
     """
-    Schedules the execution of function `func` in the default thread pool (referred as 'executor') that has been
+    Schedules the execution of function `function` in the default thread pool (referred as 'executor') that has been
     associated with the global event loop.
 
-    :param func: function to be executed concurrently, in a dedicated thread.
+    :param function: function to be executed concurrently, in a dedicated thread.
     :return: an asyncio.Future to be awaited.
     """
 
-    return asyncio.get_event_loop().run_in_executor(executor=None, func=func)
+    return asyncio.get_event_loop().run_in_executor(executor=None, func=function)
 
 
 async def get_and_set_concurrently(get_and_set_funcs: [], entities: [], **kwargs):
@@ -46,23 +46,20 @@ async def get_and_set_concurrently(get_and_set_funcs: [], entities: [], **kwargs
     if len(entities) == 0:
         return
 
-    try:
-        tasks = {
-            asyncio.ensure_future(
-                get_and_set_func(entity, **kwargs)
-            ) for entity in entities for get_and_set_func in get_and_set_funcs
-        }
-        await asyncio.wait(tasks)
-    except Exception as e:
-        print_exception('Failed to run function concurrently: {}'.format(e))
+    tasks = {
+        asyncio.ensure_future(
+            get_and_set_func(entity, **kwargs)
+        ) for entity in entities for get_and_set_func in get_and_set_funcs
+    }
+    await asyncio.wait(tasks)
 
 
-async def map_concurrently(coro, entities, **kwargs):
+async def map_concurrently(coroutine, entities, **kwargs):
     """
     Given a list of entities, executes coroutine `coro` concurrently on each entity and returns a list of the obtained
     results ([await coro(entity_x), await coro(entity_a), ..., await coro(entity_z)]).
 
-    :param coro: coroutine to be executed concurrently. Takes an entity as parameter and returns a new entity.
+    :param coroutine: coroutine to be executed concurrently. Takes an entity as parameter and returns a new entity.
     :param entities: a list of the same type of entity (ex: cluster ids)
 
     :return: a list of new entities (ex: clusters)
@@ -72,16 +69,15 @@ async def map_concurrently(coro, entities, **kwargs):
         return []
 
     results = []
-    try:
-        tasks = {
-            asyncio.ensure_future(
-                coro(entity, **kwargs)
-            ) for entity in entities
-        }
-        for task in asyncio.as_completed(tasks):
-            result = await task
-            results.append(result)
-    except Exception as e:
-        print_exception('Failed to map concurrently: {}'.format(e))
+
+    tasks = {
+        asyncio.ensure_future(
+            coroutine(entity, **kwargs)
+        ) for entity in entities
+    }
+
+    for task in asyncio.as_completed(tasks):
+        result = await task
+        results.append(result)
 
     return results

--- a/ScoutSuite/providers/utils.py
+++ b/ScoutSuite/providers/utils.py
@@ -56,7 +56,7 @@ async def get_and_set_concurrently(get_and_set_funcs: [], entities: [], **kwargs
 
 async def map_concurrently(coroutine, entities, **kwargs):
     """
-    Given a list of entities, executes coroutine `coro` concurrently on each entity and returns a list of the obtained
+    Given a list of entities, executes coroutine `coroutine` concurrently on each entity and returns a list of the obtained
     results ([await coro(entity_x), await coro(entity_a), ..., await coro(entity_z)]).
 
     :param coroutine: coroutine to be executed concurrently. Takes an entity as parameter and returns a new entity.


### PR DESCRIPTION
Addressed comments made by @misg in https://github.com/nccgroup/ScoutSuite/pull/312.

I also changed the variable name for the `run_concurrently` and `map_concurrently` functions, is there a reason for using abreviations? They aren't reserved names.