### PR TITLE
Fix for https://github.com/nccgroup/ScoutSuite/issues/448

### DIFF
--- a/ScoutSuite/core/console.py
+++ b/ScoutSuite/core/console.py
@@ -1,10 +1,10 @@
+import logging
 import os
 import sys
 import traceback
 
+import coloredlogs
 from six.moves import input
-
-import coloredlogs, logging
 
 from ScoutSuite import ERRORS_LIST
 
@@ -15,23 +15,25 @@ from ScoutSuite import ERRORS_LIST
 verbose_exceptions = False
 logger = logging.getLogger('scout')
 
+
 def set_logger_configuration(is_debug=False, quiet=False, output_file_path=None):
     """
     Configure whether full stacktraces should be dumped in the console output
     """
+
+    # set debug level
     global verbose_exceptions
     verbose_exceptions = is_debug
 
     # if "quiet" is set, don't output anything
-    if not quiet:
-        coloredlogs.install(level='DEBUG' if is_debug else 'INFO', logger=logger)
+    if quiet:
+        coloredlogs.install(level='ERROR', logger=logger)
     else:
-        coloredlogs.install(level='CRITICAL', logger=logger)  # we don't use critical so should never output
+        coloredlogs.install(level='DEBUG' if is_debug else 'INFO', logger=logger)
 
     if output_file_path:
         # create file handler which logs messages
         fh = logging.FileHandler(output_file_path, 'w+')
-        fh.setLevel(logging.DEBUG if is_debug else logging.INFO)
         # create formatter and add it to the handlers
         formatter = logging.Formatter(fmt='%(asctime)s %(hostname)s %(name)s[%(process)d] %(levelname)s %(message)s',
                                       datefmt='%Y-%m-%d %H:%M:%S')
@@ -57,7 +59,6 @@ def print_error(msg):
 
 
 def print_exception(exception, additional_details=None):
-
     try:
         exc_type, exc_obj, exc_tb = sys.exc_info()
         file_name = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
@@ -70,7 +71,6 @@ def print_exception(exception, additional_details=None):
         traceback_exc = None
         str = '{}'.format(exception)
 
-    global verbose_exceptions
     if verbose_exceptions:
         logger.exception(str)
     else:
@@ -84,7 +84,6 @@ def print_exception(exception, additional_details=None):
 
 
 def print_info(msg):
-
     print_generic(msg)
 
 

--- a/ScoutSuite/core/console.py
+++ b/ScoutSuite/core/console.py
@@ -21,9 +21,12 @@ def set_logger_configuration(is_debug=False, quiet=False, output_file_path=None)
     """
     global verbose_exceptions
     verbose_exceptions = is_debug
+
     # if "quiet" is set, don't output anything
     if not quiet:
         coloredlogs.install(level='DEBUG' if is_debug else 'INFO', logger=logger)
+    else:
+        coloredlogs.install(level='CRITICAL', logger=logger)  # we don't use critical so should never output
 
     if output_file_path:
         # create file handler which logs messages


### PR DESCRIPTION
Tweaks the behavior:
- The stdout and file log file logs **need to** have the same level
  - This is necessary because a sublogger (file log) can't have a lower level of logging than the parent (stdout). So for example if the `--quiet` flag is used, then you can't disable stdout output but still have 'INFO' level logging in the file
- If `--quiet` is used, will set the output to `ERROR` (both in stdout and file). Otherwise will be `INFO` (unless `--debug` is set).
- Having both `--quiet` and `--debug` will output only `ERROR` level, but will include stack trace.
