### PR TITLE
Fixed scoping issue in _get_and_set_inline_policies

### DIFF
--- a/ScoutSuite/providers/aws/facade/iam.py
+++ b/ScoutSuite/providers/aws/facade/iam.py
@@ -203,7 +203,7 @@ class IAMFacade(AWSBaseFacade):
             try:
                 tasks = {
                     asyncio.ensure_future(
-                        run_concurrently(lambda: get_policy_method(**dict(args, PolicyName=policy_name)))
+                        run_concurrently(lambda policy_name=policy_name: get_policy_method(**dict(args, PolicyName=policy_name)))
                     ) for policy_name in policy_names
                 }
             except Exception as e:


### PR DESCRIPTION
The current implementation scopes variables passed to the lambda function such that an entity with multiple inline policies will have get_policy_method called with the same policy_name for each policy. Creating a policy_name parameter with a default fixes this issue.