### PR TITLE
Dashboard inactive links 

### DIFF
--- a/ScoutSuite/output/data/html/report.html
+++ b/ScoutSuite/output/data/html/report.html
@@ -123,18 +123,19 @@
                                 </div>
                             </a>
                             {{#each items.summary}}
-                            <a href="#services.{{@key}}.findings" class="card" style="color: black !important">
-                                <div class="finding-title card-header">
-                                    <i class="fa finding-badge finding-badge-{{dashboard_color max_level checked_items flagged_items}}"></i>
-                                    {{makeTitle @key}}
-                                    <div class="col-sm-2 float-right" style="text-align: center">{{checked_items}}</div>
-                                    <div class="col-sm-2 float-right" style="text-align: center">{{flagged_items}}</div>
-                                    <div class="col-sm-2 float-right" style="text-align: center">{{rules_count}}</div>
-                                    <div class="col-sm-2 float-right" style="text-align: center">{{resources_count}}</div>
-                                </div>
-                            </a>
-                            {{/each}}
+                            <div class="card finding-title finding-title-{{dashboard_color level rules_count rules_count}} plain-link">
+                                <a href="#services.{{@key}}.findings">
+                                    <div class="finding-title card-header">
+                                        <i class="fa finding-badge finding-badge-{{dashboard_color max_level checked_items flagged_items}}"></i>
+                                        {{makeTitle @key}}
+                                        <div class="col-sm-2 float-right" style="text-align: center">{{checked_items}}</div>
+                                        <div class="col-sm-2 float-right" style="text-align: center">{{flagged_items}}</div>
+                                        <div class="col-sm-2 float-right" style="text-align: center">{{rules_count}}</div>
+                                        <div class="col-sm-2 float-right" style="text-align: center">{{resources_count}}</div>
+                                    </div>
+                                </a>
                             </div>
+                            {{/each}}
                         </div>
                     </div>
                 </h4>

--- a/ScoutSuite/output/data/inc-scoutsuite/css/scoutsuite-dark.css
+++ b/ScoutSuite/output/data/inc-scoutsuite/css/scoutsuite-dark.css
@@ -118,3 +118,7 @@ span.slider.round {
     color: #fff;
     margin-right: 5px;
 }
+
+.disabled-link a .finding-title {
+    color: rgb(173, 173, 173) !important;
+}


### PR DESCRIPTION
Implements https://github.com/nccgroup/ScoutSuite/issues/422, only working for light theme for some reason.

Light:

![sc_2019-06-10_09h45m27s](https://user-images.githubusercontent.com/4206926/59180268-c33c2500-8b64-11e9-8429-053467b710e7.jpg)

Dark:

![sc_2019-06-10_09h45m35s](https://user-images.githubusercontent.com/4206926/59180261-bfa89e00-8b64-11e9-92b1-5b5724af61df.jpg)
