### PR TITLE
Show VPC ID instead of name when no name is available. Fixes #707

### DIFF
--- a/ScoutSuite/output/data/html/partials/aws/left_menu_for_vpc.html
+++ b/ScoutSuite/output/data/html/partials/aws/left_menu_for_vpc.html
@@ -16,7 +16,13 @@
       </div>
       {{#each vpcs}}
       <div class="list-group-item list-sub-element" id="services.{{../../service_name}}.regions.{{@../key}}.vpcs.{{@key}}.{{../../resource_type}}.list">
-        <a href="#services.{{../../service_name}}.regions.{{@../key}}.vpcs.{{@key}}.{{../../resource_type}}">{{getValueAt 'services.vpc.regions' @../key 'vpcs' @key 'name'}}</a>
+        <a href="#services.{{../../service_name}}.regions.{{@../key}}.vpcs.{{@key}}.{{../../resource_type}}">
+          {{#if (getValueAt 'services.vpc.regions' @../key 'vpcs' @key 'name')}}
+            {{getValueAt 'services.vpc.regions' @../key 'vpcs' @key 'name'}}
+          {{else}}
+            {{@key}}
+          {{/if}}
+        </a>
         {{#each (lookup . ../../resource_type)}}
         <div class="list-group-item-text list-sub-element" id="services.{{../../../service_name}}.regions.{{@../../key}}.vpcs.{{@../key}}.{{../../../resource_type}}.{{@key}}.link">
           <a href="#services.{{../../../service_name}}.regions.{{@../../key}}.vpcs.{{@../key}}.{{../../../resource_type}}.{{@key}}.view">{{name}}</a>


### PR DESCRIPTION
# Description

The report was showing whitespaces in the left menu for VPC-based resources instead of VPC name. This happened when the --services option was used, as it was likely the name was not available as the VPC resource was not fetched.

The changes replace the VPC name with the VPC ID (which is accessible) when the name is not available.

Fixes #707 

## Type of change

Select the relevant option(s):

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes
