### PR TITLE
Bugfix/Wrong count for resources

### DIFF
--- a/ScoutSuite/providers/base/provider.py
+++ b/ScoutSuite/providers/base/provider.py
@@ -117,8 +117,11 @@ class BaseProvider(object):
                     'version': scout_version, 'ruleset_name': ruleset.name, 'ruleset_about': ruleset.about,
                     'summary': {}}
         for service in self.services:
-            last_run['summary'][service] = {'checked_items': 0, 'flagged_items': 0, 'max_level': 'warning',
-                                            'rules_count': 0, 'resources_count': 0}
+            last_run['summary'][service] = {'checked_items': 0,
+                                            'flagged_items': 0,
+                                            'max_level': 'warning',
+                                            'rules_count': 0,
+                                            'resources_count': 0}
             if self.services[service] is None:
                 # Not supported yet
                 continue

--- a/ScoutSuite/providers/base/provider.py
+++ b/ScoutSuite/providers/base/provider.py
@@ -164,27 +164,23 @@ class BaseProvider(object):
                                  '.') if x != 'id'])
 
                     # Update counts
-                    service_config = self.services[service]
-                    if not service_config:
-                        continue
+                    self.metadata[service_group][service]['resources'][resource]['count'] = \
+                        self.recursive_get_count(resource,
+                                                 self.services[service])
 
-                    count = '%s_count' % resource
-                    if resource != 'regions':
-                        if 'regions' in service_config.keys() and isinstance(service_config['regions'], dict):
-                            self.metadata[service_group][service]['resources'][resource]['count'] = 0
-                            for region in service_config['regions']:
-                                if count in service_config['regions'][region].keys():
-                                    self.metadata[service_group][service]['resources'][resource]['count'] += \
-                                        service_config['regions'][region][count]
-                        else:
-                            try:
-                                self.metadata[service_group][service]['resources'][resource]['count'] = \
-                                    service_config[count]
-                            except Exception as e:
-                                print_exception(e)
-                    else:
-                        self.metadata[service_group][service]['resources'][resource]['count'] = len(
-                            service_config['regions'])
+    def recursive_get_count(self, resource, resources):
+        """
+        Recursively look for counts of a specific resource in a resource tree.
+        """
+        count = 0
+        resource_count = '%s_count' % resource
+        if isinstance(resources, dict):
+            if resource_count in resources.keys():
+                count += resources[resource_count]
+            else:
+                for k in resources.keys():
+                    count += self.recursive_get_count(resource, resources[k])
+        return count
 
     def manage_object(self, object, attr, init, callback=None):
         """

--- a/ScoutSuite/providers/base/resources/base.py
+++ b/ScoutSuite/providers/base/resources/base.py
@@ -87,6 +87,7 @@ class CompositeResources(Resources, metaclass=abc.ABCMeta):
             else:
                 if resource_parent.get(child_name) is None:
                     resource_parent[child_name] = {}
+                    resource_parent[child_name + '_count'] = 0
 
                 resource_parent[child_name].update(child)
-                resource_parent[child_name + '_count'] = len(child)
+                resource_parent[child_name + '_count'] += len(child)


### PR DESCRIPTION
This PR aims to fix https://github.com/nccgroup/ScoutSuite/issues/346. 

The main change is a modification to `ScoutSuite/providers/base/provider.py` which adds a `recursive_get_count` method that simplifies merging all the `<resource>_count` instances to the metadata.

TODO:
- Identify root cause (why wasn't this happening before)
- Ensure this works across all providers
