### PR TITLE
Added hosted zones and removed regions from route53

### DIFF
--- a/ScoutSuite/providers/aws/facade/route53.py
+++ b/ScoutSuite/providers/aws/facade/route53.py
@@ -4,9 +4,21 @@ from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 
 
 class Route53Facade(AWSBaseFacade):
-    async def get_domains(self, region):
+    async def get_domains(self):
         try:
-            return await AWSFacadeUtils.get_all_pages('route53domains', region, self.session, 'list_domains', 'Domains')
+            return await AWSFacadeUtils.get_all_pages('route53domains', None, self.session, 'list_domains', 'Domains')
         except Exception as e:
             print_exception('Failed to get Route53 domains: {}'.format(e))
             return []
+
+    async def get_hosted_zones(self):
+        try:
+            return await AWSFacadeUtils.get_all_pages('route53', None, self.session, 'list_hosted_zones', 'HostedZones')
+        except Exception as e:
+            print_exception('Failed to get Route53 hosted zones: {}'.format(e))
+
+    async def get_resource_records(self, hosted_zone_id):
+        try:
+            return await AWSFacadeUtils.get_all_pages('route53', None, self.session, 'list_resource_record_sets', 'ResourceRecordSets', HostedZoneId=hosted_zone_id, MaxItems='99999')
+        except Exception as e:
+            print_exception('Failed to get Route53 resource records: {}'.format(e))

--- a/ScoutSuite/providers/aws/facade/route53.py
+++ b/ScoutSuite/providers/aws/facade/route53.py
@@ -6,7 +6,7 @@ from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 class Route53Facade(AWSBaseFacade):
     async def get_domains(self):
         try:
-            return await AWSFacadeUtils.get_all_pages('route53domains', None, self.session, 'list_domains', 'Domains')
+            return await AWSFacadeUtils.get_all_pages('route53domains', 'us-east-1', self.session, 'list_domains', 'Domains')
         except Exception as e:
             print_exception('Failed to get Route53 domains: {}'.format(e))
             return []

--- a/ScoutSuite/providers/aws/resources/route53/base.py
+++ b/ScoutSuite/providers/aws/resources/route53/base.py
@@ -1,16 +1,12 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
-from ScoutSuite.providers.aws.resources.regions import Regions
+from ScoutSuite.providers.aws.resources.base import AWSCompositeResources
 from ScoutSuite.providers.aws.resources.base import AWSResources
 from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class Route53Domains(AWSResources):
-    def __init__(self, facade: AWSFacade, region: str):
-        super(Route53Domains, self).__init__(facade)
-        self.region = region
-
     async def fetch_all(self):
-        raw_domains = await self.facade.route53.get_domains(self.region)
+        raw_domains = await self.facade.route53.get_domains()
         for raw_domain in raw_domains:
             id, domain = self._parse_domain(raw_domain)
             self[id] = domain
@@ -21,10 +17,31 @@ class Route53Domains(AWSResources):
         return domain_id, raw_domain
 
 
-class Route53(Regions):
+class Route53HostedZones(AWSResources):
+    async def fetch_all(self):
+        raw_hosted_zones = await self.facade.route53.get_hosted_zones()
+        for raw_hosted_zone in raw_hosted_zones:
+            hosted_zone_id, hosted_zone = await self._parse_hosted_zone(raw_hosted_zone)
+            self[hosted_zone_id] = hosted_zone
+
+    async def _parse_hosted_zone(self, raw_hosted_zone):
+        hosted_zone_id = raw_hosted_zone.pop('Id')
+        raw_hosted_zone['name'] = raw_hosted_zone.pop('Name')
+        raw_hosted_zone['id'] = hosted_zone_id
+        resource_records = await self.facade.route53.get_resource_records(hosted_zone_id)
+        raw_hosted_zone['ResourceRecordSets'] = resource_records
+        return hosted_zone_id, raw_hosted_zone
+
+
+class Route53(AWSCompositeResources):
     _children = [
-        (Route53Domains, 'domains')
+        (Route53Domains, 'domains'),
+        (Route53HostedZones, 'hosted_zones')
     ]
 
     def __init__(self, facade: AWSFacade):
-        super(Route53, self).__init__('route53domains', facade)
+        super(Route53, self).__init__(facade)
+        self.service = 'route53'
+
+    async def fetch_all(self, regions=None, partition_name='aws'):
+        await self._fetch_children(self)

--- a/ScoutSuite/providers/aws/rules/findings/route53-domain-no-autorenew.json
+++ b/ScoutSuite/providers/aws/rules/findings/route53-domain-no-autorenew.json
@@ -1,7 +1,7 @@
 {
     "dashboard_name": "Domains",
     "description": "Domain not set to autorenew",
-    "path": "route53.regions.id.domains.id",
+    "path": "route53.domains.id",
     "conditions": [ "and",
         [ "AutoRenew", "false", "" ]
     ],

--- a/ScoutSuite/providers/aws/rules/findings/route53-domain-no-transferlock.json
+++ b/ScoutSuite/providers/aws/rules/findings/route53-domain-no-transferlock.json
@@ -1,7 +1,7 @@
 {
     "dashboard_name": "Domains",
     "description": "Domain transfer not locked",
-    "path": "route53.regions.id.domains.id",
+    "path": "route53.domains.id",
     "conditions": [ "and",
         [ "TransferLock", "false", "" ]
     ],

--- a/ScoutSuite/providers/aws/rules/findings/route53-domain-transferlock-not-authorized.json
+++ b/ScoutSuite/providers/aws/rules/findings/route53-domain-transferlock-not-authorized.json
@@ -1,7 +1,7 @@
 {
     "dashboard_name": "Domains",
     "description": "Domain transfer lock not supported by TLD",
-    "path": "route53.regions.id.domains.id",
+    "path": "route53.domains.id",
     "conditions": [ "and",
         [ "name", "match", [".*\\.io", ".*\\.co.nz"] ]
     ],


### PR DESCRIPTION
As per #473, this PR adds the hosted zones resource back into ScoutSuite for Route53.

While I was doing this, i also realised that the `Route53` config class was inheriting from `ScoutSuite.providers.aws.resources.regions.Regions`, which didn't make sense since Route53 is a service that has no region selection. However I also realised that for domains specifically, there is no global endpoint but only one regional endpoint, which is `us-east-1`, which was probably the reason why the domains were placed under `us-east-1` Nonetheless, it is essentially a global service and it makes more sense to place it as a global service. 

With this PR, the `Route53` config class was changed to inherit from `AWSCompositeResources` instead. This means that both the domains and the newly added hosted zones will not be classified as resources under the `us-east-1` region.

If I recall correctly, domains were also previously classified as global services. Do let me know if there are any problems with classifying them as a global service. Hosted zones are most definitely global as the api endpoint for it is also global. 