### PR TITLE
Add support for AWS config resources

### DIFF
--- a/ScoutSuite/output/data/html/partials/aws/services.config.regions.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.config.regions.html
@@ -1,0 +1,50 @@
+
+<!-- Recorder partial -->
+<script id="services.config.regions.partial" type="text/x-handlebars-template">
+    <div class="list-group-item active">
+      <h4 class="list-group-item-heading">{{name}}</h4>
+    </div>
+    <div class="list-group-item">
+    <h4>Information</h4>
+      <ul>
+        <li class="list-group-item-text">Configured:
+          <span id="config.regions.{{name}}.NotConfigured">
+            {{#ifPositive recorders_count}}true{{else}}false{{/ifPositive}}
+          </span>
+        </li>
+    </div>
+    <div class="list-group-item">
+      <div class="accordion">
+        <h4 class="list-group-item-heading accordion-heading">Recorders
+            {{> count_badge target=(concat '#config.regions' name 'recorders') count=recorders_count}}
+        </h4>
+        <div id="config.regions.{{name}}.recorders" class="accordion-body">
+          <div class="accordion-inner">
+            <ul class="no-bullet">
+              {{#each this.recorders}}
+                <li><a href="javascript:showObject('services.config.regions.{{../name}}.recorders.{{@key}}')">{{name}}</a></li>
+              {{/each}}
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="accordion">
+        <h4 class="list-group-item-heading accordion-heading">Rules
+            {{> count_badge target=(concat '#config.regions' name 'rules') count=rules_count}}
+        </h4>
+        <div id="config.regions.{{name}}.rules" class="accordion-body">
+          <div class="accordion-inner">
+            <ul class="no-bullet">
+              {{#each this.rules}}
+                <li><a href="javascript:showObject('services.config.regions.{{../name}}.rules.{{@key}}')">{{name}}</a></li>
+              {{/each}}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+</script>
+<script>
+  Handlebars.registerPartial("services.config.regions", $("#services\\.config\\.regions\\.partial").html());
+</script>
+

--- a/ScoutSuite/output/data/html/partials/aws/services.config.regions.id.recorders.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.config.regions.id.recorders.html
@@ -1,0 +1,28 @@
+
+<!-- Recorder partial -->
+<script id="services.config.regions.id.recorders.partial" type="text/x-handlebars-template">
+  {{#unless scout_link}}
+    <div id="resource-name" class="list-group-item active">
+      <h4 class="list-group-item-heading">{{name}}</h4>
+    </div>
+    <div class="list-group-item">
+    <h4>Information</h4>
+      <ul>
+        <li class="list-group-item-text">Name: {{name}}</li>
+        <li class="list-group-item-text">Region: {{region}}</li>
+        <li class="list-group-item-text">Recording: {{recording}}</li>
+      </ul>
+    </div>
+  {{/unless}}
+</script>
+<script>
+  Handlebars.registerPartial("services.config.regions.id.recorders", $("#services\\.config\\.regions\\.id\\.recorders\\.partial").html());
+</script>
+
+<!-- Single Config recorder template -->
+<script id="single_config_recorder-template" type="text/x-handlebars-template">
+    {{> modal-template template='services.config.regions.id.recorders' }}
+</script>
+<script>
+    var single_config_recorder_template = Handlebars.compile($("#single_config_recorder-template").html());
+</script>

--- a/ScoutSuite/output/data/html/partials/aws/services.config.regions.id.rules.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.config.regions.id.rules.html
@@ -1,0 +1,28 @@
+
+<!-- Rule partial -->
+<script id="services.config.regions.id.rules.partial" type="text/x-handlebars-template">
+  {{#unless scout_link}}
+    <div id="resource-name" class="list-group-item active">
+      <h4 class="list-group-item-heading">{{name}}</h4>
+    </div>
+    <div class="list-group-item">
+    <h4>Information</h4>
+      <ul>
+        <li class="list-group-item-text">Name: {{name}}</li>
+        <li class="list-group-item-text">Region: {{region}}</li>
+        <li class="list-group-item-text">Description: {{Description}}</li>
+      </ul>
+    </div>
+  {{/unless}}
+</script>
+<script>
+  Handlebars.registerPartial("services.config.regions.id.rules", $("#services\\.config\\.regions\\.id\\.rules\\.partial").html());
+</script>
+
+<!-- Single Config rule template -->
+<script id="single_config_rule-template" type="text/x-handlebars-template">
+    {{> modal-template template='services.config.regions.id.rules' }}
+</script>
+<script>
+    var single_config_rule_template = Handlebars.compile($("#single_config_rule-template").html());
+</script>

--- a/ScoutSuite/providers/aws/facade/base.py
+++ b/ScoutSuite/providers/aws/facade/base.py
@@ -8,6 +8,7 @@ from ScoutSuite.providers.aws.facade.awslambda import LambdaFacade
 from ScoutSuite.providers.aws.facade.cloudformation import CloudFormation
 from ScoutSuite.providers.aws.facade.cloudtrail import CloudTrailFacade
 from ScoutSuite.providers.aws.facade.cloudwatch import CloudWatch
+from ScoutSuite.providers.aws.facade.config import ConfigFacade
 from ScoutSuite.providers.aws.facade.directconnect import DirectConnectFacade
 from ScoutSuite.providers.aws.facade.ec2 import EC2Facade
 from ScoutSuite.providers.aws.facade.efs import EFSFacade
@@ -27,7 +28,6 @@ from ScoutSuite.providers.utils import run_concurrently
 
 try:
     from ScoutSuite.providers.aws.facade.dynamodb_private import DynamoDBFacade
-    from ScoutSuite.providers.aws.facade.config_private import ConfigFacade
     from ScoutSuite.providers.aws.facade.kms_private import KMSFacade
 except ImportError:
     pass
@@ -73,6 +73,7 @@ class AWSFacade(AWSBaseFacade):
         self.cloudformation = CloudFormation(self.session)
         self.cloudtrail = CloudTrailFacade(self.session)
         self.cloudwatch = CloudWatch(self.session)
+        self.config = ConfigFacade(self.session)
         self.directconnect = DirectConnectFacade(self.session)
         self.efs = EFSFacade(self.session)
         self.elasticache = ElastiCacheFacade(self.session)
@@ -90,7 +91,6 @@ class AWSFacade(AWSBaseFacade):
 
         try:
             self.dynamodb = DynamoDBFacade(self.session)
-            self.config = ConfigFacade(self.session)
             self.kms = KMSFacade(self.session)
         except NameError:
             pass

--- a/ScoutSuite/providers/aws/facade/config.py
+++ b/ScoutSuite/providers/aws/facade/config.py
@@ -1,3 +1,4 @@
+from ScoutSuite.core.console import print_exception
 from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
 from ScoutSuite.providers.utils import run_concurrently

--- a/ScoutSuite/providers/aws/facade/config.py
+++ b/ScoutSuite/providers/aws/facade/config.py
@@ -1,0 +1,18 @@
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
+from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
+from ScoutSuite.providers.utils import run_concurrently
+
+
+class ConfigFacade(AWSBaseFacade):
+    async def get_rules(self, region):
+        return await AWSFacadeUtils.get_all_pages('config', region, self.session, 'describe_config_rules', 'ConfigRules')
+
+    async def get_recorder_status(self, region):
+        client = AWSFacadeUtils.get_client('config', self.session, region)
+        try:
+            recorder_status = await run_concurrently(
+                lambda: client.describe_configuration_recorder_status())
+        except Exception as e:
+            print_exception('Failed to describe recorder status: {}'.format(e))
+        else:
+            return recorder_status['ConfigurationRecordersStatus']

--- a/ScoutSuite/providers/aws/metadata.json
+++ b/ScoutSuite/providers/aws/metadata.json
@@ -59,6 +59,9 @@
                 },
                 "recorders": {
                     "path": "services.config.regions.id.recorders"
+                },
+                "rules": {
+                    "path": "services.config.regions.id.rules"
                 }
             }
         }

--- a/ScoutSuite/providers/aws/resources/config/base.py
+++ b/ScoutSuite/providers/aws/resources/config/base.py
@@ -1,0 +1,58 @@
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.regions import Regions
+from ScoutSuite.providers.aws.resources.base import AWSResources
+
+
+class RecorderStatus(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super(RecorderStatus, self).__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        raw_recorder_status_list = await self.facade.config.get_recorder_status(self.region)
+        for raw_recorder_status in raw_recorder_status_list:
+            name, resource = self._parse_recorder_status(raw_recorder_status)
+            self[name] = resource
+
+    def _parse_recorder_status(self, raw_recorder_status):
+        # Drop some data
+        for key in ['lastStartTime', 'lastStatus', 'lastStatusChangeTime']:
+            if key in raw_recorder_status:
+                raw_recorder_status.pop(key)
+
+        rule_id = raw_recorder_status['name']
+        return rule_id, raw_recorder_status
+
+
+class Rules(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super(Rules, self).__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        raw_rules = await self.facade.config.get_rules(self.region)
+        for raw_rule in raw_rules:
+            name, resource = self._parse_rule(raw_rule)
+            self[name] = resource
+
+    def _parse_rule(self, raw_rule):
+        raw_rule['arn'] = raw_rule.pop('ConfigRuleArn')
+        raw_rule['name'] = raw_rule.pop('ConfigRuleName')
+
+        # Drop some data
+        for key in ['ConfigRuleState']:
+            if key in raw_rule:
+                raw_rule.pop(key)
+
+        rule_id = raw_rule['name']
+        return rule_id, raw_rule
+
+
+class Config(Regions):
+    _children = [
+        (RecorderStatus, 'recorders'),
+        (Rules, 'rules')
+    ]
+
+    def __init__(self, facade: AWSFacade):
+        super(Config, self).__init__('config', facade)

--- a/ScoutSuite/providers/aws/rules/findings/config-recorder-not-configured.json
+++ b/ScoutSuite/providers/aws/rules/findings/config-recorder-not-configured.json
@@ -1,0 +1,10 @@
+{
+    "description": "Not configured",
+    "rationale": "Config recorder is not enabled, which means that changes in AWS resource configuration are not logged.",
+    "path": "config.regions.id", 
+    "dashboard_name": "Regions",
+    "conditions": [ "and",
+        [ "recorders_count", "equal", "0" ]
+    ],
+    "id_suffix": "NotConfigured"
+}

--- a/ScoutSuite/providers/aws/rules/rulesets/default.json
+++ b/ScoutSuite/providers/aws/rules/rulesets/default.json
@@ -43,6 +43,12 @@
                 "level": "warning"
             }
         ],
+        "config-recorder-not-configured.json": [
+            {
+                "enabled": false,
+                "level": "danger"
+            }
+        ],
         "ec2-default-security-group-in-use.json": [
             {
                 "enabled": true,

--- a/ScoutSuite/providers/aws/rules/rulesets/detailed.json
+++ b/ScoutSuite/providers/aws/rules/rulesets/detailed.json
@@ -43,6 +43,12 @@
                 "level": "warning"
             }
         ],
+        "config-recorder-not-configured.json": [
+            {
+                "enabled": false,
+                "level": "danger"
+            }
+        ],
         "ec2-default-security-group-in-use.json": [
             {
                 "enabled": true,

--- a/ScoutSuite/providers/aws/services.py
+++ b/ScoutSuite/providers/aws/services.py
@@ -3,6 +3,7 @@ from ScoutSuite.providers.aws.resources.awslambda.base import Lambdas
 from ScoutSuite.providers.aws.resources.cloudformation.base import CloudFormation
 from ScoutSuite.providers.aws.resources.cloudtrail.base import CloudTrail
 from ScoutSuite.providers.aws.resources.cloudwatch.base import CloudWatch
+from ScoutSuite.providers.aws.resources.config.base import Config
 from ScoutSuite.providers.aws.resources.directconnect.base import DirectConnect
 from ScoutSuite.providers.aws.resources.ec2.base import EC2
 from ScoutSuite.providers.aws.resources.efs.base import EFS
@@ -24,10 +25,6 @@ from ScoutSuite.providers.base.services import BaseServicesConfig
 # Try to import proprietary services
 try:
     from ScoutSuite.providers.aws.resources.private_dynamodb.base import DynamoDB
-except ImportError:
-    pass
-try:
-    from ScoutSuite.providers.aws.resources.private_config.base import Config
 except ImportError:
     pass
 try:


### PR DESCRIPTION
This change adds AWS config resources to the collected data, and defines one new finding to verify if there are any configuration recorders for each enabled region.

The finding is disabled in the default and detailed rule sets.