### PR TITLE
Can't create exception for world listable buckets

### DIFF
--- a/ScoutSuite/core/exceptions.py
+++ b/ScoutSuite/core/exceptions.py
@@ -1,13 +1,12 @@
-"""
-Exceptions handling
-"""
-
 from ScoutSuite.core.console import print_debug
 
 from ScoutSuite.output.result_encoder import JavaScriptEncoder
 
 
 class RuleExceptions(object):
+    """
+    Exceptions handling
+    """
 
     def __init__(self, file_path=None):
         self.jsrw = JavaScriptEncoder()

--- a/ScoutSuite/output/data/html/partials/aws/services.s3.acls.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.s3.acls.html
@@ -17,16 +17,32 @@
                 <tr>
                   <td width="20%" class="text-center bucket-name table-hover" onclick="toggleName(this)">{{DisplayName}}</td>
                   <td width="20%" class="text-center">
-                    <span id="{{../resource_path}}.grantees.{{@key}}.read">{{{s3_grant_2_icon permissions.read}}}</td></span>
+                    {{#if permissions.read}}
+                    <i id="{{../../resource_path}}.grantees.{{@key}}.read" class="fa fa-check"></i>
+                    {{else}}
+                    <i id="{{../../resource_path}}.grantees.{{@key}}.read" class="fa fa-times"></i>
+                    {{/if}}
                   </td>
                   <td width="20%" class="text-center">
-                    <span id="{{../resource_path}}.grantees.{{@key}}.write">{{{s3_grant_2_icon permissions.write}}}</td></span>
+                    {{#if permissions.write}}
+                    <i id="{{../../resource_path}}.grantees.{{@key}}.write" class="fa fa-check"></i>
+                    {{else}}
+                    <i id="{{../../resource_path}}.grantees.{{@key}}.write" class="fa fa-times"></i>
+                    {{/if}}
                   </td>
                   <td width="20%" class="text-center">
-                    <span id="{{../resource_path}}.grantees.{{@key}}.read_acp">{{{s3_grant_2_icon permissions.read_acp}}}</td></span>
+                    {{#if permissions.read_acp}}
+                    <i id="{{../../resource_path}}.grantees.{{@key}}.read_acp" class="fa fa-check"></i>
+                    {{else}}
+                    <i id="{{../../resource_path}}.grantees.{{@key}}.read_acp" class="fa fa-times"></i>
+                    {{/if}}
                   </td>
                   <td width="20%" class="text-center">
-                    <span id="{{../resource_path}}.grantees.{{@key}}.write_acp">{{{s3_grant_2_icon permissions.write_acp}}}</td></span>
+                    {{#if permissions.write_acp}}
+                    <i id="{{../../resource_path}}.grantees.{{@key}}.write_acp" class="fa fa-check"></i>
+                    {{else}}
+                    <i id="{{../../resource_path}}.grantees.{{@key}}.write_acp" class="fa fa-times"></i>
+                    {{/if}}
                   </td>
                 </tr>
                 {{/each}}

--- a/ScoutSuite/output/data/inc-scoutsuite/helpers.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/helpers.js
@@ -72,10 +72,6 @@ Handlebars.registerHelper('list_permissions', function (permissions) {
     return r
 })
 
-Handlebars.registerHelper('s3_grant_2_icon', function (value) {
-    return '<i class="' + ((value === true) ? 'fa fa-check' : '') + '"></i>'
-})
-
 Handlebars.registerHelper('good_bad_icon', function (finding, bucketId, keyId, suffix) {
     var keyPath = 's3.buckets.' + bucketId + '.keys.' + keyId + '.' + suffix
     var index = runResults['services']['s3']['findings'][finding]['items'].indexOf(keyPath)


### PR DESCRIPTION
This PR resolves https://github.com/nccgroup/ScoutSuite/issues/26.

The issue was that there was an image inside the element which had the resource's ID, so when adding an exception the effective ID used was that of the image which was `None`.