### PR TITLE
Improve AWS exception handling

### DIFF
--- a/ScoutSuite/providers/aws/facade/ec2.py
+++ b/ScoutSuite/providers/aws/facade/ec2.py
@@ -27,22 +27,30 @@ class EC2Facade(AWSBaseFacade):
 
     async def get_instances(self, region: str, vpc: str):
         filters = [{'Name': 'vpc-id', 'Values': [vpc]}]
-        reservations = \
-            await AWSFacadeUtils.get_all_pages(
-                'ec2', region, self.session, 'describe_instances', 'Reservations', Filters=filters)
+        try:
+            reservations = \
+                await AWSFacadeUtils.get_all_pages(
+                    'ec2', region, self.session, 'describe_instances', 'Reservations', Filters=filters)
 
-        instances = []
-        for reservation in reservations:
-            for instance in reservation['Instances']:
-                instance['ReservationId'] = reservation['ReservationId']
-                instances.append(instance)
+            instances = []
+            for reservation in reservations:
+                for instance in reservation['Instances']:
+                    instance['ReservationId'] = reservation['ReservationId']
+                    instances.append(instance)
 
-        return instances
+            return instances
+        except Exception as e:
+            print_exception('Failed to describe EC2 instances: {}'.format(e))
+            return []
 
     async def get_security_groups(self, region: str, vpc: str):
         filters = [{'Name': 'vpc-id', 'Values': [vpc]}]
-        return await AWSFacadeUtils.get_all_pages(
-            'ec2', region, self.session, 'describe_security_groups', 'SecurityGroups', Filters=filters)
+        try:
+            return await AWSFacadeUtils.get_all_pages(
+                'ec2', region, self.session, 'describe_security_groups', 'SecurityGroups', Filters=filters)
+        except Exception as e:
+            print_exception('Failed to describe EC2 security groups: {}'.format(e))
+            return []
 
     async def get_vpcs(self, region: str):
         ec2_client = AWSFacadeUtils.get_client('ec2', self.session, region)
@@ -50,6 +58,7 @@ class EC2Facade(AWSBaseFacade):
             return await run_concurrently(lambda: ec2_client.describe_vpcs()['Vpcs'])
         except Exception as e:
             print_exception('Failed to describe EC2 VPC: {}'.format(e))
+            return []
 
     async def get_images(self, region: str, owner_id: str):
         filters = [{'Name': 'owner-id', 'Values': [owner_id]}]
@@ -58,16 +67,25 @@ class EC2Facade(AWSBaseFacade):
             return await run_concurrently(lambda: client.describe_images(Filters=filters)['Images'])
         except Exception as e:
             print_exception('Failed to get EC2 images: {}'.format(e))
+            return []
 
     async def get_network_interfaces(self, region: str, vpc: str):
         filters = [{'Name': 'vpc-id', 'Values': [vpc]}]
-        return await AWSFacadeUtils.get_all_pages(
-            'ec2', region, self.session, 'describe_network_interfaces', 'NetworkInterfaces', Filters=filters)
+        try:
+            return await AWSFacadeUtils.get_all_pages(
+                'ec2', region, self.session, 'describe_network_interfaces', 'NetworkInterfaces', Filters=filters)
+        except Exception as e:
+            print_exception('Failed to get EC2 network interfaces: {}'.format(e))
+            return []
 
     async def get_volumes(self, region: str):
-        volumes = await AWSFacadeUtils.get_all_pages('ec2', region, self.session, 'describe_volumes', 'Volumes')
-        await get_and_set_concurrently([self._get_and_set_key_manager], volumes, region=region)
-        return volumes
+        try:
+            volumes = await AWSFacadeUtils.get_all_pages('ec2', region, self.session, 'describe_volumes', 'Volumes')
+            await get_and_set_concurrently([self._get_and_set_key_manager], volumes, region=region)
+            return volumes
+        except Exception as e:
+            print_exception('Failed to get EC2 volumes: {}'.format(e))
+            return []
 
     async def _get_and_set_key_manager(self, volume: {}, region: str):
         kms_client = AWSFacadeUtils.get_client('kms', self.session, region)
@@ -101,12 +119,20 @@ class EC2Facade(AWSBaseFacade):
 
     async def get_network_acls(self, region: str, vpc: str):
         filters = [{'Name': 'vpc-id', 'Values': [vpc]}]
-        return await AWSFacadeUtils.get_all_pages(
-            'ec2', region, self.session, 'describe_network_acls', 'NetworkAcls', Filters=filters)
+        try:
+            return await AWSFacadeUtils.get_all_pages(
+                'ec2', region, self.session, 'describe_network_acls', 'NetworkAcls', Filters=filters)
+        except Exception as e:
+            print_exception('Failed to get EC2 network ACLs: {}'.format(e))
+            return []
 
     async def get_flow_logs(self, region: str):
-        await self.cache_flow_logs(region)
-        return self.flow_logs_cache[region]
+        try:
+            await self.cache_flow_logs(region)
+            return self.flow_logs_cache[region]
+        except Exception as e:
+            print_exception('Failed to get EC2 flow logs: {}'.format(e))
+            return []
 
     async def cache_flow_logs(self, region: str):
         async with self.regional_flow_logs_cache_locks.setdefault(region, asyncio.Lock()):

--- a/ScoutSuite/providers/aws/facade/elasticache.py
+++ b/ScoutSuite/providers/aws/facade/elasticache.py
@@ -1,6 +1,6 @@
 from asyncio import Lock
-from botocore.exceptions import ClientError
 
+from botocore.exceptions import ClientError
 
 from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade

--- a/ScoutSuite/providers/aws/facade/elasticache.py
+++ b/ScoutSuite/providers/aws/facade/elasticache.py
@@ -78,6 +78,6 @@ class ElastiCacheFacade(AWSBaseFacade):
         try:
             return await AWSFacadeUtils.get_all_pages(
                 'elasticache', region, self.session, 'describe_cache_parameter_groups', 'CacheParameterGroups')
-        except ClientError as ex:
-            if ex.response['Error']['Code'] != 'InvalidParameterValue':
-                print_exception('Failed to get parameter groups: {}'.format(e))
+        except ClientError as e:
+            if e.response['Error']['Code'] != 'InvalidParameterValue':
+                print_exception('Failed to describe cache parameter groups: {}'.format(e))

--- a/ScoutSuite/providers/aws/facade/redshift.py
+++ b/ScoutSuite/providers/aws/facade/redshift.py
@@ -1,11 +1,11 @@
 from asyncio import Lock
-from botocore.exceptions import ClientError
+
+from botocore.utils import ClientError
 
 from ScoutSuite.core.console import print_exception
-from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.aws.utils import ec2_classic
-from botocore.utils import ClientError
 
 
 class RedshiftFacade(AWSBaseFacade):
@@ -25,7 +25,7 @@ class RedshiftFacade(AWSBaseFacade):
                 'redshift', region, self.session, 'describe_clusters', 'Clusters')
 
             for cluster in self.clusters_cache[region]:
-                cluster['VpcId'] =\
+                cluster['VpcId'] = \
                     cluster['VpcId'] if 'VpcId' in cluster and cluster['VpcId'] else ec2_classic
 
     async def get_cluster_parameter_groups(self, region: str):

--- a/ScoutSuite/providers/aws/facade/redshift.py
+++ b/ScoutSuite/providers/aws/facade/redshift.py
@@ -1,5 +1,7 @@
 from asyncio import Lock
+from botocore.exceptions import ClientError
 
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
 from ScoutSuite.providers.aws.utils import ec2_classic
@@ -35,7 +37,9 @@ class RedshiftFacade(AWSBaseFacade):
         try:
             return await AWSFacadeUtils.get_all_pages(
                 'redshift', region, self.session, 'describe_cluster_security_groups', 'ClusterSecurityGroups')
-        except ClientError:
+        except ClientError as e:
+            if e.response['Error']['Code'] != 'InvalidParameterValue':
+                print_exception('Failed to describe cluster security groups: {}'.format(e))
             return []
 
     async def get_cluster_parameters(self, region: str, parameter_group: str):

--- a/ScoutSuite/providers/aws/facade/utils.py
+++ b/ScoutSuite/providers/aws/facade/utils.py
@@ -1,8 +1,8 @@
 import boto3
-
 from botocore.exceptions import ClientError
-from ScoutSuite.providers.utils import run_concurrently
+
 from ScoutSuite.core.conditions import print_exception
+from ScoutSuite.providers.utils import run_concurrently
 
 
 class AWSFacadeUtils:
@@ -57,7 +57,10 @@ class AWSFacadeUtils:
         try:
             return await run_concurrently(lambda: AWSFacadeUtils._get_all_pages_from_paginator(paginator, entities))
         except ClientError as e:
-            if e.response['Error']['Code'] in ['AccessDenied', 'AccessDeniedException', 'UnauthorizedOperation', 'AuthorizationError']:
+            if e.response['Error']['Code'] in ['AccessDenied',
+                                               'AccessDeniedException',
+                                               'UnauthorizedOperation',
+                                               'AuthorizationError']:
                 print_exception('Failed to get all pages from paginator for the {} service: {}'.format(service, e))
                 return []
             else:

--- a/ScoutSuite/providers/aws/facade/utils.py
+++ b/ScoutSuite/providers/aws/facade/utils.py
@@ -53,12 +53,7 @@ class AWSFacadeUtils:
             paginator_name).paginate(**paginator_args)
 
         # Getting all pages from a paginator requires API calls so we need to do it concurrently:
-        try:
-            return await run_concurrently(lambda: AWSFacadeUtils._get_all_pages_from_paginator(paginator, entities))
-        except Exception as e:
-            print_exception('Failed to get all pages from paginator for the {} service: {}'.format(service, e))
-
-            return []
+        return await run_concurrently(lambda: AWSFacadeUtils._get_all_pages_from_paginator(paginator, entities))
 
     @staticmethod
     def _get_all_pages_from_paginator(paginator, entities: list):

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -57,16 +57,11 @@ class AWSProvider(BaseProvider):
         :return: None
         """
         ip_ranges = [] if ip_ranges is None else ip_ranges
+
         self._map_all_subnets()
 
-        if 'emr' in self.service_list:
-            self._set_emr_vpc_ids()
-
-        # TODO: Handle that when refactoring is done?
-        # self.parse_elb_policies()
-        self._set_emr_vpc_ids()
-
         # Various data processing calls
+
         if 'ec2' in self.service_list:
             self._map_all_sgs()
             self._check_ec2_zone_distribution()
@@ -82,8 +77,16 @@ class AWSProvider(BaseProvider):
         if 'elbv2' in self.service_list and 'ec2' in self.service_list:
             self._add_security_group_data_to_elbv2()
 
+        if 'elb' in self.service_list and 'ec2' in self.service_list:
+            # TODO: Handle that when refactoring is done?
+            # self.parse_elb_policies()
+            pass
+
         if 's3' in self.service_list and 'iam' in self.service_list:
             self._match_iam_policies_and_buckets()
+
+        if 'emr' in self.service_list and 'ec2' in self.service_list:
+            self._set_emr_vpc_ids()
 
         self._add_cidr_display_name(ip_ranges, ip_ranges_name_key)
 
@@ -538,10 +541,10 @@ class AWSProvider(BaseProvider):
                            self.set_emr_vpc_ids_callback,
                            {'clear_list': clear_list})
         for region in clear_list:
-            self.services['emr']['regions'][region]['vpcs'].pop('TODO')
+            self.services['emr']['regions'][region]['vpcs'].pop('EMR-UNKNOWN-VPC')
 
     def set_emr_vpc_ids_callback(self, current_config, path, current_path, vpc_id, callback_args):
-        if vpc_id != 'TODO':
+        if vpc_id != 'EMR-UNKNOWN-VPC':
             return
         region = current_path[3]
         vpc_id = sg_id = subnet_id = None

--- a/ScoutSuite/providers/aws/resources/emr/base.py
+++ b/ScoutSuite/providers/aws/resources/emr/base.py
@@ -23,9 +23,9 @@ class EMRVpcs(AWSCompositeResources):
     ]
 
     async def fetch_all(self, **kwargs):
-        # EMR won't disclose its VPC, so we put everything in a VPC named "TODO", and we
+        # EMR won't disclose its VPC, so we put everything in a VPC named "EMR-UNKNOWN-VPC", and we
         # infer the VPC afterwards during the preprocessing.
-        tmp_vpc = 'TODO'
+        tmp_vpc = 'EMR-UNKNOWN-VPC'
         self[tmp_vpc] = {}
         await self._fetch_children(self[tmp_vpc], {'region': self.scope['region'], 'vpc': tmp_vpc})
 


### PR DESCRIPTION
- Removed exception handling from `/ScoutSuite/providers/aws/facade/utils.py` so that it can be handled in the facades
  - It's similar to what we did for `/ScoutSuite/providers/utils.py`. I guess if/when we merge the code for the 3 providers having AWS-specific exception handling in `get_multiple_entities_from_all_pages` will have to be rethought.
  - This allows catching exceptions which should be ignored, such as for `get_parameter_groups` in `ScoutSuite/providers/aws/facade/elasticache.py`
- Partial fix for https://github.com/nccgroup/ScoutSuite/issues/299, still not sure where the issue lies (there's a lot of old code black magic)