### PR TITLE
Azure/Limit AAD Users Fetched

### DIFF
--- a/ScoutSuite/providers/azure/facade/aad.py
+++ b/ScoutSuite/providers/azure/facade/aad.py
@@ -20,14 +20,14 @@ class AADFacade:
             user_filter = " and ".join([
                 'userType eq \'Guest\''
             ])
-            return await run_concurrently(lambda: list(self._client.users.list(filter=user_filter)))
+            return await run_concurrently(lambda: list(self.get_client().users.list(filter=user_filter)))
         except Exception as e:
             print_exception('Failed to retrieve users: {}'.format(e))
             return []
 
     async def get_user(self, user_id):
         try:
-            return await run_concurrently(lambda: self._client.users.get(user_id))
+            return await run_concurrently(lambda: self.get_client().users.get(user_id))
         except Exception as e:
             print_exception('Failed to retrieve user {}: {}'.format(user_id, e))
             return []

--- a/ScoutSuite/providers/azure/facade/aad.py
+++ b/ScoutSuite/providers/azure/facade/aad.py
@@ -4,10 +4,9 @@ from ScoutSuite.providers.utils import run_concurrently
 
 
 class AADFacade:
-    def __init__(self, credentials, subscriptions_list):
+    def __init__(self, credentials):
         self._client = GraphRbacManagementClient(credentials.aad_graph_credentials,
                                                  tenant_id=credentials.get_tenant_id())
-        self._subscriptions_list = subscriptions_list
 
     async def get_users(self):
         try:

--- a/ScoutSuite/providers/azure/provider.py
+++ b/ScoutSuite/providers/azure/provider.py
@@ -79,12 +79,8 @@ class AzureProvider(BaseProvider):
 
     def _match_rbac_roles_and_principals(self):
         """
-        Matches ARM roles to AAD service principals
-
-        :return:
+        Matches ARM role assignments to AAD service principals
         """
-
-        # Add role assignments
         if 'rbac' in self.service_list and 'aad' in self.service_list:
             for subscription in self.services['rbac']['subscriptions']:
                 for assignment in self.services['rbac']['subscriptions'][subscription]['role_assignments'].values():

--- a/ScoutSuite/providers/azure/resources/aad/base.py
+++ b/ScoutSuite/providers/azure/resources/aad/base.py
@@ -17,9 +17,26 @@ class AAD(AzureCompositeResources):
     async def fetch_all(self):
         await self._fetch_children(resource_parent=self)
 
-    async def finalize(self):
+    async def fetch_additional_users(self, user_list):
+        """
+        Special method to fetch additional users
+        """
+        # fetch the users
+        additional_users = Users(self.facade)
+        await additional_users.fetch_additional_users(user_list)
+        # add them to the resource and update count
+        self['users'].update(additional_users)
+        self['users_count'] = len(self['users'].values())
+        # re-run the finalize method
+        await self.finalize()
 
-        # Add group members
+    async def finalize(self):
+        self.assign_group_memberships()
+
+    def assign_group_memberships(self):
+        """
+        Assigns members to groups
+        """
         for group in self['groups']:
             for user in self['users']:
                 if group in self['users'][user]['groups']:

--- a/ScoutSuite/providers/azure/resources/aad/users.py
+++ b/ScoutSuite/providers/azure/resources/aad/users.py
@@ -7,6 +7,16 @@ class Users(AzureResources):
             id, user = await self._parse_user(raw_user)
             self[id] = user
 
+    async def fetch_additional_users(self, user_list):
+        """
+        Alternative method which only fetches defined users
+        :param user_list: a list of the users to fetch and parse
+        """
+        for user in user_list:
+            raw_user = await self.facade.aad.get_user(user)
+            id, user = await self._parse_user(raw_user)
+            self[id] = user
+
     async def _parse_user(self, raw_user):
         user_dict = {}
         user_dict['id'] = raw_user.object_id

--- a/ScoutSuite/providers/azure/resources/rbac/base.py
+++ b/ScoutSuite/providers/azure/resources/rbac/base.py
@@ -9,3 +9,15 @@ class RBAC(Subscriptions):
         (Roles, 'roles'),
         (RoleAssignments, 'role_assignments')
     ]
+
+    def get_user_id_list(self):
+        """
+        Generates and returns a unique list of user IDs which have a role assigned.
+        """
+        user_set = set()
+        for subscription in self['subscriptions'].values():
+            for role_assignment in subscription['role_assignments'].values():
+                if role_assignment['principal_type'] == 'User':
+                    user_set.add(role_assignment['principal_id'])
+        return list(user_set)
+

--- a/ScoutSuite/providers/azure/services.py
+++ b/ScoutSuite/providers/azure/services.py
@@ -66,3 +66,13 @@ class AzureServicesConfig(BaseServicesConfig):
 
     def _is_provider(self, provider_name):
         return provider_name == 'azure'
+
+    async def fetch(self, services: list, regions: list, excluded_regions: list):
+        await super(AzureServicesConfig, self).fetch(services, regions, excluded_regions)
+
+        # This is a unique case where we'll want to fetch additional resources (in the AAD service) in the
+        # event the RBAC service was included. There's no existing cross-service fetching logic (only cross-service
+        # processing), hence why we needed to add this.
+        if 'rbac' in services and 'aad' in services:
+            user_list = self.rbac.get_user_id_list()
+            await self.aad.fetch_additional_users(user_list)

--- a/ScoutSuite/providers/base/resources/base.py
+++ b/ScoutSuite/providers/base/resources/base.py
@@ -67,7 +67,7 @@ class CompositeResources(Resources, metaclass=abc.ABCMeta):
 
     async def _fetch_children(self, resource_parent: object, scope: dict = {}):
         """This method fetches all children of a given resource (the so called 'resource_parent') by calling fetch_all
-        method on each child defined in '_children' and then sto.res the fetched resources in `resource_parent` under
+        method on each child defined in '_children' and then stores the fetched resources in `resource_parent` under
         the key associated with the child. It also creates a "<child_name>_count" entry for each child.
 
         :param resource_parent: The resource in which the children will be stored.


### PR DESCRIPTION
# Description

Fix for https://github.com/nccgroup/ScoutSuite/issues/698.

As Azure tenants can be very large, pulling all the users can break the execution. This PR limits the resources that are pulled:

- AAD facade now filters for `Guest` users, which are currently the only ones directly used by a AAD rule
- Cross-service fetching allows only pulling AAD users which have RBAC roles assigned in a subscription

Going forward, the filter will have to be modified to write rules flagging additional user configurations.

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
