### PR TITLE
ELB Listener Security Rules

### DIFF
--- a/ScoutSuite/providers/aws/rules/findings/elb-listener-allowing-cleartext.json
+++ b/ScoutSuite/providers/aws/rules/findings/elb-listener-allowing-cleartext.json
@@ -1,0 +1,13 @@
+{
+    "description": "ELB allowing clear text (HTTP) communication",
+    "rationale": "<b>Description:</b><br><br>Use of a secure protocol (HTTPS or SSL) is best practice for encrypted communication. This rule checks for load balancers that are not using recommended security configurations.",
+    "path": "elb.regions.id.vpcs.id.elbs.id.listeners.id.Protocol",
+    "dashboard_name": "Load Balancer Listeners",
+    "display_path": "elb.regions.id.vpcs.id.elbs.id",
+    "conditions": [ "and",
+        [ "this", "containNoneOf", [
+            "HTTPS",
+            "SSL"
+        ] ]
+    ]
+}

--- a/ScoutSuite/providers/aws/rules/findings/elb-older-ssl-policy.json
+++ b/ScoutSuite/providers/aws/rules/findings/elb-older-ssl-policy.json
@@ -1,0 +1,18 @@
+{
+    "description": "Older SSL/TLS policy",
+    "rationale": "<b>Description:</b><br><br>Use of AWS latest TLS policies is best practice. The recommended predefined security policies are: ELBSecurityPolicy-2016-08, ELBSecurityPolicy-FS-2018-06, ELBSecurityPolicy-TLS-1-1-2017-01, ELBSecurityPolicy-TLS-1-2-2017-01, ELBSecurityPolicy-TLS-1-2-Ext-2018-06, ELBSecurityPolicy-FS-1-1-2019-08, ELBSecurityPolicy-FS-1-2-2019-08 and ELBSecurityPolicy-FS-1-2-Res-2019-08.",
+    "path": "elb.regions.id.elb_policies.id.reference_security_policy",
+    "dashboard_name": "Load Balancer Listeners Security Policy",
+    "display_path": "elb.regions.id.elb_policies.id.reference_security_policy",
+    "conditions": [ "and",
+        [ "this", "containNoneOf", [
+            "ELBSecurityPolicy-2016-08",
+            "ELBSecurityPolicy-TLS-1-1-2017-01",
+            "ELBSecurityPolicy-TLS-1-2-2017-01",
+            "ELBSecurityPolicy-TLS-1-2-Ext-2018-06",
+            "ELBSecurityPolicy-FS-2018-06",
+            "ELBSecurityPolicy-FS-1-1-2019-08",
+            "ELBSecurityPolicy-FS-1-2-2019-08",
+            "ELBSecurityPolicy-FS-1-2-Res-2019-08" ] ]
+    ]
+}

--- a/ScoutSuite/providers/aws/rules/findings/elbv2-listener-allowing-cleartext.json
+++ b/ScoutSuite/providers/aws/rules/findings/elbv2-listener-allowing-cleartext.json
@@ -1,0 +1,10 @@
+{
+    "description": "ELBv2 allowing clear text (HTTP) communication",
+    "rationale": "<b>Description:</b><br><br>Use of a secure protocol (HTTPS or SSL) is best practice for encrypted communication. This rule checks for load balancers that are not using recommended security configurations.",
+    "path": "elbv2.regions.id.vpcs.id.lbs.id.listeners.id.Protocol",
+    "dashboard_name": "Load Balancer Listeners",
+    "display_path": "elbv2.regions.id.vpcs.id.lbs.id",
+    "conditions": [ "and",
+        [ "elbv2.regions.id.vpcs.id.lbs.id.listeners.id.Protocol", "equal", "HTTP" ]
+    ]
+}

--- a/ScoutSuite/providers/aws/rules/rulesets/default.json
+++ b/ScoutSuite/providers/aws/rules/rulesets/default.json
@@ -340,10 +340,28 @@
                 "level": "warning"
             }
         ],
+        "elb-listener-allowing-cleartext.json": [
+            {
+                "enabled": true,
+                "level": "danger"
+            }
+        ],
         "elb-no-access-logs.json": [
             {
                 "enabled": true,
                 "level": "warning"
+            }
+        ],
+        "elb-older-ssl-policy.json": [
+            {
+                "enabled": true,
+                "level": "danger"
+            }
+        ],
+        "elbv2-listener-allowing-cleartext.json": [
+            {
+                "enabled": true,
+                "level": "danger"
             }
         ],
         "elbv2-no-access-logs.json": [

--- a/ScoutSuite/providers/aws/rules/rulesets/detailed.json
+++ b/ScoutSuite/providers/aws/rules/rulesets/detailed.json
@@ -361,10 +361,28 @@
                 "level": "warning"
             }
         ],
+        "elb-listener-allowing-cleartext.json": [
+            {
+                "enabled": true,
+                "level": "danger"
+            }
+        ],
         "elb-no-access-logs.json": [
             {
                 "enabled": true,
                 "level": "warning"
+            }
+        ],
+        "elb-older-ssl-policy.json": [
+            {
+                "enabled": true,
+                "level": "danger"
+            }
+        ],
+        "elbv2-listener-allowing-cleartext.json": [
+            {
+                "enabled": true,
+                "level": "danger"
             }
         ],
         "elbv2-no-access-logs.json": [


### PR DESCRIPTION
# Description
This PR creates three new rules for testing Classic and Application Load Balancers in AWS. This is to come in parity with AWS Trusted Advisor check for ELB Listener Security that looks for:
- A load balancer has no listener that uses a secure protocol (HTTPS or SSL)
- A load balancer listener uses an outdated predefined SSL security policy

Both the above cases have been captured in the new rules added with this PR for Classic and Application Load Balancers. There is already a pre-existing rule that checks for older SSL policies in ALBs, so adding older SSL policy rule just for Classic Load Balancers.

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
