### PR TITLE
Make reading auth files allot more reliable

### DIFF
--- a/ScoutSuite/core/cli_parser.py
+++ b/ScoutSuite/core/cli_parser.py
@@ -172,7 +172,7 @@ class ScoutSuiteArgumentParser:
 
         azure_auth_modes.add_argument('--file-auth',
                                       action='store',
-                                      type=argparse.FileType('r'),
+                                      type=argparse.FileType('rb'),
                                       dest='file_auth',
                                       metavar="FILE",
                                       help='Run Scout with the specified credential file')


### PR DESCRIPTION
without the 'b' on the file open, files originating from windows or utf-8 environments dont open correctly.