### PR TITLE
Enhancement: Allow AWS Authentication with API Keys

### DIFF
--- a/ScoutSuite/__main__.py
+++ b/ScoutSuite/__main__.py
@@ -31,6 +31,9 @@ def run_from_cli():
         return run(provider=args.get('provider'),
                    # AWS
                    profile=args.get('profile'),
+                   aws_access_key_id=args.get('aws_access_key_id'),
+                   aws_secret_access_key=args.get('aws_secret_access_key'),
+                   aws_session_token=args.get('aws_session_token'),
                    # Azure
                    user_account=args.get('user_account'), service_account=args.get('service_account'),
                    cli=args.get('cli'), msi=args.get('msi'), service_principal=args.get('service_principal'), file_auth=args.get('file_auth'),
@@ -67,6 +70,9 @@ def run_from_cli():
 def run(provider,
         # AWS
         profile=None,
+        aws_access_key_id=None,
+        aws_secret_access_key=None,
+        aws_session_token=None,
         # Azure
         user_account=False, service_account=None,
         cli=False, msi=False, service_principal=False, file_auth=None,
@@ -108,6 +114,9 @@ def run(provider,
 async def _run(provider,
                # AWS
                profile,
+               aws_access_key_id,
+               aws_secret_access_key,
+               aws_session_token,
                # Azure
                user_account, service_account,
                cli, msi, service_principal, file_auth, tenant_id, subscription_id,
@@ -147,6 +156,9 @@ async def _run(provider,
     auth_strategy = get_authentication_strategy(provider)
     try:
         credentials = auth_strategy.authenticate(profile=profile,
+                                                 aws_access_key_id=aws_access_key_id,
+                                                 aws_secret_access_key=aws_secret_access_key,
+                                                 aws_session_token=aws_session_token,
                                                  user_account=user_account,
                                                  service_account=service_account,
                                                  cli=cli,

--- a/ScoutSuite/core/cli_parser.py
+++ b/ScoutSuite/core/cli_parser.py
@@ -36,6 +36,7 @@ class ScoutSuiteArgumentParser:
                                             help="Run Scout against an Amazon Web Services account")
 
         aws_parser = parser.add_argument_group('Authentication modes')
+        aws_auth_params = parser.add_argument_group('Authentication parameters')
 
         aws_auth_modes = aws_parser.add_mutually_exclusive_group(required=True)
 
@@ -43,7 +44,27 @@ class ScoutSuiteArgumentParser:
                                     '--profile',
                                     dest='profile',
                                     default=None,
-                                    help='Name of the profile')
+                                    help='Run with a named profile')
+
+        aws_auth_modes.add_argument('--access-keys',
+                                    action='store_true',
+                                    dest='aws_access_keys',
+                                    help='Run with access keys')
+        aws_auth_params.add_argument('--access-key-id',
+                                     action='store',
+                                     default=None,
+                                     dest='aws_access_key_id',
+                                     help='AWS Access Key ID')
+        aws_auth_params.add_argument('--secret-access-key',
+                                     action='store',
+                                     default=None,
+                                     dest='aws_secret_access_key',
+                                     help='AWS Secret Access Key')
+        aws_auth_params.add_argument('--session-token',
+                                     action='store',
+                                     default=None,
+                                     dest='aws_session_token',
+                                     help='AWS Session Token')
 
         aws_additional_parser = parser.add_argument_group('Additional arguments')
 
@@ -326,7 +347,11 @@ class ScoutSuiteArgumentParser:
 
         # Test conditions
         v = vars(args)
-        if v.get('provider') == 'azure:':
+        if v.get('provider') == 'aws':
+            if v.get('aws_access_keys') and not (v.get('aws_access_key_id') or v.get('aws_secret_access_key')):
+                self.parser.error('When running with --access-keys, you must provide an Access Key ID '
+                                  'and Secret Access Key.')
+        elif v.get('provider') == 'azure':
             if v.get('tenant_id') and not (v.get('user_account') or v.get('service_principal') or v.get('msi')):
                 self.parser.error('--tenant can only be set when using --user-account, --service-principal or --msi')
             if v.get('subscription_id') and not (v.get('user_account') or v.get('service_principal') or v.get('msi')):

--- a/ScoutSuite/providers/aws/authentication_strategy.py
+++ b/ScoutSuite/providers/aws/authentication_strategy.py
@@ -15,11 +15,29 @@ class AWSAuthenticationStrategy(AuthenticationStrategy):
     Implements authentication for the AWS provider
     """
 
-    def authenticate(self, profile=None, **kwargs):
+    def authenticate(self,
+                     profile=None,
+                     aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None,
+                     **kwargs):
 
         try:
 
-            session = boto3.Session(profile_name=profile)
+            if profile:
+                session = boto3.Session(profile_name=profile)
+            elif aws_access_key_id and aws_secret_access_key:
+                if aws_session_token:
+                    session = boto3.Session(
+                        aws_access_key_id=aws_access_key_id,
+                        aws_secret_access_key=aws_secret_access_key,
+                        aws_session_token=aws_session_token,
+                    )
+                else:
+                    session = boto3.Session(
+                        aws_access_key_id=aws_access_key_id,
+                        aws_secret_access_key=aws_secret_access_key,
+                    )
+            else:
+                raise AuthenticationException('Insufficient credentials provided')
 
             # Test querying for current user
             identity = get_caller_identity(session)


### PR DESCRIPTION
Implements https://github.com/nccgroup/ScoutSuite/issues/494.

With this, you can now launch an AWS run as so:
` python scout.py aws --access-keys --access-key-id <AKIA...> --secret-access-key <secret> --session-token <token> `

The `--session-token` is optional and only used for temporary credentials (i.e. role assumption).

When executing programatically, the following should be provided:
- `aws_access_key_id`
- `aws_secret_access_key`
- `aws_session_token` (optional)