### PR TITLE
Include tags in ELB and ELBv2 data

### DIFF
--- a/ScoutSuite/output/data/html/partials/aws/services.elb.regions.id.vpcs.id.elbs.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.elb.regions.id.vpcs.id.elbs.html
@@ -61,6 +61,16 @@
             {{> services.elb.regions.vpcs.elbs.linked_resources region = region vpc = vpc resources = Subnets resource_type = 'subnets'}}
           </ul>
         </div>
+        {{#if tags}}
+            <div class="list-group-item">
+                <h4>Tags</h4>
+                <ul>
+                    {{#each tags}}
+                        <li class="list-group-item-text">{{@key}}: {{this}}</li>
+                    {{/each}}
+                </ul>
+            </div>
+        {{/if}}
     </script>
     <script>
       Handlebars.registerPartial("services.elb.regions.id.vpcs.id.elbs", $("#services\\.elb\\.regions\\.id\\.vpcs\\.id\\.elbs\\.partial").html());

--- a/ScoutSuite/output/data/html/partials/aws/services.elb.regions.id.vpcs.id.elbs.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.elb.regions.id.vpcs.id.elbs.html
@@ -66,7 +66,7 @@
                 <h4>Tags</h4>
                 <ul>
                     {{#each tags}}
-                        <li class="list-group-item-text">{{@key}}: {{this}}</li>
+                        <li class="list-group-item-text"><samp>{{@key}}</samp>: <samp>{{this}}</samp></li>
                     {{/each}}
                 </ul>
             </div>

--- a/ScoutSuite/output/data/html/partials/aws/services.elbv2.regions.id.vpcs.id.lbs.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.elbv2.regions.id.vpcs.id.lbs.html
@@ -55,6 +55,16 @@
                 </div>
             </div>
         </div>
+        {{#if tags}}
+            <div class="list-group-item">
+                <h4>Tags</h4>
+                <ul>
+                    {{#each tags}}
+                        <li class="list-group-item-text">{{@key}}: {{this}}</li>
+                    {{/each}}
+                </ul>
+            </div>
+        {{/if}}
 
     </script>
     <script>

--- a/ScoutSuite/output/data/html/partials/aws/services.elbv2.regions.id.vpcs.id.lbs.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.elbv2.regions.id.vpcs.id.lbs.html
@@ -60,7 +60,7 @@
                 <h4>Tags</h4>
                 <ul>
                     {{#each tags}}
-                        <li class="list-group-item-text">{{@key}}: {{this}}</li>
+                    <li class="list-group-item-text"><samp>{{@key}}</samp>: <samp>{{this}}</samp></li>
                     {{/each}}
                 </ul>
             </div>

--- a/ScoutSuite/providers/aws/resources/elb/load_balancers.py
+++ b/ScoutSuite/providers/aws/resources/elb/load_balancers.py
@@ -35,4 +35,7 @@ class LoadBalancers(AWSResources):
         for i in raw_load_balancer['Instances']:
             load_balancer['instances'].append(i['InstanceId'])
 
+        if 'Tags' in raw_load_balancer and raw_load_balancer['Tags']:
+            load_balancer['tags'] = {x['Key']: x['Value'] for x in raw_load_balancer['Tags']}
+
         return get_non_provider_id(load_balancer['name']), load_balancer

--- a/ScoutSuite/providers/aws/resources/elbv2/load_balancers.py
+++ b/ScoutSuite/providers/aws/resources/elbv2/load_balancers.py
@@ -36,4 +36,8 @@ class LoadBalancers(AWSCompositeResources):
                 load_balancer['security_groups'].append({'GroupId': sg})
             load_balancer.pop('SecurityGroups')
 
+        if 'Tags' in load_balancer and load_balancer['Tags']:
+            load_balancer['tags'] = {x['Key']: x['Value'] for x in load_balancer['Tags']}
+            load_balancer.pop('Tags')
+
         return get_non_provider_id(load_balancer['name']), load_balancer


### PR DESCRIPTION
Retrieves tags associated with ELB and ELBv2 load balancers.  This would allow
custom rules to be written that could use these tags when deciding whether or
not to generate a finding.