### PR TITLE
Include tags in EC2 security group data

### DIFF
--- a/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
+++ b/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
@@ -25,6 +25,9 @@ class SecurityGroups(AWSResources):
         security_group['description'] = raw_security_group['Description']
         security_group['owner_id'] = raw_security_group['OwnerId']
 
+        if 'Tags' in raw_security_group:
+            security_group['tags'] = {x['Key']: x['Value'] for x in raw_security_group['Tags']}
+
         security_group['rules'] = {'ingress': {}, 'egress': {}}
         ingress_protocols, ingress_rules_count = self._parse_security_group_rules(
             raw_security_group['IpPermissions'])


### PR DESCRIPTION
Retrieves tags associated with EC2 security groups.  This would allow custom
rules to be written that could use these tags when deciding whether or not to
generate a finding.