### PR TITLE
Bugfix/GCP Project Selection

### DIFF
--- a/ScoutSuite/providers/base/provider.py
+++ b/ScoutSuite/providers/base/provider.py
@@ -40,7 +40,8 @@ class BaseProvider(object):
 
         self._load_metadata()
 
-        self.services = self.services_config(self.credentials)
+        if not self.services:
+            self.services = self.services_config(self.credentials)
         supported_services = vars(self.services).keys()
         self.service_list = self._build_services_list(supported_services, services, skipped_services)
 

--- a/ScoutSuite/providers/gcp/facade/base.py
+++ b/ScoutSuite/providers/gcp/facade/base.py
@@ -7,8 +7,10 @@ class GCPBaseFacade:
         self._client = None
 
     def _build_client(self) -> discovery.Resource:
-        return discovery.build(self._client_name, self._client_version, 
-            cache_discovery=False, cache=MemoryCache())
+        return self._build_arbitrary_client(self._client_name, self._client_version)
+
+    def _build_arbitrary_client(self, client_name, client_version):
+        return discovery.build(client_name, client_version, cache_discovery=False, cache=MemoryCache())
 
     # Since the HTTP library used by the Google API Client library is not 
     # thread-safe, we need to create a new client for each request.

--- a/ScoutSuite/providers/gcp/facade/gcp.py
+++ b/ScoutSuite/providers/gcp/facade/gcp.py
@@ -8,6 +8,8 @@ from ScoutSuite.providers.gcp.facade.gce import GCEFacade
 from ScoutSuite.providers.gcp.facade.iam import IAMFacade
 from ScoutSuite.providers.gcp.facade.stackdriverlogging import StackdriverLoggingFacade
 from ScoutSuite.providers.gcp.facade.utils import GCPFacadeUtils
+from ScoutSuite.core.console import print_exception, print_info
+from ScoutSuite.providers.utils import run_concurrently
 
 # Try to import proprietary facades
 try:
@@ -16,8 +18,15 @@ except ImportError:
     pass
 
 class GCPFacade(GCPBaseFacade):
-    def __init__(self):
+    def __init__(self, default_project_id=None, project_id=None, folder_id=None, organization_id=None, all_projects=None):
         super(GCPFacade, self).__init__('cloudresourcemanager', 'v1')
+
+        self.default_project_id = default_project_id
+        self.all_projects = all_projects
+        self.project_id = project_id
+        self.folder_id = folder_id
+        self.organization_id = organization_id
+
         self.cloudresourcemanager = CloudResourceManagerFacade()
         self.cloudsql = CloudSQLFacade()
         self.cloudstorage = CloudStorageFacade()
@@ -35,10 +44,115 @@ class GCPFacade(GCPBaseFacade):
 
     async def get_projects(self):
         try:
-            resourcemanager_client = self._get_client()
-            request = resourcemanager_client.projects().list() 
-            projects_group = resourcemanager_client.projects()
-            return await GCPFacadeUtils.get_all('projects', request, projects_group)
+
+            # resourcemanager_client = self._get_client()
+            # request = resourcemanager_client.projects().list()
+            # projects_group = resourcemanager_client.projects()
+            # return await GCPFacadeUtils.get_all('projects', request, projects_group)
+
+            # All projects to which the user / Service Account has access to
+            if self.all_projects:
+                return await self._get_projects_recursively(
+                    parent_type='all', parent_id=None)
+            # Project passed through the CLI
+            elif self.project_id:
+                return await self._get_projects_recursively(
+                    parent_type='project', parent_id=self.project_id)
+            # Folder passed through the CLI
+            elif self.folder_id:
+                return await self._get_projects_recursively(
+                    parent_type='folder', parent_id=self.folder_id)
+            # Organization passed through the CLI
+            elif self.organization_id:
+                return await self._get_projects_recursively(
+                    parent_type='organization', parent_id=self.organization_id)
+            # Project inferred from default configuration
+            elif self.default_project_id:
+                return await self._get_projects_recursively(
+                    parent_type='project', parent_id=self.default_project_id)
+            # Raise exception if none of the above
+            else:
+                print_info(
+                    "Could not infer the Projects to scan and no default Project ID was found.")
+                return []
+
         except Exception as e:
             print_exception('Failed to retrieve projects: {}'.format(e))
             return []
+
+
+    async def _get_projects_recursively(self, parent_type, parent_id):
+        """
+        Returns all the projects in a given organization or folder. For a project_id it only returns the project
+        details.
+        """
+
+        if parent_type not in ['project', 'organization', 'folder', 'all']:
+            return None
+
+        projects = []
+
+        # FIXME can't currently be done with API client library as it consumes v1 which doesn't support folders
+        """
+        resource_manager_client = resource_manager.Client(credentials=self.credentials)
+        project_list = resource_manager_client.list_projects()
+        for p in project_list:
+            if p.parent['id'] == self.organization_id and p.status == 'ACTIVE':
+                projects.append(p.project_id)
+        """
+
+        resourcemanager_client = self._get_client()
+        # resource_manager_client_v1 = gcp_connect_service(
+        #     service='cloudresourcemanager', credentials=self.credentials)
+        # resource_manager_client_v2 = gcp_connect_service(
+        #     service='cloudresourcemanager-v2', credentials=self.credentials)
+
+        try:
+            if parent_type == 'project':
+                request = resourcemanager_client.projects().list(filter='id:%s' %
+                                                                        parent_id)
+                projects_group = resourcemanager_client.projects()
+                project_response = await GCPFacadeUtils.get_all('projects', request, projects_group)
+                # if 'projects' in project_response.keys():
+                #     for project in project_response['projects']:
+                for project in project_response:
+                    if project['lifecycleState'] == "ACTIVE":
+                        projects.append(project)
+
+            elif parent_type == 'all':
+                request = resourcemanager_client.projects().list()
+                projects_group = resourcemanager_client.projects()
+                project_response = await GCPFacadeUtils.get_all('projects', request, projects_group)
+                if 'projects' in project_response.keys():
+                    for project in project_response['projects']:
+                        if project['lifecycleState'] == "ACTIVE":
+                            projects.append(project)
+            else:
+
+                # get parent children projects
+                request = resourcemanager_client.projects().list(filter='parent.id:%s' % parent_id)
+                while request is not None:
+
+                    projects_group = resourcemanager_client.projects()
+                    response = await GCPFacadeUtils.get_all('projects', request, projects_group)
+                    if 'projects' in response.keys():
+                        for project in response['projects']:
+                            if project['lifecycleState'] == "ACTIVE":
+                                projects.append(project)
+
+                    request = resourcemanager_client.projects().list_next(previous_request=request,
+                                                                          previous_response=response)
+
+                # # get parent children projects in children folders recursively
+                # folder_response = resource_manager_client_v2.folders().list(
+                #     parent='%ss/%s' % (parent_type, parent_id)).execute()
+                # if 'folders' in folder_response.keys():
+                #     for folder in folder_response['folders']:
+                #         projects.extend(self._get_projects(
+                #             "folder", folder['name'].strip(u'folders/')))
+
+        except Exception as e:
+            print_exception('Unable to list accessible Projects: {}'.format(e))
+
+        finally:
+            return projects

--- a/ScoutSuite/providers/gcp/provider.py
+++ b/ScoutSuite/providers/gcp/provider.py
@@ -10,7 +10,8 @@ class GCPProvider(BaseProvider):
     Implements provider for GCP
     """
 
-    def __init__(self, project_id=None, folder_id=None, organization_id=None, all_projects=None,
+    def __init__(self,
+                 project_id=None, folder_id=None, organization_id=None, all_projects=None,
                  report_dir=None, timestamp=None, services=None, skipped_services=None, result_format='json', **kwargs):
         services = [] if services is None else services
         skipped_services = [] if skipped_services is None else skipped_services
@@ -22,15 +23,16 @@ class GCPProvider(BaseProvider):
         self.provider_name = 'Google Cloud Platform'
         self.environment = 'default'
 
-        self.projects = []
         self.all_projects = all_projects
         self.project_id = project_id
         self.folder_id = folder_id
         self.organization_id = organization_id
 
-        self.services_config = GCPServicesConfig
         self.credentials = kwargs['credentials']
         self._set_account_id()
+
+        self.services = GCPServicesConfig(self.credentials, self.credentials.default_project_id,
+                                          self.project_id, self.folder_id, self.organization_id, self.all_projects)
 
         self.result_format = result_format
 
@@ -41,13 +43,7 @@ class GCPProvider(BaseProvider):
         """
         Returns the name of the report using the provider's configuration
         """
-        if self.project_id:
-            return 'gcp-{}'.format(self.project_id)
-        elif self.organization_id:
-            return 'gcp-{}'.format(self.organization_id)
-        elif self.folder_id:
-            return 'gcp-{}'.format(self.folder_id)
-        elif self.account_id:
+        if self.account_id:
             return 'gcp-{}'.format(self.account_id)
         else:
             return 'gcp'
@@ -73,6 +69,8 @@ class GCPProvider(BaseProvider):
         # Project inferred from default configuration
         elif self.credentials.default_project_id:
             self.account_id = self.credentials.default_project_id
+        else:
+            self.account_id = 'unknown-project-id'
 
     def preprocessing(self, ip_ranges=None, ip_ranges_name_key=None):
         """

--- a/ScoutSuite/providers/gcp/provider.py
+++ b/ScoutSuite/providers/gcp/provider.py
@@ -55,8 +55,8 @@ class GCPProvider(BaseProvider):
             if self.credentials.is_service_account and hasattr(self.credentials, 'service_account_email'):
                 self.account_id = self.credentials.service_account_email
             else:
-                # TODO use username email
-                self.account_id = 'GCP'
+                # TODO use username email (can't find it...)
+                self.account_id = 'user-account'
         # Project passed through the CLI
         elif self.project_id:
             self.account_id = self.project_id

--- a/ScoutSuite/providers/gcp/services.py
+++ b/ScoutSuite/providers/gcp/services.py
@@ -14,9 +14,11 @@ except ImportError:
     pass
 
 class GCPServicesConfig(BaseServicesConfig):
-    def __init__(self, credentials=None, projects=None, **kwargs):
+    def __init__(self, credentials=None, default_project_id=None,
+                 project_id=None, folder_id=None, organization_id=None, all_projects=None,
+                 **kwargs):
         super(GCPServicesConfig, self).__init__(credentials)
-        facade = GCPFacade()
+        facade = GCPFacade(default_project_id, project_id, folder_id, organization_id, all_projects)
         self.cloudresourcemanager = CloudResourceManager(facade)
         self.cloudsql = CloudSQL(facade)
         self.cloudstorage = CloudStorage(facade)


### PR DESCRIPTION
This PR restores GCP project selection which was broken during refactoring.

As before, the logic is:
- If a Project, Folder or Organization is provided through the CLI, then that's what will be scanned
- If the `--all-projects` CLI argument is passed, we pull all the Projects to which the user/Service Account has access to, and we'll scan all of them
- Otherwise, if a Project is inferred (default project configured for a user or set in the Service Account credentials file), then that project will be scanned