### PR TITLE
feat: add python3.8 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,17 @@ sudo: false
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 matrix:
   include:
     - python: "3.7"
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+    - python: "3.8"
+      dist: bionic
+      sudo: required
 
 install:
   - pip install -U setuptools

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
 )


### PR DESCRIPTION
This adds Python 3.8 to the Travis build matrix, as well as to the python module definition itself.