### PR TITLE
Bugfix/password policy error handling

### DIFF
--- a/ScoutSuite/providers/aws/facade/iam.py
+++ b/ScoutSuite/providers/aws/facade/iam.py
@@ -155,20 +155,10 @@ class IAMFacade(AWSBaseFacade):
         client = AWSFacadeUtils.get_client('iam', self.session)
         try:
             return (await run_concurrently(client.get_account_password_policy))['PasswordPolicy']
-        except Exception as e:
-            if e.response['Error']['Code'] == 'NoSuchEntity':
-                return {
-                    'MinimumPasswordLength': '1',
-                    'RequireUppercaseCharacters': False,
-                    'RequireLowercaseCharacters': False, 
-                    'RequireNumbers': False,
-                    'RequireSymbols': False, 
-                    'PasswordReusePrevention': False,
-                    'ExpirePasswords': False
-                }
-            else:
+        except ClientError as e:
+            if e.response['Error']['Code'] != 'NoSuchEntity':
                 print_exception('Failed to get account password policy: {}'.format(e))
-                return []
+            return None
 
     async def _get_and_set_user_acces_keys(self, user: {}):
         client = AWSFacadeUtils.get_client('iam', self.session)

--- a/ScoutSuite/providers/aws/facade/iam.py
+++ b/ScoutSuite/providers/aws/facade/iam.py
@@ -156,8 +156,19 @@ class IAMFacade(AWSBaseFacade):
         try:
             return (await run_concurrently(client.get_account_password_policy))['PasswordPolicy']
         except Exception as e:
-            print_exception('Failed to get account password policy: {}'.format(e))
-            return []
+            if e.response['Error']['Code'] == 'NoSuchEntity':
+                return {
+                    'MinimumPasswordLength': '1',
+                    'RequireUppercaseCharacters': False,
+                    'RequireLowercaseCharacters': False, 
+                    'RequireNumbers': False,
+                    'RequireSymbols': False, 
+                    'PasswordReusePrevention': False,
+                    'ExpirePasswords': False
+                }
+            else:
+                print_exception('Failed to get account password policy: {}'.format(e))
+                return []
 
     async def _get_and_set_user_acces_keys(self, user: {}):
         client = AWSFacadeUtils.get_client('iam', self.session)

--- a/ScoutSuite/providers/aws/resources/iam/passwordpolicy.py
+++ b/ScoutSuite/providers/aws/resources/iam/passwordpolicy.py
@@ -9,6 +9,17 @@ class PasswordPolicy(AWSResources):
         self.update(password_policy)
 
     def _parse_password_policy(self, raw_password_policy):
+        if raw_password_policy is None:
+            return {
+                    'MinimumPasswordLength': '1',
+                    'RequireUppercaseCharacters': False,
+                    'RequireLowercaseCharacters': False, 
+                    'RequireNumbers': False,
+                    'RequireSymbols': False, 
+                    'PasswordReusePrevention': False,
+                    'ExpirePasswords': False
+            }
+
         if 'PasswordReusePrevention' not in raw_password_policy:
             raw_password_policy['PasswordReusePrevention'] = False
         else:

--- a/ScoutSuite/providers/aws/resources/iam/passwordpolicy.py
+++ b/ScoutSuite/providers/aws/resources/iam/passwordpolicy.py
@@ -4,20 +4,8 @@ from botocore.exceptions import ClientError
 
 class PasswordPolicy(AWSResources):
     async def fetch_all(self, **kwargs):
-        try:
-            password_policy = self._parse_password_policy(await self.facade.iam.get_password_policy())
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'NoSuchEntity':
-                password_policy = {
-                    'MinimumPasswordLength': '1',
-                    'RequireUppercaseCharacters': False,
-                    'RequireLowercaseCharacters': False, 'RequireNumbers': False,
-                    'RequireSymbols': False, 'PasswordReusePrevention': False,
-                    'ExpirePasswords': False
-                }
-            else:
-                raise e
-
+        raw_password_policy = await self.facade.iam.get_password_policy()
+        password_policy = self._parse_password_policy(raw_password_policy)
         self.update(password_policy)
 
     def _parse_password_policy(self, raw_password_policy):


### PR DESCRIPTION
It seems like the error handling PR introduced a bug with IAM. An exception was muted, but there was custom handling at a higher level. Since the exception was muted, the higher-level handling was never called. This PR fixes the problem.