### PR TITLE
Improve Trusted Microsoft Services Enabled rule (fixes #763)

### DIFF
--- a/ScoutSuite/providers/azure/resources/storageaccounts/storage_accounts.py
+++ b/ScoutSuite/providers/azure/resources/storageaccounts/storage_accounts.py
@@ -52,7 +52,7 @@ class StorageAccounts(AzureCompositeResources):
     def _is_trusted_microsoft_services_enabled(self, storage_account):
         if storage_account.network_rule_set.bypass:
             return "AzureServices" in storage_account.network_rule_set.bypass
-        return false
+        return False
 
     def _parse_access_keys_last_rotation_date(self, activity_logs):
         last_rotation_date = None

--- a/ScoutSuite/providers/azure/resources/storageaccounts/storage_accounts.py
+++ b/ScoutSuite/providers/azure/resources/storageaccounts/storage_accounts.py
@@ -50,7 +50,9 @@ class StorageAccounts(AzureCompositeResources):
         return storage_account.network_rule_set.default_action == "Allow"
 
     def _is_trusted_microsoft_services_enabled(self, storage_account):
-        return storage_account.network_rule_set.bypass == "AzureServices"
+        if storage_account.network_rule_set.bypass:
+            return "AzureServices" in storage_account.network_rule_set.bypass
+        return false
 
     def _parse_access_keys_last_rotation_date(self, activity_logs):
         last_rotation_date = None


### PR DESCRIPTION
# Description

Quick and easy improvement to the Trusted Microsoft Services Enabled rule. See https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.storage.fluent.models.networkruleset.bypass?view=azure-dotnet. 

NetworkRuleSet.Bypass can be any combination of Logging|Metrics|AzureServices.
Logging/Monitoring have no effect on the rule, so all I did was change the check the be `"AzureServices" in` instead of `==`.

I'm not setup to test this, but it should be trivial (famous last words).

Mind giving it a go @Dziubey ?

Fixes #763 

## Type of change

Select the relevant option(s):

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
