### PR TITLE
Suppress output #408

### DIFF
--- a/ScoutSuite/__main__.py
+++ b/ScoutSuite/__main__.py
@@ -6,7 +6,7 @@ import webbrowser
 from concurrent.futures import ThreadPoolExecutor
 
 from ScoutSuite.core.cli_parser import ScoutSuiteArgumentParser
-from ScoutSuite.core.console import set_config_debug_level, print_info, print_exception
+from ScoutSuite.core.console import set_logger_configuration, print_info, print_exception
 from ScoutSuite.core.exceptions import RuleExceptions
 from ScoutSuite.core.processingengine import ProcessingEngine
 from ScoutSuite.core.ruleset import Ruleset
@@ -46,6 +46,7 @@ def run_from_cli():
                args.get('ruleset'), args.get('exceptions'),
                args.get('force_write'),
                args.get('debug'),
+               args.get('no_logging'),
                args.get('no_browser'))
 
 
@@ -68,6 +69,7 @@ def run(provider,
         ruleset='default.json', exceptions=None,
         force_write=False,
         debug=False,
+        no_logging=False,
         no_browser=False):
     """
     Run a scout job in an async event loop.
@@ -98,6 +100,7 @@ async def _run(provider,
                ruleset, exceptions,
                force_write,
                debug,
+               no_logging,
                no_browser,
                **kwargs):
     """
@@ -105,7 +108,7 @@ async def _run(provider,
     """
 
     # Configure the debug level
-    set_config_debug_level(debug)
+    set_logger_configuration(debug, no_logging)
 
     print_info('Launching Scout')
 

--- a/ScoutSuite/__main__.py
+++ b/ScoutSuite/__main__.py
@@ -46,7 +46,8 @@ def run_from_cli():
                args.get('ruleset'), args.get('exceptions'),
                args.get('force_write'),
                args.get('debug'),
-               args.get('no_logging'),
+               args.get('quiet'),
+               args.get('log_file'),
                args.get('no_browser'))
 
 
@@ -69,7 +70,8 @@ def run(provider,
         ruleset='default.json', exceptions=None,
         force_write=False,
         debug=False,
-        no_logging=False,
+        quiet=False,
+        log_file=None,
         no_browser=False):
     """
     Run a scout job in an async event loop.
@@ -100,7 +102,8 @@ async def _run(provider,
                ruleset, exceptions,
                force_write,
                debug,
-               no_logging,
+               quiet,
+               log_file,
                no_browser,
                **kwargs):
     """
@@ -108,7 +111,7 @@ async def _run(provider,
     """
 
     # Configure the debug level
-    set_logger_configuration(debug, no_logging)
+    set_logger_configuration(debug, quiet, log_file)
 
     print_info('Launching Scout')
 

--- a/ScoutSuite/core/cli_parser.py
+++ b/ScoutSuite/core/cli_parser.py
@@ -175,16 +175,22 @@ class ScoutSuiteArgumentParser:
                             default=False,
                             action='store_true',
                             help='Use local data previously fetched and re-run the analysis.')
-        parser.add_argument('--no-logging',
-                            dest='no_logging',
-                            default=False,
-                            action='store_true',
-                            help='Disables logging')
         parser.add_argument('--debug',
                             dest='debug',
                             default=False,
                             action='store_true',
                             help='Print the stack trace when exception occurs')
+        parser.add_argument('--quiet',
+                            dest='quiet',
+                            default=False,
+                            action='store_true',
+                            help='Disables CLI output')
+        parser.add_argument('--logfile',
+                            dest='log_file',
+                            default=None,
+                            action='store',
+                            nargs='?',
+                            help='Additional output to the specified file')
         # parser.add_argument('--resume',
         #                     dest='resume',
         #                     default=False,

--- a/ScoutSuite/core/cli_parser.py
+++ b/ScoutSuite/core/cli_parser.py
@@ -175,6 +175,11 @@ class ScoutSuiteArgumentParser:
                             default=False,
                             action='store_true',
                             help='Use local data previously fetched and re-run the analysis.')
+        parser.add_argument('--no-logging',
+                            dest='no_logging',
+                            default=False,
+                            action='store_true',
+                            help='Disables logging')
         parser.add_argument('--debug',
                             dest='debug',
                             default=False,

--- a/ScoutSuite/core/console.py
+++ b/ScoutSuite/core/console.py
@@ -15,13 +15,15 @@ from ScoutSuite import ERRORS_LIST
 verbose_exceptions = False
 logger = logging.getLogger('scout')
 
-def set_config_debug_level(is_debug):
+def set_logger_configuration(is_debug=False, no_logging=False):
     """
     Configure whether full stacktraces should be dumped in the console output
     """
     global verbose_exceptions
     verbose_exceptions = is_debug
-    coloredlogs.install(level='DEBUG' if is_debug else 'INFO', logger=logger)
+    # if "no logging" is set, don't output anything
+    if not no_logging:
+        coloredlogs.install(level='DEBUG' if is_debug else 'INFO', logger=logger)
 
 
 ########################################

--- a/ScoutSuite/core/console.py
+++ b/ScoutSuite/core/console.py
@@ -15,15 +15,26 @@ from ScoutSuite import ERRORS_LIST
 verbose_exceptions = False
 logger = logging.getLogger('scout')
 
-def set_logger_configuration(is_debug=False, no_logging=False):
+def set_logger_configuration(is_debug=False, quiet=False, output_file_path=None):
     """
     Configure whether full stacktraces should be dumped in the console output
     """
     global verbose_exceptions
     verbose_exceptions = is_debug
-    # if "no logging" is set, don't output anything
-    if not no_logging:
+    # if "quiet" is set, don't output anything
+    if not quiet:
         coloredlogs.install(level='DEBUG' if is_debug else 'INFO', logger=logger)
+
+    if output_file_path:
+        # create file handler which logs messages
+        fh = logging.FileHandler(output_file_path, 'w+')
+        fh.setLevel(logging.DEBUG if is_debug else logging.INFO)
+        # create formatter and add it to the handlers
+        formatter = logging.Formatter(fmt='%(asctime)s %(hostname)s %(name)s[%(process)d] %(levelname)s %(message)s',
+                                      datefmt='%Y-%m-%d %H:%M:%S')
+        fh.setFormatter(formatter)
+        # add the handlers to the logger
+        logger.addHandler(fh)
 
 
 ########################################

--- a/tests/test-rules-processingengine.py
+++ b/tests/test-rules-processingengine.py
@@ -2,7 +2,7 @@ import json
 import os
 import tempfile
 
-from ScoutSuite.core.console import set_config_debug_level, print_error
+from ScoutSuite.core.console import set_logger_configuration, print_error
 from ScoutSuite.core.processingengine import ProcessingEngine
 from ScoutSuite.core.ruleset import Ruleset
 
@@ -14,7 +14,7 @@ class DummyObject(object):
 class TestScoutRulesProcessingEngine:
 
     def setup(self):
-        set_config_debug_level(True)
+        set_logger_configuration(is_debug=True)
         self.rule_counters = {'found': 0, 'tested': 0, 'verified': 0}
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/test-rules-ruleset.py
+++ b/tests/test-rules-ruleset.py
@@ -1,7 +1,7 @@
 import os
 
 from mock import patch
-from ScoutSuite.core.console import set_config_debug_level, print_debug
+from ScoutSuite.core.console import set_logger_configuration, print_debug
 from ScoutSuite.core.rule import Rule
 from ScoutSuite.core.ruleset import Ruleset
 
@@ -9,7 +9,7 @@ from ScoutSuite.core.ruleset import Ruleset
 class TestScoutRulesRuleset:
 
     def setup(self):
-        set_config_debug_level(True)
+        set_logger_configuration(is_debug=True)
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
 
         self.test_ruleset_001 = os.path.join(self.test_dir, 'data/test-ruleset.json')

--- a/tests/test-scoutsuite.py
+++ b/tests/test-scoutsuite.py
@@ -3,14 +3,14 @@ import mock
 
 from nose.plugins.attrib import attr
 from ScoutSuite.__main__ import run_from_cli
-from ScoutSuite.core.console import set_config_debug_level
+from ScoutSuite.core.console import set_logger_configuration
 
 
 class TestScoutSuiteClass:
 
     @classmethod
     def setUpClass(cls):
-        set_config_debug_level(True)
+        set_logger_configuration(is_debug=True)
         cls.has_run_scout_suite = False
 
     @staticmethod


### PR DESCRIPTION
Adds the following CLI options:
- `--quiet` flag to suppress CLI output
- `--logfile` param to specify an additional file path to store output (supports `--debug` flag)

Implements https://github.com/nccgroup/ScoutSuite/issues/408.