### PR TITLE
parsing bug fixes

### DIFF
--- a/ScoutSuite/providers/gcp/resources/cloudstorage/buckets.py
+++ b/ScoutSuite/providers/gcp/resources/cloudstorage/buckets.py
@@ -25,13 +25,20 @@ class Buckets(Resources):
         bucket_dict['storage_class'] = raw_bucket.storage_class.lower()
         bucket_dict['versioning_enabled'] = raw_bucket.versioning_enabled
         bucket_dict['logging_enabled'] = raw_bucket.logging is not None
-        bucket_dict['uniform_bucket_level_access'] = raw_bucket.iam_configuration['bucketPolicyOnly']['enabled']
+        iam_configuration = raw_bucket.iam_configuration.get('uniformBucketLevelAccess', False) or raw_bucket.iam_configuration.get('bucketPolicyOnly', False)
+        if iam_configuration:
+            bucket_dict['uniform_bucket_level_access'] = policy.get("enabled", False)
+        else:
+            print("raw_bucket.iam_configuration missing both uniformBucketLevelAccess and bucketPolicyOnly")
+            raise 
+        
         if bucket_dict['uniform_bucket_level_access']:
             bucket_dict['acls'] = []
             bucket_dict['default_object_acl'] = []
         else:
             bucket_dict['acls'] = list(raw_bucket.acl)
             bucket_dict['default_object_acl'] = list(raw_bucket.default_object_acl)
+        
         bucket_dict['acl_configuration'] = self._get_cloudstorage_bucket_acl(raw_bucket)  # FIXME this should be "IAM"
         return bucket_dict['id'], bucket_dict
 

--- a/ScoutSuite/providers/gcp/resources/cloudstorage/buckets.py
+++ b/ScoutSuite/providers/gcp/resources/cloudstorage/buckets.py
@@ -27,7 +27,7 @@ class Buckets(Resources):
         bucket_dict['logging_enabled'] = raw_bucket.logging is not None
         iam_configuration = raw_bucket.iam_configuration.get('uniformBucketLevelAccess', False) or raw_bucket.iam_configuration.get('bucketPolicyOnly', False)
         if iam_configuration:
-            bucket_dict['uniform_bucket_level_access'] = policy.get("enabled", False)
+            bucket_dict['uniform_bucket_level_access'] = iam_configuration.get("enabled", False)
         else:
             print("raw_bucket.iam_configuration missing both uniformBucketLevelAccess and bucketPolicyOnly")
             raise 

--- a/ScoutSuite/providers/gcp/resources/gce/disks.py
+++ b/ScoutSuite/providers/gcp/resources/gce/disks.py
@@ -8,7 +8,7 @@ class Disks(Resources):
         disk_dict['id'] = get_non_provider_id(raw_disk['deviceName'])
         disk_dict['type'] = raw_disk['type']
         disk_dict['mode'] = raw_disk['mode']
-        disk_dict['source_url'] = raw_disk['source']
+        disk_dict['source_url'] = raw_disk.get('source', "source_url not found for disk")
         disk_dict['source_device_name'] = raw_disk['deviceName']
         disk_dict['bootable'] = raw_disk['boot']
         disk_dict['encrypted_with_csek'] = self._is_encrypted_with_csek(raw_disk)


### PR DESCRIPTION
Fix parsing errors in GCE/disks.py and CloudStorage/buckets.py

Line 31 in `bucket.py` presently raises an error if either of `bucketPolicyOnly` or `uniformBucketLevelAccess` keys are not found in the iam configuration. It may be fair to assume that if those values are not found then Uniform Bucket Level Access is not enabled. This has not been verified.

Fixes https://github.com/nccgroup/ScoutSuite/issues/673

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
