### PR TITLE
Gather addtional context for Cloudformation Stacks

### DIFF
--- a/ScoutSuite/output/data/html/partials/aws/services.cloudformation.regions.id.stacks.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.cloudformation.regions.id.stacks.html
@@ -23,6 +23,17 @@
     <div class="list-group-item-text item-margin">Termination protection enabled: <span id="cloudformation.regions.{{region}}.stacks.{{@key}}.cloudformation_stack_no_termination_protection">{{EnableTerminationProtection}}</span></div>
     <div class="list-group-item-text item-margin">Configuration has drifted: <span id="cloudformation.regions.{{region}}.stacks.{{@key}}.cloudformation_stack_drifted">{{drifted}}</span></div>
     <div class="list-group-item-text item-margin">Deletion policy: <span id="cloudformation.regions.{{region}}.stacks.{{@key}}.cloudformation_stack_no_deletion_policy">{{deletion_policy}}</span></div>
+    <div class="list-group-item-text item-margin">Notification ARNs:
+      <span id="cloudformation.regions.{{region}}.stacks.{{@key}}.cloudformation_stack_lacks_notifications">
+        <ul>
+        {{#each notificationARNs}}
+            <li class="list-group-item-text"><samp>{{this}}</samp></li>
+        {{else}}
+            <li class="list-group-item-text"><samp>None</samp></li>
+        {{/each}}
+        </ul>
+      </span>
+    </div>
   </div>
   <div class="list-group-item">
     <h4 class="list-group-item-heading">Capabilities {{> count_badge count=Capabilities.length}}</h4>

--- a/ScoutSuite/providers/aws/resources/cloudformation/stacks.py
+++ b/ScoutSuite/providers/aws/resources/cloudformation/stacks.py
@@ -22,7 +22,7 @@ class Stacks(AWSResources):
                                    'StackDriftStatus'] == 'DRIFTED'
         raw_stack['termination_protection'] = raw_stack['EnableTerminationProtection']
         raw_stack['arn'] = raw_stack['id']
-
+        raw_stack['notificationARNs'] = raw_stack['NotificationARNs']
         template = raw_stack.pop('template')
         raw_stack['deletion_policy'] = self.has_deletion_policy(template)
 


### PR DESCRIPTION
# Description

Minor expansion of what we collect/display for Cloudformation stacks, specifically targeting notification ARNs. Provides baseline for easily expanding to all data returned by describe_stacks

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
