### PR TITLE
EC2: add instance-profile-arn listing to EC2 Instances

### DIFF
--- a/ScoutSuite/providers/aws/resources/ec2/instances.py
+++ b/ScoutSuite/providers/aws/resources/ec2/instances.py
@@ -25,6 +25,9 @@ class EC2Instances(AWSResources):
         instance['monitoring_enabled'] = raw_instance['Monitoring']['State'] == 'enabled'
         instance['user_data'] = await self.facade.ec2.get_instance_user_data(self.region, id)
         instance['user_data_secrets'] = self._identify_user_data_secrets(instance['user_data'])
+        instance['iam_instance_profile_id'] = raw_instance['IamInstanceProfile']['Id']
+        if "IamInstanceProfile" in raw_instance:
+            instance['iam_instance_profile_arn'] = raw_instance['IamInstanceProfile']['Arn']
 
         get_name(raw_instance, instance, 'InstanceId')
         get_keys(raw_instance, instance,

--- a/ScoutSuite/providers/aws/resources/ec2/instances.py
+++ b/ScoutSuite/providers/aws/resources/ec2/instances.py
@@ -25,14 +25,15 @@ class EC2Instances(AWSResources):
         instance['monitoring_enabled'] = raw_instance['Monitoring']['State'] == 'enabled'
         instance['user_data'] = await self.facade.ec2.get_instance_user_data(self.region, id)
         instance['user_data_secrets'] = self._identify_user_data_secrets(instance['user_data'])
-        instance['iam_instance_profile_id'] = raw_instance['IamInstanceProfile']['Id']
-        if "IamInstanceProfile" in raw_instance:
-            instance['iam_instance_profile_arn'] = raw_instance['IamInstanceProfile']['Arn']
 
         get_name(raw_instance, instance, 'InstanceId')
         get_keys(raw_instance, instance,
                  ['KeyName', 'LaunchTime', 'InstanceType', 'State', 'IamInstanceProfile', 'SubnetId'])
 
+        if "IamInstanceProfile" in raw_instance:
+            instance['iam_instance_profile_id'] = raw_instance['IamInstanceProfile']['Id']
+            instance['iam_instance_profile_arn'] = raw_instance['IamInstanceProfile']['Arn']
+        
         instance['network_interfaces'] = {}
         for eni in raw_instance['NetworkInterfaces']:
             nic = {}


### PR DESCRIPTION
# Description

The [instance profile ARN+ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html) is not mapped to EC2 Instances when retrieving data with ScoutSuite.  This makes it difficult to create rules that compare EC2 instance profiles against IAM policies that can grant too much permission to an instance.

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
