### PR TITLE
Migrated GKE to new architecture 

### DIFF
--- a/ScoutSuite/providers/gcp/metadata.json
+++ b/ScoutSuite/providers/gcp/metadata.json
@@ -46,7 +46,7 @@
       "resources": {
         "clusters": {
           "cols": 2,
-          "path": "services.kubernetesengine.clusters"
+          "path": "services.kubernetesengine.projects.id.zones.id.clusters"
         }
       }
     }


### PR DESCRIPTION
Migrated the Google Kubernetes Engine and its resources to the new architecture. This PR is part of the [refactoring on the proprietary repo](https://github.com/nccgroup/ScoutSuite-Proprietary/pull/131). The only missing changes on the public side is for the metadata JSON to be updated.