### PR TITLE
Fix RDS No Minor Version Upgrade Rule

### DIFF
--- a/ScoutSuite/providers/aws/rules/findings/rds-instance-no-minor-upgrade.json
+++ b/ScoutSuite/providers/aws/rules/findings/rds-instance-no-minor-upgrade.json
@@ -16,13 +16,8 @@
         ],
         [
             "rds.regions.id.vpcs.id.instances.id.Engine",
-            "containAtLeastOneOf",
-            [
-                "mariadb",
-                "mysql",
-                "postgres",
-                "aurora"
-            ]
+            "notEqual",
+            "sqlserver-se"
         ]
     ],
     "id_suffix": "AutoMinorVersionUpgrade"


### PR DESCRIPTION
# Description

Inverts the rds No Minor Version Upgrade rule to explicitly exclude sqlserver-se ([which does not support auto minor version upgrades](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.SQLServer.html)). This saves us having to update the rule every time an engine is added, and flips the risk from false negatives to false positives.

Fixes #794 

[ ] Still need to test the new rule

## Type of change

Select the relevant option(s):

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
