### PR TITLE
Enhancement: Exclude regions from execution

### DIFF
--- a/ScoutSuite/__main__.py
+++ b/ScoutSuite/__main__.py
@@ -51,6 +51,7 @@ def run_from_cli():
                    host_port=args.get('host_port'),
                    max_workers=args.get('max_workers'),
                    regions=args.get('regions'),
+                   excluded_regions=args.get('excluded_regions'),
                    fetch_local=args.get('fetch_local'), update=args.get('update'),
                    ip_ranges=args.get('ip_ranges'), ip_ranges_name_key=args.get('ip_ranges_name_key'),
                    ruleset=args.get('ruleset'), exceptions=args.get('exceptions'),
@@ -85,6 +86,7 @@ def run(provider,
         database_name=None, host_ip='127.0.0.1', host_port=8000,
         max_workers=10,
         regions=[],
+        excluded_regions=[],
         fetch_local=False, update=False,
         ip_ranges=[], ip_ranges_name_key='name',
         ruleset='default.json', exceptions=None,
@@ -124,6 +126,7 @@ async def _run(provider,
                result_format,
                database_name, host_ip, host_port,
                regions,
+               excluded_regions,
                fetch_local, update,
                ip_ranges, ip_ranges_name_key,
                ruleset, exceptions,
@@ -201,7 +204,7 @@ async def _run(provider,
         # Fetch data from provider APIs
         try:
             print_info('Gathering data from APIs')
-            await cloud_provider.fetch(regions=regions)
+            await cloud_provider.fetch(regions=regions, excluded_regions=excluded_regions)
         except KeyboardInterrupt:
             print_info('\nCancelled by user')
             return 130
@@ -263,6 +266,7 @@ async def _run(provider,
         'services': services,
         'skipped_services': skipped_services,
         'regions': regions,
+        'excluded_regions': excluded_regions,
     }
     # Finalize
     cloud_provider.postprocessing(report.current_time, finding_rules, run_parameters)

--- a/ScoutSuite/core/cli_parser.py
+++ b/ScoutSuite/core/cli_parser.py
@@ -53,6 +53,12 @@ class ScoutSuiteArgumentParser:
                                            default=[],
                                            nargs='+',
                                            help='Name of regions to run the tool in, defaults to all')
+        aws_additional_parser.add_argument('-xr',
+                                           '--excluded-regions',
+                                           dest='excluded_regions',
+                                           default=[],
+                                           nargs='+',
+                                           help='Name of regions to excluded from execution')
         aws_additional_parser.add_argument('--ip-ranges',
                                            dest='ip_ranges',
                                            default=[],
@@ -278,7 +284,7 @@ class ScoutSuiteArgumentParser:
                             dest='services',
                             default=[],
                             nargs='+',
-                            help='Name of in-scope services.')
+                            help='Name of in-scope services, defaults to all.')
         parser.add_argument('--skip',
                             dest='skipped_services',
                             default=[],

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -366,32 +366,33 @@ class AWSProvider(BaseProvider):
                 s3_info, bucket_name, iam_entity, allowed_iam_entity, policy_info)
 
     def _update_iam_permissions(self, s3_info, bucket_name, iam_entity, allowed_iam_entity, policy_info):
-        if bucket_name != '*' and bucket_name in s3_info['buckets']:
-            bucket = s3_info['buckets'][bucket_name]
-            manage_dictionary(bucket, iam_entity, {})
-            manage_dictionary(bucket, iam_entity + '_count', 0)
-            if allowed_iam_entity not in bucket[iam_entity]:
-                bucket[iam_entity][allowed_iam_entity] = {}
-                bucket[iam_entity + '_count'] = bucket[iam_entity + '_count'] + 1
+        if self.services.get('s3') and self.services.get('iam'):  # validate both services were included in run
+            if bucket_name != '*' and bucket_name in s3_info['buckets']:
+                bucket = s3_info['buckets'][bucket_name]
+                manage_dictionary(bucket, iam_entity, {})
+                manage_dictionary(bucket, iam_entity + '_count', 0)
+                if allowed_iam_entity not in bucket[iam_entity]:
+                    bucket[iam_entity][allowed_iam_entity] = {}
+                    bucket[iam_entity + '_count'] = bucket[iam_entity + '_count'] + 1
 
-            if 'inline_policies' in policy_info:
-                manage_dictionary(
-                    bucket[iam_entity][allowed_iam_entity], 'inline_policies', {})
-                bucket[iam_entity][allowed_iam_entity]['inline_policies'].update(
-                    policy_info['inline_policies'])
-            if 'policies' in policy_info:
-                manage_dictionary(bucket[iam_entity]
-                                  [allowed_iam_entity], 'policies', {})
-                bucket[iam_entity][allowed_iam_entity]['policies'].update(
-                    policy_info['policies'])
-        elif bucket_name == '*':
-            for bucket in s3_info['buckets']:
-                self._update_iam_permissions(
-                    s3_info, bucket, iam_entity, allowed_iam_entity, policy_info)
-            pass
-        else:
-            # Could be an error or cross-account access, ignore
-            pass
+                if 'inline_policies' in policy_info:
+                    manage_dictionary(
+                        bucket[iam_entity][allowed_iam_entity], 'inline_policies', {})
+                    bucket[iam_entity][allowed_iam_entity]['inline_policies'].update(
+                        policy_info['inline_policies'])
+                if 'policies' in policy_info:
+                    manage_dictionary(bucket[iam_entity]
+                                      [allowed_iam_entity], 'policies', {})
+                    bucket[iam_entity][allowed_iam_entity]['policies'].update(
+                        policy_info['policies'])
+            elif bucket_name == '*':
+                for bucket in s3_info['buckets']:
+                    self._update_iam_permissions(
+                        s3_info, bucket, iam_entity, allowed_iam_entity, policy_info)
+                pass
+            else:
+                # Could be an error or cross-account access, ignore
+                pass
 
     def match_network_acls_and_subnets_callback(self, current_config, path, current_path, acl_id, callback_args):
         for association in current_config['Associations']:

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -1,7 +1,7 @@
 import copy
 import os
 
-from ScoutSuite.core.console import print_debug, print_error, print_exception, print_info
+from ScoutSuite.core.console import print_debug, print_error, print_exception
 from ScoutSuite.providers.aws.services import AWSServicesConfig
 from ScoutSuite.providers.aws.resources.vpc.base import put_cidr_name
 from ScoutSuite.providers.aws.utils import ec2_classic, get_aws_account_id
@@ -192,7 +192,6 @@ class AWSProvider(BaseProvider):
 
     @staticmethod
     def _process_cloudtrail_trails(cloudtrail_config):
-        print_info('Processing CloudTrail config')
         global_events_logging = []
         data_logging_trails_count = 0
         for region in cloudtrail_config['regions']:
@@ -402,38 +401,39 @@ class AWSProvider(BaseProvider):
             subnet['network_acl'] = acl_id
 
     def match_instances_and_subnets_callback(self, current_config, path, current_path, instance_id, callback_args):
-        subnet_id = current_config['SubnetId']
-        if subnet_id:
-            vpc = self.subnet_map[subnet_id]
-            subnet = self.services['vpc']['regions'][vpc['region']
-            ]['vpcs'][vpc['vpc_id']]['subnets'][subnet_id]
-            manage_dictionary(subnet, 'instances', [])
-            if instance_id not in subnet['instances']:
-                subnet['instances'].append(instance_id)
+        if self.services.get('ec2') and self.services.get('vpc'):  # validate both services were included in run
+            subnet_id = current_config['SubnetId']
+            if subnet_id:
+                vpc = self.subnet_map[subnet_id]
+                subnet = self.services['vpc']['regions'][vpc['region']
+                ]['vpcs'][vpc['vpc_id']]['subnets'][subnet_id]
+                manage_dictionary(subnet, 'instances', [])
+                if instance_id not in subnet['instances']:
+                    subnet['instances'].append(instance_id)
 
     def _match_instances_and_roles(self):
-        print_info('Matching EC2 instances and IAM roles')
-        ec2_config = self.services['ec2']
-        iam_config = self.services['iam']
-        role_instances = {}
-        for r in ec2_config['regions']:
-            for v in ec2_config['regions'][r]['vpcs']:
-                if 'instances' in ec2_config['regions'][r]['vpcs'][v]:
-                    for i in ec2_config['regions'][r]['vpcs'][v]['instances']:
-                        instance_profile = ec2_config['regions'][r]['vpcs'][v]['instances'][i]['IamInstanceProfile']
-                        instance_profile_id = instance_profile['Id'] if instance_profile else None
-                        if instance_profile_id:
-                            manage_dictionary(
-                                role_instances, instance_profile_id, [])
-                            role_instances[instance_profile_id].append(i)
-        for role_id in iam_config['roles']:
-            iam_config['roles'][role_id]['instances_count'] = 0
-            for instance_profile_id in iam_config['roles'][role_id]['instance_profiles']:
-                if instance_profile_id in role_instances:
-                    iam_config['roles'][role_id]['instance_profiles'][instance_profile_id]['instances'] = \
-                        role_instances[instance_profile_id]
-                    iam_config['roles'][role_id]['instances_count'] += len(
-                        role_instances[instance_profile_id])
+        if self.services.get('ec2') and self.services.get('iam'):  # validate both services were included in run
+            ec2_config = self.services['ec2']
+            iam_config = self.services['iam']
+            role_instances = {}
+            for r in ec2_config['regions']:
+                for v in ec2_config['regions'][r]['vpcs']:
+                    if 'instances' in ec2_config['regions'][r]['vpcs'][v]:
+                        for i in ec2_config['regions'][r]['vpcs'][v]['instances']:
+                            instance_profile = ec2_config['regions'][r]['vpcs'][v]['instances'][i]['IamInstanceProfile']
+                            instance_profile_id = instance_profile['Id'] if instance_profile else None
+                            if instance_profile_id:
+                                manage_dictionary(
+                                    role_instances, instance_profile_id, [])
+                                role_instances[instance_profile_id].append(i)
+            for role_id in iam_config['roles']:
+                iam_config['roles'][role_id]['instances_count'] = 0
+                for instance_profile_id in iam_config['roles'][role_id]['instance_profiles']:
+                    if instance_profile_id in role_instances:
+                        iam_config['roles'][role_id]['instance_profiles'][instance_profile_id]['instances'] = \
+                            role_instances[instance_profile_id]
+                        iam_config['roles'][role_id]['instances_count'] += len(
+                            role_instances[instance_profile_id])
 
     def process_vpc_peering_connections_callback(self, current_config, path, current_path, pc_id, callback_args):
 

--- a/ScoutSuite/providers/aws/resources/awslambda/base.py
+++ b/ScoutSuite/providers/aws/resources/awslambda/base.py
@@ -1,22 +1,7 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.regions import Regions
-from ScoutSuite.providers.aws.resources.base import AWSResources
 
-
-class Functions(AWSResources):
-    def __init__(self, facade: AWSFacade, region: str):
-        super(Functions, self).__init__(facade)
-        self.region = region
-
-    async def fetch_all(self):
-        raw_functions = await self.facade.awslambda.get_functions(self.region)
-        for raw_function in raw_functions:
-            name, resource = self._parse_function(raw_function)
-            self[name] = resource
-
-    def _parse_function(self, raw_function):
-        raw_function['name'] = raw_function.pop('FunctionName')
-        return raw_function['name'], raw_function
+from .functions import Functions
 
 
 class Lambdas(Regions):

--- a/ScoutSuite/providers/aws/resources/awslambda/functions.py
+++ b/ScoutSuite/providers/aws/resources/awslambda/functions.py
@@ -1,0 +1,18 @@
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSResources
+
+
+class Functions(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super(Functions, self).__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        raw_functions = await self.facade.awslambda.get_functions(self.region)
+        for raw_function in raw_functions:
+            name, resource = self._parse_function(raw_function)
+            self[name] = resource
+
+    def _parse_function(self, raw_function):
+        raw_function['name'] = raw_function.pop('FunctionName')
+        return raw_function['name'], raw_function

--- a/ScoutSuite/providers/aws/resources/cloudformation/base.py
+++ b/ScoutSuite/providers/aws/resources/cloudformation/base.py
@@ -1,63 +1,6 @@
-import re
-
-from ScoutSuite.providers.aws.resources.regions import Regions
-from ScoutSuite.providers.aws.resources.base import AWSResources
 from ScoutSuite.providers.aws.facade.base import AWSFacade
-
-
-class Stacks(AWSResources):
-    def __init__(self, facade: AWSFacade, region: str):
-        super(Stacks, self).__init__(facade)
-        self.region = region
-
-    async def fetch_all(self):
-        raw_stacks = await self.facade.cloudformation.get_stacks(self.region)
-        for raw_stack in raw_stacks:
-            name, stack = self._parse_stack(raw_stack)
-            self[name] = stack
-
-    def _parse_stack(self, raw_stack):
-        raw_stack['id'] = raw_stack.pop('StackId')
-        raw_stack['name'] = raw_stack.pop('StackName')
-        raw_stack['drifted'] = raw_stack.pop('DriftInformation')[
-            'StackDriftStatus'] == 'DRIFTED'
-        raw_stack['termination_protection'] = raw_stack['EnableTerminationProtection']
-
-        template = raw_stack.pop('template')
-        raw_stack['deletion_policy'] = self.has_deletion_policy(template)
-
-        if hasattr(template, 'keys'):
-            for group in template.keys():
-                if 'DeletionPolicy' in template[group]:
-                    raw_stack['deletion_policy'] = template[group]['DeletionPolicy']
-                    break
-
-        return raw_stack['name'], raw_stack
-
-    @staticmethod
-    def has_deletion_policy(template):
-        """
-        Return region to be used for global calls such as list bucket and get bucket location
-        :param template:                    The api response containing the stack's template
-        :return:
-        """
-        has_dp = True
-        # If a ressource is found to not have a deletion policy or have it to delete, the boolean is switched to
-        # false to indicate that the ressource will be deleted once the stack is deleted
-        if isinstance(template, dict):
-            template = template['Resources']
-            for group in template.keys():
-                if 'DeletionPolicy' in template[group]:
-                    if template[group]['DeletionPolicy'] == 'Delete':
-                        has_dp = False
-                else:
-                    has_dp = False
-        if isinstance(template, str):
-            if re.match(r'\"DeletionPolicy\"\s*:\s*\"Delete\"', template):
-                has_dp = False
-            elif not re.match(r'\"DeletionPolicy\"', template):
-                has_dp = False
-        return has_dp
+from ScoutSuite.providers.aws.resources.regions import Regions
+from .stacks import Stacks
 
 
 class CloudFormation(Regions):

--- a/ScoutSuite/providers/aws/resources/cloudformation/stacks.py
+++ b/ScoutSuite/providers/aws/resources/cloudformation/stacks.py
@@ -1,0 +1,59 @@
+import re
+
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSResources
+
+
+class Stacks(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super(Stacks, self).__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        raw_stacks = await self.facade.cloudformation.get_stacks(self.region)
+        for raw_stack in raw_stacks:
+            name, stack = self._parse_stack(raw_stack)
+            self[name] = stack
+
+    def _parse_stack(self, raw_stack):
+        raw_stack['id'] = raw_stack.pop('StackId')
+        raw_stack['name'] = raw_stack.pop('StackName')
+        raw_stack['drifted'] = raw_stack.pop('DriftInformation')[
+                                   'StackDriftStatus'] == 'DRIFTED'
+        raw_stack['termination_protection'] = raw_stack['EnableTerminationProtection']
+
+        template = raw_stack.pop('template')
+        raw_stack['deletion_policy'] = self.has_deletion_policy(template)
+
+        if hasattr(template, 'keys'):
+            for group in template.keys():
+                if 'DeletionPolicy' in template[group]:
+                    raw_stack['deletion_policy'] = template[group]['DeletionPolicy']
+                    break
+
+        return raw_stack['name'], raw_stack
+
+    @staticmethod
+    def has_deletion_policy(template):
+        """
+        Return region to be used for global calls such as list bucket and get bucket location
+        :param template:                    The api response containing the stack's template
+        :return:
+        """
+        has_dp = True
+        # If a ressource is found to not have a deletion policy or have it to delete, the boolean is switched to
+        # false to indicate that the ressource will be deleted once the stack is deleted
+        if isinstance(template, dict):
+            template = template['Resources']
+            for group in template.keys():
+                if 'DeletionPolicy' in template[group]:
+                    if template[group]['DeletionPolicy'] == 'Delete':
+                        has_dp = False
+                else:
+                    has_dp = False
+        if isinstance(template, str):
+            if re.match(r'\"DeletionPolicy\"\s*:\s*\"Delete\"', template):
+                has_dp = False
+            elif not re.match(r'\"DeletionPolicy\"', template):
+                has_dp = False
+        return has_dp

--- a/ScoutSuite/providers/aws/resources/cloudtrail/base.py
+++ b/ScoutSuite/providers/aws/resources/cloudtrail/base.py
@@ -1,71 +1,7 @@
-import time
-
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.regions import Regions
-from ScoutSuite.providers.aws.resources.base import AWSResources
-from ScoutSuite.providers.utils import get_non_provider_id
 
-
-class Trails(AWSResources):
-    def __init__(self, facade: AWSFacade, region: str):
-        super(Trails, self).__init__(facade)
-        self.region = region
-
-    async def fetch_all(self):
-        raw_trails = await self.facade.cloudtrail.get_trails(self.region)
-        for raw_trail in raw_trails:
-            name, resource = self._parse_trail(raw_trail)
-            self[name] = resource
-
-    def _parse_trail(self, raw_trail):
-        trail = {'name': raw_trail.pop('Name')}
-        trail_id = get_non_provider_id(trail['name'])
-
-        # Do not duplicate entries for multiregion trails
-        if 'IsMultiRegionTrail' in raw_trail and raw_trail['IsMultiRegionTrail'] and \
-                raw_trail['HomeRegion'] != self.region:
-            for key in ['HomeRegion', 'TrailARN']:
-                trail[key] = raw_trail[key]
-            trail['scout_link'] = 'services.cloudtrail.regions.%s.trails.%s' % (raw_trail['HomeRegion'], trail_id)
-            return trail_id, trail
-
-        for key in raw_trail:
-            trail[key] = raw_trail[key]
-        trail['bucket_id'] = get_non_provider_id(trail.pop('S3BucketName'))
-        for key in ['IsMultiRegionTrail', 'LogFileValidationEnabled']:
-            if key not in trail:
-                trail[key] = False
-                
-        for key in ['KMSKeyId', 'IsLogging', 'LatestDeliveryTime', 'LatestDeliveryError', 'StartLoggingTime',
-                    'StopLoggingTime', 'LatestNotificationTime', 'LatestNotificationError',
-                    'LatestCloudWatchLogsDeliveryError', 'LatestCloudWatchLogsDeliveryTime']:
-            trail[key] = trail[key] if key in trail else None
-
-        # using trail ARN instead of name as with Organizations the trail would be located in another account
-        trail['wildcard_data_logging'] = self.data_logging_status(trail)
-
-        for event_selector in trail['EventSelectors']:
-            trail['DataEventsEnabled'] = len(event_selector['DataResources']) > 0
-            trail['ManagementEventsEnabled'] = event_selector['IncludeManagementEvents']
-            
-        return trail_id, trail
-
-    def data_logging_status(self, trail):
-        for event_selector in trail['EventSelectors']:
-            has_wildcard =\
-                {u'Values': [u'arn:aws:s3:::'], u'Type': u'AWS::S3::Object'} in event_selector['DataResources']
-            is_logging = trail['IsLogging']
-
-            if has_wildcard and is_logging and self.is_fresh(trail):
-                return True
-
-        return False
-
-    @staticmethod
-    def is_fresh(trail_details):
-        delivery_time = trail_details.get('LatestCloudWatchLogsDeliveryTime', "9999999").strftime("%s")
-        delivery_age = ((int(time.time()) - int(delivery_time)) / 1440)
-        return delivery_age <= 24
+from .trails import Trails
 
 
 class CloudTrail(Regions):

--- a/ScoutSuite/providers/aws/resources/cloudtrail/trails.py
+++ b/ScoutSuite/providers/aws/resources/cloudtrail/trails.py
@@ -1,0 +1,67 @@
+import time
+
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
+
+
+class Trails(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super(Trails, self).__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        raw_trails = await self.facade.cloudtrail.get_trails(self.region)
+        for raw_trail in raw_trails:
+            name, resource = self._parse_trail(raw_trail)
+            self[name] = resource
+
+    def _parse_trail(self, raw_trail):
+        trail = {'name': raw_trail.pop('Name')}
+        trail_id = get_non_provider_id(trail['name'])
+
+        # Do not duplicate entries for multiregion trails
+        if 'IsMultiRegionTrail' in raw_trail and raw_trail['IsMultiRegionTrail'] and \
+                raw_trail['HomeRegion'] != self.region:
+            for key in ['HomeRegion', 'TrailARN']:
+                trail[key] = raw_trail[key]
+            trail['scout_link'] = 'services.cloudtrail.regions.%s.trails.%s' % (raw_trail['HomeRegion'], trail_id)
+            return trail_id, trail
+
+        for key in raw_trail:
+            trail[key] = raw_trail[key]
+        trail['bucket_id'] = get_non_provider_id(trail.pop('S3BucketName'))
+        for key in ['IsMultiRegionTrail', 'LogFileValidationEnabled']:
+            if key not in trail:
+                trail[key] = False
+
+        for key in ['KMSKeyId', 'IsLogging', 'LatestDeliveryTime', 'LatestDeliveryError', 'StartLoggingTime',
+                    'StopLoggingTime', 'LatestNotificationTime', 'LatestNotificationError',
+                    'LatestCloudWatchLogsDeliveryError', 'LatestCloudWatchLogsDeliveryTime']:
+            trail[key] = trail[key] if key in trail else None
+
+        # using trail ARN instead of name as with Organizations the trail would be located in another account
+        trail['wildcard_data_logging'] = self.data_logging_status(trail)
+
+        for event_selector in trail['EventSelectors']:
+            trail['DataEventsEnabled'] = len(event_selector['DataResources']) > 0
+            trail['ManagementEventsEnabled'] = event_selector['IncludeManagementEvents']
+
+        return trail_id, trail
+
+    def data_logging_status(self, trail):
+        for event_selector in trail['EventSelectors']:
+            has_wildcard = \
+                {u'Values': [u'arn:aws:s3:::'], u'Type': u'AWS::S3::Object'} in event_selector['DataResources']
+            is_logging = trail['IsLogging']
+
+            if has_wildcard and is_logging and self.is_fresh(trail):
+                return True
+
+        return False
+
+    @staticmethod
+    def is_fresh(trail_details):
+        delivery_time = trail_details.get('LatestCloudWatchLogsDeliveryTime', "9999999").strftime("%s")
+        delivery_age = ((int(time.time()) - int(delivery_time)) / 1440)
+        return delivery_age <= 24

--- a/ScoutSuite/providers/aws/resources/cloudwatch/alarms.py
+++ b/ScoutSuite/providers/aws/resources/cloudwatch/alarms.py
@@ -1,0 +1,27 @@
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
+
+
+class Alarms(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super(Alarms, self).__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        raw_alarms = await self.facade.cloudwatch.get_alarms(self.region)
+        for raw_alarm in raw_alarms:
+            name, resource = self._parse_alarm(raw_alarm)
+            self[name] = resource
+
+    def _parse_alarm(self, raw_alarm):
+        raw_alarm['arn'] = raw_alarm.pop('AlarmArn')
+        raw_alarm['name'] = raw_alarm.pop('AlarmName')
+
+        # Drop some data
+        for key in ['AlarmConfigurationUpdatedTimestamp', 'StateReason', 'StateReasonData', 'StateUpdatedTimestamp']:
+            if key in raw_alarm:
+                raw_alarm.pop(key)
+
+        alarm_id = get_non_provider_id(raw_alarm['arn'])
+        return alarm_id, raw_alarm

--- a/ScoutSuite/providers/aws/resources/cloudwatch/base.py
+++ b/ScoutSuite/providers/aws/resources/cloudwatch/base.py
@@ -1,32 +1,7 @@
-from ScoutSuite.providers.aws.resources.regions import Regions
-from ScoutSuite.providers.aws.resources.base import AWSResources
-
-from ScoutSuite.providers.utils import get_non_provider_id
 from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.regions import Regions
 
-
-class Alarms(AWSResources):
-    def __init__(self, facade: AWSFacade, region: str):
-        super(Alarms, self).__init__(facade)
-        self.region = region
-
-    async def fetch_all(self):
-        raw_alarms = await self.facade.cloudwatch.get_alarms(self.region)
-        for raw_alarm in raw_alarms:
-            name, resource = self._parse_alarm(raw_alarm)
-            self[name] = resource
-
-    def _parse_alarm(self, raw_alarm):
-        raw_alarm['arn'] = raw_alarm.pop('AlarmArn')
-        raw_alarm['name'] = raw_alarm.pop('AlarmName')
-
-        # Drop some data
-        for key in ['AlarmConfigurationUpdatedTimestamp', 'StateReason', 'StateReasonData', 'StateUpdatedTimestamp']:
-            if key in raw_alarm:
-                raw_alarm.pop(key)
-
-        alarm_id = get_non_provider_id(raw_alarm['arn'])
-        return alarm_id, raw_alarm
+from .alarms import Alarms
 
 
 class CloudWatch(Regions):

--- a/ScoutSuite/providers/aws/resources/config/base.py
+++ b/ScoutSuite/providers/aws/resources/config/base.py
@@ -12,7 +12,3 @@ class Config(Regions):
 
     def __init__(self, facade: AWSFacade):
         super(Config, self).__init__('config', facade)
-
-    async def fetch_all(self, regions=None, partition_name='aws'):
-        await super(Config, self).fetch_all(regions, partition_name)
-

--- a/ScoutSuite/providers/aws/resources/directconnect/base.py
+++ b/ScoutSuite/providers/aws/resources/directconnect/base.py
@@ -1,23 +1,7 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.regions import Regions
-from ScoutSuite.providers.aws.resources.base import AWSResources
 
-
-class Connections(AWSResources):
-    def __init__(self, facade: AWSFacade, region: str):
-        super(Connections, self).__init__(facade)
-        self.region = region
-
-    async def fetch_all(self):
-        raw_connections = await self.facade.directconnect.get_connections(self.region)
-        for raw_connection in raw_connections:
-            name, resource = self._parse_connection(raw_connection)
-            self[name] = resource
-
-    def _parse_connection(self, raw_connection):
-        raw_connection['id'] = raw_connection.pop('connectionId')
-        raw_connection['name'] = raw_connection.pop('connectionName')
-        return raw_connection['id'], raw_connection
+from .connections import Connections
 
 
 class DirectConnect(Regions):

--- a/ScoutSuite/providers/aws/resources/directconnect/connections.py
+++ b/ScoutSuite/providers/aws/resources/directconnect/connections.py
@@ -1,0 +1,19 @@
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSResources
+
+
+class Connections(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super(Connections, self).__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        raw_connections = await self.facade.directconnect.get_connections(self.region)
+        for raw_connection in raw_connections:
+            name, resource = self._parse_connection(raw_connection)
+            self[name] = resource
+
+    def _parse_connection(self, raw_connection):
+        raw_connection['id'] = raw_connection.pop('connectionId')
+        raw_connection['name'] = raw_connection.pop('connectionName')
+        return raw_connection['id'], raw_connection

--- a/ScoutSuite/providers/aws/resources/ec2/base.py
+++ b/ScoutSuite/providers/aws/resources/ec2/base.py
@@ -16,7 +16,7 @@ class EC2(Regions):
     def __init__(self, facade):
         super(EC2, self).__init__('ec2', facade)
 
-    async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws'):
+    async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws', **kwargs):
         await super(EC2, self).fetch_all(regions, excluded_regions, partition_name)
 
         for region in self['regions']:

--- a/ScoutSuite/providers/aws/resources/ec2/base.py
+++ b/ScoutSuite/providers/aws/resources/ec2/base.py
@@ -16,8 +16,8 @@ class EC2(Regions):
     def __init__(self, facade):
         super(EC2, self).__init__('ec2', facade)
 
-    async def fetch_all(self, regions=None, partition_name='aws'):
-        await super(EC2, self).fetch_all(regions, partition_name)
+    async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws'):
+        await super(EC2, self).fetch_all(regions, excluded_regions, partition_name)
 
         for region in self['regions']:
             self['regions'][region]['instances_count'] =\

--- a/ScoutSuite/providers/aws/resources/efs/base.py
+++ b/ScoutSuite/providers/aws/resources/efs/base.py
@@ -1,26 +1,7 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
-from ScoutSuite.providers.aws.resources.base import AWSResources
 from ScoutSuite.providers.aws.resources.regions import Regions
 
-
-class FileSystems(AWSResources):
-    def __init__(self, facade: AWSFacade, region: str):
-        super(FileSystems, self).__init__(facade)
-        self.region = region
-
-    async def fetch_all(self):
-        raw_file_systems = await self.facade.efs.get_file_systems(self.region)
-        for raw_file_system in raw_file_systems:
-            name, resource = self._parse_file_system(raw_file_system)
-            self[name] = resource
-
-    def _parse_file_system(self, raw_file_system):
-        fs_id = raw_file_system.pop('FileSystemId')
-        raw_file_system['name'] = raw_file_system.pop('Name') if 'Name' in raw_file_system else None
-        raw_file_system['tags'] = raw_file_system.pop('Tags')
-        
-        return fs_id, raw_file_system
-
+from .filesystems import FileSystems
 
 
 class EFS(Regions):

--- a/ScoutSuite/providers/aws/resources/efs/filesystems.py
+++ b/ScoutSuite/providers/aws/resources/efs/filesystems.py
@@ -1,0 +1,21 @@
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSResources
+
+
+class FileSystems(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super(FileSystems, self).__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        raw_file_systems = await self.facade.efs.get_file_systems(self.region)
+        for raw_file_system in raw_file_systems:
+            name, resource = self._parse_file_system(raw_file_system)
+            self[name] = resource
+
+    def _parse_file_system(self, raw_file_system):
+        fs_id = raw_file_system.pop('FileSystemId')
+        raw_file_system['name'] = raw_file_system.pop('Name') if 'Name' in raw_file_system else None
+        raw_file_system['tags'] = raw_file_system.pop('Tags')
+
+        return fs_id, raw_file_system

--- a/ScoutSuite/providers/aws/resources/elasticache/base.py
+++ b/ScoutSuite/providers/aws/resources/elasticache/base.py
@@ -15,8 +15,8 @@ class ElastiCache(Regions):
     def __init__(self, facade: AWSFacade):
         super(ElastiCache, self).__init__('elasticache', facade)
 
-    async def fetch_all(self, regions=None, partition_name='aws'):
-        await super(ElastiCache, self).fetch_all(regions, partition_name)
+    async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws', **kwargs):
+        await super(ElastiCache, self).fetch_all(regions, excluded_regions, partition_name)
 
         for region in self['regions']:
             self['regions'][region]['clusters_count'] = \

--- a/ScoutSuite/providers/aws/resources/emr/base.py
+++ b/ScoutSuite/providers/aws/resources/emr/base.py
@@ -13,7 +13,7 @@ class EMR(Regions):
         super(EMR, self).__init__('emr', facade)
 
     async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws', **kwargs):
-        await super(EMR, self).fetch_all(regions, partition_name)
+        await super(EMR, self).fetch_all(regions, excluded_regions, partition_name)
 
         for region in self['regions']:
             self['regions'][region]['clusters_count'] = sum(

--- a/ScoutSuite/providers/aws/resources/emr/base.py
+++ b/ScoutSuite/providers/aws/resources/emr/base.py
@@ -1,41 +1,7 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.regions import Regions
-from ScoutSuite.providers.aws.resources.base import AWSCompositeResources, AWSResources
 
-
-class EMRClusters(AWSResources):
-    def __init__(self, facade: AWSFacade, region: str):
-        super(EMRClusters, self).__init__(facade)
-        self.region = region
-
-    async def fetch_all(self):
-        raw_clusters = await self.facade.emr.get_clusters(self.region)
-        for raw_cluster in raw_clusters:
-            name, resource = self._parse_cluster(raw_cluster)
-            self[name] = resource
-
-    def _parse_cluster(self, raw_cluster):
-        raw_cluster['id'] = raw_cluster.pop('Id')
-        raw_cluster['name'] = raw_cluster.pop('Name')
-        return raw_cluster['id'], raw_cluster
-
-
-class EMRVpcs(AWSCompositeResources):
-    _children = [
-        (EMRClusters, 'clusters')
-    ]
-
-    def __init__(self, facade: AWSFacade, region: str):
-        self.region = region
-
-        super(EMRVpcs, self).__init__(facade)
-
-    async def fetch_all(self):
-        # EMR won't disclose its VPC, so we put everything in a VPC named "EMR-UNKNOWN-VPC", and we
-        # infer the VPC afterwards during the preprocessing.
-        tmp_vpc = 'EMR-UNKNOWN-VPC'
-        self[tmp_vpc] = {}
-        await self._fetch_children(self[tmp_vpc], {'region': self.region})
+from .vpcs import EMRVpcs
 
 
 class EMR(Regions):
@@ -46,7 +12,7 @@ class EMR(Regions):
     def __init__(self, facade: AWSFacade):
         super(EMR, self).__init__('emr', facade)
 
-    async def fetch_all(self, regions=None, partition_name='aws'):
+    async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws'):
         await super(EMR, self).fetch_all(regions, partition_name)
 
         for region in self['regions']:

--- a/ScoutSuite/providers/aws/resources/emr/base.py
+++ b/ScoutSuite/providers/aws/resources/emr/base.py
@@ -12,7 +12,7 @@ class EMR(Regions):
     def __init__(self, facade: AWSFacade):
         super(EMR, self).__init__('emr', facade)
 
-    async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws'):
+    async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws', **kwargs):
         await super(EMR, self).fetch_all(regions, partition_name)
 
         for region in self['regions']:

--- a/ScoutSuite/providers/aws/resources/emr/clusters.py
+++ b/ScoutSuite/providers/aws/resources/emr/clusters.py
@@ -1,0 +1,19 @@
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSResources
+
+
+class EMRClusters(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super(EMRClusters, self).__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        raw_clusters = await self.facade.emr.get_clusters(self.region)
+        for raw_cluster in raw_clusters:
+            name, resource = self._parse_cluster(raw_cluster)
+            self[name] = resource
+
+    def _parse_cluster(self, raw_cluster):
+        raw_cluster['id'] = raw_cluster.pop('Id')
+        raw_cluster['name'] = raw_cluster.pop('Name')
+        return raw_cluster['id'], raw_cluster

--- a/ScoutSuite/providers/aws/resources/emr/vpcs.py
+++ b/ScoutSuite/providers/aws/resources/emr/vpcs.py
@@ -1,0 +1,22 @@
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSCompositeResources
+
+from .clusters import EMRClusters
+
+
+class EMRVpcs(AWSCompositeResources):
+    _children = [
+        (EMRClusters, 'clusters')
+    ]
+
+    def __init__(self, facade: AWSFacade, region: str):
+        self.region = region
+
+        super(EMRVpcs, self).__init__(facade)
+
+    async def fetch_all(self):
+        # EMR won't disclose its VPC, so we put everything in a VPC named "EMR-UNKNOWN-VPC", and we
+        # infer the VPC afterwards during the preprocessing.
+        tmp_vpc = 'EMR-UNKNOWN-VPC'
+        self[tmp_vpc] = {}
+        await self._fetch_children(self[tmp_vpc], {'region': self.region})

--- a/ScoutSuite/providers/aws/resources/iam/base.py
+++ b/ScoutSuite/providers/aws/resources/iam/base.py
@@ -22,7 +22,7 @@ class IAM(AWSCompositeResources):
         super(IAM, self).__init__(facade)
         self.service = 'iam'
 
-    async def fetch_all(self, regions=None, partition_name='aws', **kwargs):
+    async def fetch_all(self, partition_name='aws', **kwargs):
         await self._fetch_children(self)
 
         # We do not want the report to count the password policies as resources, they aren't really resources.

--- a/ScoutSuite/providers/aws/resources/iam/base.py
+++ b/ScoutSuite/providers/aws/resources/iam/base.py
@@ -22,7 +22,7 @@ class IAM(AWSCompositeResources):
         super(IAM, self).__init__(facade)
         self.service = 'iam'
 
-    async def fetch_all(self, regions=None, partition_name='aws'):
+    async def fetch_all(self, regions=None, partition_name='aws', **kwargs):
         await self._fetch_children(self)
 
         # We do not want the report to count the password policies as resources, they aren't really resources.

--- a/ScoutSuite/providers/aws/resources/rds/base.py
+++ b/ScoutSuite/providers/aws/resources/rds/base.py
@@ -15,8 +15,8 @@ class RDS(Regions):
     def __init__(self, facade: AWSFacade):
         super(RDS, self).__init__('rds', facade)
 
-    async def fetch_all(self, regions=None, partition_name='aws'):
-        await super(RDS, self).fetch_all(regions, partition_name)
+    async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws', **kwargs):
+        await super(RDS, self).fetch_all(regions, excluded_regions, partition_name)
 
         for region in self['regions']:
             self['regions'][region]['instances_count'] =\

--- a/ScoutSuite/providers/aws/resources/regions.py
+++ b/ScoutSuite/providers/aws/resources/regions.py
@@ -9,7 +9,7 @@ class Regions(AWSCompositeResources, metaclass=abc.ABCMeta):
         super(Regions, self).__init__(facade)
         self.service = service
 
-    async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws'):
+    async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws', **kwargs):
         self['regions'] = {}
         for region in await self.facade.build_region_list(self.service, regions, excluded_regions, partition_name):
             self['regions'][region] = {

--- a/ScoutSuite/providers/aws/resources/regions.py
+++ b/ScoutSuite/providers/aws/resources/regions.py
@@ -9,9 +9,9 @@ class Regions(AWSCompositeResources, metaclass=abc.ABCMeta):
         super(Regions, self).__init__(facade)
         self.service = service
 
-    async def fetch_all(self, regions=None, partition_name='aws'):
+    async def fetch_all(self, regions=None, excluded_regions=None, partition_name='aws'):
         self['regions'] = {}
-        for region in await self.facade.build_region_list(self.service, regions, partition_name):
+        for region in await self.facade.build_region_list(self.service, regions, excluded_regions, partition_name):
             self['regions'][region] = {
                 'id': region,
                 'region': region,

--- a/ScoutSuite/providers/aws/resources/route53/base.py
+++ b/ScoutSuite/providers/aws/resources/route53/base.py
@@ -1,29 +1,12 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.regions import Regions
-from ScoutSuite.providers.aws.resources.base import AWSResources
-from ScoutSuite.providers.utils import get_non_provider_id
 
-
-class Route53Domains(AWSResources):
-    def __init__(self, facade: AWSFacade, region: str):
-        super(Route53Domains, self).__init__(facade)
-        self.region = region
-
-    async def fetch_all(self):
-        raw_domains = await self.facade.route53.get_domains(self.region)
-        for raw_domain in raw_domains:
-            id, domain = self._parse_domain(raw_domain)
-            self[id] = domain
-
-    def _parse_domain(self, raw_domain):
-        domain_id = get_non_provider_id(raw_domain['DomainName'])
-        raw_domain['name'] = raw_domain.pop('DomainName')
-        return domain_id, raw_domain
+from .domains import Domains
 
 
 class Route53(Regions):
     _children = [
-        (Route53Domains, 'domains')
+        (Domains, 'domains')
     ]
 
     def __init__(self, facade: AWSFacade):

--- a/ScoutSuite/providers/aws/resources/route53/domains.py
+++ b/ScoutSuite/providers/aws/resources/route53/domains.py
@@ -1,0 +1,20 @@
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
+
+
+class Domains(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super(Domains, self).__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        raw_domains = await self.facade.route53.get_domains(self.region)
+        for raw_domain in raw_domains:
+            id, domain = self._parse_domain(raw_domain)
+            self[id] = domain
+
+    def _parse_domain(self, raw_domain):
+        domain_id = get_non_provider_id(raw_domain['DomainName'])
+        raw_domain['name'] = raw_domain.pop('DomainName')
+        return domain_id, raw_domain

--- a/ScoutSuite/providers/aws/resources/s3/base.py
+++ b/ScoutSuite/providers/aws/resources/s3/base.py
@@ -1,35 +1,6 @@
-from ScoutSuite.providers.aws.resources.base import AWSResources, AWSCompositeResources
-
-from ScoutSuite.providers.utils import get_non_provider_id
-
-
-class Buckets(AWSResources):
-    async def fetch_all(self):
-        raw_buckets = await self.facade.s3.get_buckets()
-        for raw_bucket in raw_buckets:
-            name, resource = self._parse_bucket(raw_bucket)
-            self[name] = resource
-
-    def _parse_bucket(self, raw_bucket):
-        """
-        Parse a single S3 bucket
-
-        TODO:
-        - CORS
-        - Lifecycle
-        - Notification ?
-        - Get bucket's policy
-
-        :param bucket:
-        :param params:
-        :return:
-        """
-        raw_bucket['name'] = raw_bucket.pop('Name')
-        raw_bucket['CreationDate'] = str(raw_bucket['CreationDate'])
-
-        # If requested, get key properties
-        raw_bucket['id'] = get_non_provider_id(raw_bucket['name'])
-        return raw_bucket['id'], raw_bucket
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSCompositeResources
+from .buckets import Buckets
 
 
 class S3(AWSCompositeResources):
@@ -37,5 +8,9 @@ class S3(AWSCompositeResources):
         (Buckets, 'buckets')
     ]
 
-    async def fetch_all(self, regions=None, partition_name='aws'):
+    def __init__(self, facade: AWSFacade):
+        super(S3, self).__init__(facade)
+        self.service = 's3'
+
+    async def fetch_all(self, partition_name='aws', **kwargs):
         await self._fetch_children(self)

--- a/ScoutSuite/providers/aws/resources/s3/buckets.py
+++ b/ScoutSuite/providers/aws/resources/s3/buckets.py
@@ -1,0 +1,32 @@
+from ScoutSuite.providers.aws.resources.base import AWSResources
+
+from ScoutSuite.providers.utils import get_non_provider_id
+
+
+class Buckets(AWSResources):
+    async def fetch_all(self):
+        raw_buckets = await self.facade.s3.get_buckets()
+        for raw_bucket in raw_buckets:
+            name, resource = self._parse_bucket(raw_bucket)
+            self[name] = resource
+
+    def _parse_bucket(self, raw_bucket):
+        """
+        Parse a single S3 bucket
+
+        TODO:
+        - CORS
+        - Lifecycle
+        - Notification ?
+        - Get bucket's policy
+
+        :param bucket:
+        :param params:
+        :return:
+        """
+        raw_bucket['name'] = raw_bucket.pop('Name')
+        raw_bucket['CreationDate'] = str(raw_bucket['CreationDate'])
+
+        # If requested, get key properties
+        raw_bucket['id'] = get_non_provider_id(raw_bucket['name'])
+        return raw_bucket['id'], raw_bucket

--- a/ScoutSuite/providers/aws/resources/sqs/base.py
+++ b/ScoutSuite/providers/aws/resources/sqs/base.py
@@ -1,41 +1,12 @@
-import json
-
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.regions import Regions
-from ScoutSuite.providers.aws.resources.base import AWSResources
 
-
-class RegionalQueues(AWSResources):
-    def __init__(self, facade: AWSFacade, region: str):
-        super(RegionalQueues, self).__init__(facade)
-        self.region = region
-
-    async def fetch_all(self):
-        queues = await self.facade.sqs.get_queues(
-            self.region, ['CreatedTimestamp', 'Policy', 'QueueArn', 'KmsMasterKeyId'])
-        for queue_url, queue_attributes in queues:
-            id, queue = self._parse_queue(queue_url, queue_attributes)
-            self[id] = queue
-
-    def _parse_queue(self, queue_url, queue_attributes):
-        queue = {}
-        queue['QueueUrl'] = queue_url
-        queue['arn'] = queue_attributes.pop('QueueArn')
-        queue['name'] = queue['arn'].split(':')[-1]
-        queue['kms_master_key_id'] = queue_attributes.pop('KmsMasterKeyId', None)
-        queue['CreatedTimestamp'] = queue_attributes.pop('CreatedTimestamp', None)
-
-        if 'Policy' in queue_attributes:
-            queue['Policy'] = json.loads(queue_attributes['Policy'])
-        else:
-            queue['Policy'] = {'Statement': []}
-
-        return queue['name'], queue
+from .queues import Queues
 
 
 class SQS(Regions):
     _children = [
-        (RegionalQueues, 'queues')
+        (Queues, 'queues')
     ]
 
     def __init__(self, facade: AWSFacade):

--- a/ScoutSuite/providers/aws/resources/sqs/queues.py
+++ b/ScoutSuite/providers/aws/resources/sqs/queues.py
@@ -1,0 +1,32 @@
+import json
+
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSResources
+
+
+class Queues(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super(Queues, self).__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        queues = await self.facade.sqs.get_queues(self.region,
+                                                  ['CreatedTimestamp', 'Policy', 'QueueArn', 'KmsMasterKeyId'])
+        for queue_url, queue_attributes in queues:
+            id, queue = self._parse_queue(queue_url, queue_attributes)
+            self[id] = queue
+
+    def _parse_queue(self, queue_url, queue_attributes):
+        queue = {}
+        queue['QueueUrl'] = queue_url
+        queue['arn'] = queue_attributes.pop('QueueArn')
+        queue['name'] = queue['arn'].split(':')[-1]
+        queue['kms_master_key_id'] = queue_attributes.pop('KmsMasterKeyId', None)
+        queue['CreatedTimestamp'] = queue_attributes.pop('CreatedTimestamp', None)
+
+        if 'Policy' in queue_attributes:
+            queue['Policy'] = json.loads(queue_attributes['Policy'])
+        else:
+            queue['Policy'] = {'Statement': []}
+
+        return queue['name'], queue

--- a/ScoutSuite/providers/base/provider.py
+++ b/ScoutSuite/providers/base/provider.py
@@ -69,19 +69,19 @@ class BaseProvider(object):
         self._update_metadata()
         self._update_last_run(current_time, ruleset, run_parameters)
 
-    async def fetch(self, regions=None, skipped_regions=None, partition_name=None):
+    async def fetch(self, regions=None, excluded_regions=None, partition_name=None):
         """
         Fetch resources for each service
 
         :param regions:
-        :param skipped_regions:
+        :param excluded_regions:
         :param partition_name:
         :return:
         """
         regions = [] if regions is None else regions
-        skipped_regions = [] if skipped_regions is None else skipped_regions
+        excluded_regions = [] if excluded_regions is None else excluded_regions
         # TODO: determine partition name based on regions and warn if multiple partitions...
-        await self.services.fetch(self.service_list, regions)
+        await self.services.fetch(self.service_list, regions, excluded_regions)
 
         # TODO implement this properly
         """

--- a/ScoutSuite/providers/base/services.py
+++ b/ScoutSuite/providers/base/services.py
@@ -13,7 +13,7 @@ class BaseServicesConfig(object):
     def _is_provider(self, provider_name):
         return False
 
-    async def fetch(self, services: list, regions: list):
+    async def fetch(self, services: list, regions: list, excluded_regions: list):
 
         if not services:
             print_debug('No services to scan')
@@ -30,12 +30,12 @@ class BaseServicesConfig(object):
             if services:
                 tasks = {
                     asyncio.ensure_future(
-                        self._fetch(service, regions)
+                        self._fetch(service, regions, excluded_regions)
                     ) for service in services
                 }
                 await asyncio.wait(tasks)
 
-    async def _fetch(self, service, regions=None):
+    async def _fetch(self, service, regions=None, excluded_regions=None):
         try:
             print_info('Fetching resources for the {} service'.format(format_service_name(service)))
             service_config = getattr(self, service)
@@ -45,6 +45,8 @@ class BaseServicesConfig(object):
 
                 if regions:
                     method_args['regions'] = regions
+                if excluded_regions:
+                    method_args['excluded_regions'] = excluded_regions
 
                 if self._is_provider('aws'):
                     if service != 'iam':


### PR DESCRIPTION
Fix for https://github.com/nccgroup/ScoutSuite/issues/487.

Adds the `exclude-regions` parameter for AWS.

This can be used to exclude optional regions, e.g. by passing `--exclude-regions ap-east-1 me-south-1`.