### PR TITLE
Retrieve EC2 security group tags

### DIFF
--- a/ScoutSuite/providers/aws/facade/iam.py
+++ b/ScoutSuite/providers/aws/facade/iam.py
@@ -203,7 +203,8 @@ class IAMFacade(AWSBaseFacade):
             try:
                 tasks = {
                     asyncio.ensure_future(
-                        run_concurrently(lambda: get_policy_method(**dict(args, PolicyName=policy_name)))
+                        run_concurrently(lambda policy_name=policy_name:
+                                         get_policy_method(**dict(args, PolicyName=policy_name)))
                     ) for policy_name in policy_names
                 }
             except Exception as e:

--- a/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
+++ b/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
@@ -25,6 +25,9 @@ class SecurityGroups(AWSResources):
         security_group['description'] = raw_security_group['Description']
         security_group['owner_id'] = raw_security_group['OwnerId']
 
+        if 'Tags' in raw_security_group:
+            security_group['tags'] = {x['Key']: x['Value'] for x in raw_security_group['Tags']}
+
         security_group['rules'] = {'ingress': {}, 'egress': {}}
         ingress_protocols, ingress_rules_count = self._parse_security_group_rules(
             raw_security_group['IpPermissions'])

--- a/ScoutSuite/providers/aws/rules/findings/rds-postgres-instance-with-invalid-certificate.json
+++ b/ScoutSuite/providers/aws/rules/findings/rds-postgres-instance-with-invalid-certificate.json
@@ -5,7 +5,7 @@
     "conditions": [ "and",
         [ "rds.regions.id.vpcs.id.instances.id.Engine", "equal", "postgres" ],
         [ "rds.regions.id.vpcs.id.instances.id.DBInstanceStatus", "notEqual", "creating" ],
-        [ "rds.regions.id.vpcs.id.instances.id.InstanceCreateTime", "datePriorTo", "08/05/2014" ]
+        [ "rds.regions.id.vpcs.id.instances.id.InstanceCreateTime", "priorToDate", "08/05/2014" ]
     ],
     "id_suffix": "pgsslcert"
 }


### PR DESCRIPTION
Retrieves tags associated with EC2 security groups.  This would allow custom rules to be written that could use these tags when deciding whether or not to generate a finding.