### PR TITLE
Fixed browser freezing problem

### DIFF
--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -423,11 +423,11 @@ function updateNavbar (path) {
   } else if (splitPath[0] === 'services') {
     const service = splitPath[1]
     let element = $('#' + service + subnavbarIdSuffix)
-    while (element && (!element.attr('id') || !element.attr('id').endsWith(navbarIdSuffix))) {
+    while (element.length > 0 && (!element.attr('id') || !element.attr('id').endsWith(navbarIdSuffix))) {
       element = element.parent()
     }
 
-    if (element) {
+    if (element.length > 0) {
       element.addClass('active')
     }
   } else if (splitPath[0] === 'service_groups' && splitPath.length >= 2) {


### PR DESCRIPTION
This PR fixes the bug which caused the browser to freeze when clicking on the EFS findings. The problem was caused by a bad condition. We checked if the element selected with jquery was defined, but jquery doesn't return undefined. We have to check if the length is `> 0` instead. 