### PR TITLE
Bugfix/Minor bugs

### DIFF
--- a/ScoutSuite/providers/aws/authentication_strategy.py
+++ b/ScoutSuite/providers/aws/authentication_strategy.py
@@ -15,10 +15,6 @@ class AWSAuthenticationStrategy(AuthenticationStrategy):
             session = boto3.Session(profile_name=profile)
             credentials = session.get_credentials().__dict__
 
-            # Check if profile has access key
-            if credentials.get('access_key') is None:
-                raise AuthenticationException('Profile does not have an access key')
-
             # Test querying for current user
             sts_client = session.client('sts')
             sts_client.get_caller_identity()

--- a/ScoutSuite/providers/base/configs/services.py
+++ b/ScoutSuite/providers/base/configs/services.py
@@ -1,8 +1,8 @@
 import asyncio
 
-from ScoutSuite.utils import format_service_name
 from ScoutSuite.core.console import print_exception, print_debug, print_info
 from ScoutSuite.providers.aws.utils import get_partition_name
+from ScoutSuite.utils import format_service_name
 
 
 class BaseServicesConfig(object):
@@ -17,20 +17,19 @@ class BaseServicesConfig(object):
 
         if not services:
             print_debug('No services to scan')
-            return
+        else:
+            # Print services that are going to get skipped:
+            for service in vars(self):
+                if service not in services:
+                    print_debug('Skipping the {} service'.format(format_service_name(service)))
 
-        # Print services that are going to get skipped:
-        for service in vars(self):
-            if service not in services:
-                print_debug('Skipping the {} service'.format(format_service_name(service)))
-
-        # Then, fetch concurrently all services:
-        tasks = {
-            asyncio.ensure_future(
-                self._fetch(service, regions)
-            ) for service in services
-        }
-        await asyncio.wait(tasks)
+            # Then, fetch concurrently all services:
+            tasks = {
+                asyncio.ensure_future(
+                    self._fetch(service, regions)
+                ) for service in services
+            }
+            await asyncio.wait(tasks)
 
     async def _fetch(self, service, regions):
         try:

--- a/ScoutSuite/providers/base/configs/services.py
+++ b/ScoutSuite/providers/base/configs/services.py
@@ -13,12 +13,13 @@ class BaseServicesConfig(object):
     def _is_provider(self, provider_name):
         return False
 
-    async def fetch(self, services=None, regions=None):
-        # If services is set to None, fetch all services:
-        services = vars(self) if services is None else services
-        regions = [] if regions is None else regions
+    async def fetch(self, services: list, regions: list):
 
-        # First, print services that are going to get skipped:
+        if not services:
+            print_debug('No services to scan')
+            return
+
+        # Print services that are going to get skipped:
         for service in vars(self):
             if service not in services:
                 print_debug('Skipping the {} service'.format(format_service_name(service)))

--- a/ScoutSuite/providers/base/provider.py
+++ b/ScoutSuite/providers/base/provider.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from __future__ import print_function
 from __future__ import unicode_literals
 
@@ -8,7 +6,7 @@ import json
 import sys
 
 from ScoutSuite import __version__ as scout_version
-from ScoutSuite.core.console import print_exception, print_info
+from ScoutSuite.core.console import print_exception, print_info, print_error
 from ScoutSuite.output.html import ScoutReport
 from ScoutSuite.providers.base.configs.browser import get_object_at
 
@@ -113,7 +111,7 @@ class BaseProvider(object):
         error = False
         for service in services + skipped_services:
             if service not in supported_services:
-                print_exception('Service \"{}\" does not exist, skipping.'.format(service))
+                print_error('Service \"{}\" does not exist, skipping'.format(service))
                 error = True
         if error:
             print_info('Available services are: {}'.format(str(list(supported_services)).strip('[]')))

--- a/ScoutSuite/providers/base/provider.py
+++ b/ScoutSuite/providers/base/provider.py
@@ -298,7 +298,7 @@ class BaseProvider(object):
         """
         try:
             key = path.pop(0)
-            if not current_config:
+            if not current_config and hasattr(self, 'config'):
                 current_config = self.config
             if not current_path:
                 current_path = []


### PR DESCRIPTION
Fixes a few bugs:
- The AWS authentication check didn't handle cases where a "referenced profile" was being used (as the session credentials wouldn't have an access key in that case). Just running a `get-caller-identity` will always work.
- Modified the `services.py` because the `asyncio.wait` was failing if tasks was empty. Scout will no longer run against all services if an invalid list is provided.
- Small modification in the base `provider.py` so as to not throw an exception if no service was scanned.