### PR TITLE
adds the ability to create binary packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,6 @@ aliyun-python-sdk-kms>=2.6.0
 
 # Oracle Cloud Infrastructure Provider
 oci>=2.2.4
+
+# packaging
+pex==1.6.12

--- a/tools/gen-package.sh
+++ b/tools/gen-package.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+pex scoutsuite --compile -v -c scout -o scout.pex


### PR DESCRIPTION
ScoutSuite needs python and pip to run which makes running it in Dockerfiles a pain as you need to bake python and other things in your container.

Having the ability to create a .pex file which can be executed as a binary allows for running ScoutSuite in minimal containers.