### PR TITLE
Removed duplicate requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@ netaddr>=0.7.11
 sqlitedict>=1.6.0
 cherrypy>=18.1.0
 cherrypy-cors>=1.6
-iampoliciesgonewild>=1.0.6.2
 coloredlogs>=10.0
 
 # AWS Provider
 boto3>=1.9.60
 botocore>=1.12.118
+iampoliciesgonewild>=1.0.6.2
 
 # GCP Provider
 grpcio>=1.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,6 @@ coloredlogs>=10.0
 # AWS Provider
 boto3>=1.9.60
 botocore>=1.12.118
-iampoliciesgonewild>=1.0.6.2
-
 
 # GCP Provider
 grpcio>=1.18.0


### PR DESCRIPTION
Removed double requirement for `iampoliciesgonewild` which caused the following message and prevented from installing requirements when used on WSL (bash) :
![image](https://user-images.githubusercontent.com/17322874/55883220-edc52e00-5b73-11e9-8817-1364ae57fb81.png)
And was added [here](https://github.com/nccgroup/ScoutSuite/commit/28e6d1f3e4bd4b068c0b0caf31eb718743919d3c#diff-b4ef698db8ca845e5845c4618278f29a)