### PR TITLE
Don't generate redshift findings for default parameter groups

### DIFF
--- a/ScoutSuite/providers/aws/rules/findings/redshift-parameter-group-logging-disabled.json
+++ b/ScoutSuite/providers/aws/rules/findings/redshift-parameter-group-logging-disabled.json
@@ -9,6 +9,11 @@
     "conditions": [
         "and",
         [
+            "redshift.regions.id.parameter_groups.id.is_default",
+            "false",
+            ""
+        ],
+        [
             "redshift.regions.id.parameter_groups.id.parameters.enable_user_activity_logging.value",
             "false",
             ""

--- a/ScoutSuite/providers/aws/rules/findings/redshift-parameter-group-logging-disabled.json
+++ b/ScoutSuite/providers/aws/rules/findings/redshift-parameter-group-logging-disabled.json
@@ -1,6 +1,6 @@
 {
     "description": "User Activity Logging Disabled",
-    "rationale": "Audit logging is not enabled by default in Amazon Redshift. A lack of user activity logging could impede the ability to investigate issues involving misuse, malicious access or performance.",
+    "rationale": "Audit logging is not enabled by default in Amazon Redshift. A lack of user activity logging could impede the ability to investigate issues involving misuse, malicious access or performance.<br><br><b>Note</b> that this rule will only flag non-default parameter groups, as default parameter groups cannot be modified. It is recommended to use custom groups and configure them according to security best practice.",
     "references": [
         "https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html"
     ],

--- a/ScoutSuite/providers/aws/rules/findings/redshift-parameter-group-ssl-not-required.json
+++ b/ScoutSuite/providers/aws/rules/findings/redshift-parameter-group-ssl-not-required.json
@@ -1,6 +1,6 @@
 {
     "description": "SSL Not Required",
-    "rationale": "Parameter groups associated with Redshift clusters should have the \"require_ssl\" parameter enabled, to ensure that data in transit is encrypted.<br><br><b>Note</b> that this rule will flag default parameter groups, even though they cannot be changed. It is recommended to use custom groups and configure them according to security best practice.",
+    "rationale": "Parameter groups associated with Redshift clusters should have the \"require_ssl\" parameter enabled, to ensure that data in transit is encrypted.<br><br><b>Note</b> that this rule will only flag non-default parameter groups. It is recommended to use custom groups and configure them according to security best practice.",
     "references": [
         "https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html"
     ],
@@ -8,6 +8,11 @@
     "path": "redshift.regions.id.parameter_groups.id",
     "conditions": [
         "and",
+        [
+            "redshift.regions.id.parameter_groups.id.is_default",
+            "false",
+            ""
+        ],
         [
             "redshift.regions.id.parameter_groups.id.parameters.require_ssl.value",
             "false",

--- a/ScoutSuite/providers/aws/rules/findings/redshift-parameter-group-ssl-not-required.json
+++ b/ScoutSuite/providers/aws/rules/findings/redshift-parameter-group-ssl-not-required.json
@@ -1,6 +1,6 @@
 {
     "description": "SSL Not Required",
-    "rationale": "Parameter groups associated with Redshift clusters should have the \"require_ssl\" parameter enabled, to ensure that data in transit is encrypted.<br><br><b>Note</b> that this rule will only flag non-default parameter groups. It is recommended to use custom groups and configure them according to security best practice.",
+    "rationale": "Parameter groups associated with Redshift clusters should have the \"require_ssl\" parameter enabled, to ensure that data in transit is encrypted.<br><br><b>Note</b> that this rule will only flag non-default parameter groups, as default parameter groups cannot be modified. It is recommended to use custom groups and configure them according to security best practice.",
     "references": [
         "https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html"
     ],


### PR DESCRIPTION
AWS Redshift generates default parameter groups (e.g. "default.redshift-1.0")
that have certain parameters that can generate findings, such as
"enable_user_activity_logging" == "false", and "require_ssl" == "false".

The user is unable to modify these parameters, so in cases where a default
parameter group exists, findings will be generated which the user has no
ability to remediate.

The "redshift-parameter-group-logging-disabled" and
"redshift-parameter-group-ssl-not-required" rules are modified to only apply to
non-default parameter groups for which the user can be expected to remediate.

# Description

**Make sure the PR is against the `develop` branch (see [Contributing](https://github.com/nccgroup/ScoutSuite/blob/master/CONTRIBUTING.md)).**

Please include a summary of the change(s) and which issue(s) it addresses. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
