### PR TITLE
Improved AWS default SG rules

### DIFF
--- a/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
+++ b/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
@@ -41,7 +41,29 @@ class SecurityGroups(AWSResources):
             raw_security_group['IpPermissionsEgress'])
         security_group['rules']['egress']['protocols'] = egress_protocols
         security_group['rules']['egress']['count'] = egress_rules_count
+
+        if self._has_default_egress_rule(raw_security_group['IpPermissionsEgress']) and self._has_default_ingress_rule(raw_security_group['IpPermissions'], raw_security_group['GroupId']):
+            security_group['is_default_configuration'] = True
+        else:
+            security_group['is_default_configuration'] = False
+
         return security_group['id'], security_group
+
+    def _has_default_egress_rule(self, rule_list):
+        for rule in rule_list:
+            if rule['IpProtocol'] == '-1':
+                for ip_range in rule['IpRanges']:
+                    if ip_range['CidrIp'] == '0.0.0.0/0':
+                        return True
+        return False
+
+    def _has_default_ingress_rule(self, rule_list, group_id):
+        for rule in rule_list:
+            if rule['IpProtocol'] == '-1':
+                for source_group in rule['UserIdGroupPairs']:
+                    if source_group['GroupId'] == group_id:
+                        return True
+        return False
 
     def _parse_security_group_rules(self, rules):
         protocols = {}

--- a/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
+++ b/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
@@ -42,10 +42,9 @@ class SecurityGroups(AWSResources):
         security_group['rules']['egress']['protocols'] = egress_protocols
         security_group['rules']['egress']['count'] = egress_rules_count
 
-        if self._has_default_egress_rule(raw_security_group['IpPermissionsEgress']) and self._has_default_ingress_rule(raw_security_group['IpPermissions'], raw_security_group['GroupId']):
-            security_group['is_default_configuration'] = True
-        else:
-            security_group['is_default_configuration'] = False
+        security_group['is_default_configuration'] = \
+            self._has_default_egress_rule(raw_security_group['IpPermissionsEgress']) and \
+            self._has_default_ingress_rule(raw_security_group['IpPermissions'], raw_security_group['GroupId'])
 
         return security_group['id'], security_group
 

--- a/ScoutSuite/providers/aws/rules/findings/ec2-default-security-group-in-use.json
+++ b/ScoutSuite/providers/aws/rules/findings/ec2-default-security-group-in-use.json
@@ -35,6 +35,11 @@
             "ec2.regions.id.vpcs.id.security_groups.id.",
             "withKey",
             "used_by"
+        ],
+        [
+            "ec2.regions.id.vpcs.id.security_groups.id.is_default_configuration",
+            "true",
+            ""
         ]
     ],
     "id_suffix": "default_in_use"

--- a/ScoutSuite/providers/aws/rules/findings/ec2-default-security-group-with-rules.json
+++ b/ScoutSuite/providers/aws/rules/findings/ec2-default-security-group-with-rules.json
@@ -36,6 +36,11 @@
             "ec2.regions.id.vpcs.id.security_groups.id.rules.id.protocols",
             "notEmpty",
             ""
+        ],
+        [
+            "ec2.regions.id.vpcs.id.security_groups.id.is_default_configuration",
+            "true",
+            ""
         ]
     ],
     "id_suffix": "default_with_rules"

--- a/tests/data/rule-configs/ec2.json
+++ b/tests/data/rule-configs/ec2.json
@@ -26,6 +26,7 @@
                                     "id": "sg-ap111111",
                                     "name": "default",
                                     "owner_id": "123456789012",
+                                    "is_default_configuration": true,
                                     "rules": {
                                         "egress": {
                                             "count": 0,
@@ -77,6 +78,7 @@
                                     "id": "sg-ap222222",
                                     "name": "default",
                                     "owner_id": "123456789012",
+                                    "is_default_configuration": true,
                                     "rules": {
                                         "egress": {
                                             "count": 0,
@@ -125,6 +127,7 @@
                                     "id": "sg-eu111111",
                                     "name": "default",
                                     "owner_id": "123456789012",
+                                    "is_default_configuration": true,
                                     "rules": {
                                         "egress": {
                                             "count": 0,
@@ -154,6 +157,7 @@
                                     "id": "sg-eu111111",
                                     "name": "default",
                                     "owner_id": "123456789012",
+                                    "is_default_configuration": true,
                                     "rules": {
                                         "egress": {
                                             "count": 0,
@@ -175,6 +179,7 @@
                                     "id": "sg-eu222222",
                                     "name": "test-sg-222222",
                                     "owner_id": "123456789012",
+                                    "is_default_configuration": true,
                                     "rules": {
                                         "egress": {
                                             "count": 1,
@@ -262,6 +267,7 @@
                                     "id": "sg-sa111111",
                                     "name": "default",
                                     "owner_id": "123456789012",
+                                    "is_default_configuration": true,
                                     "rules": {
                                         "egress": {
                                             "count": 0,
@@ -278,6 +284,7 @@
                                     "id": "sg-sa111111",
                                     "name": "testsg",
                                     "owner_id": "123456789012",
+                                    "is_default_configuration": true,
                                     "rules": {
                                         "egress": {
                                             "count": 0,
@@ -308,6 +315,7 @@
                                     "id": "sg-sa33333333",
                                     "name": "testsg",
                                     "owner_id": "123456789012",
+                                    "is_default_configuration": true,
                                     "rules": {
                                         "egress": {
                                             "count": 0,

--- a/tests/test_rules_processingengine.py
+++ b/tests/test_rules_processingengine.py
@@ -20,8 +20,7 @@ class TestScoutRulesProcessingEngine(unittest.TestCase):
         self.test_dir = os.path.dirname(os.path.realpath(__file__))
 
     # TODO
-    # Check that one testcase per finding rule exists (should be within default
-    # reulset)
+    # Check that one testcase per finding rule exists (should be within default ruleset)
 
     def test_all_finding_rules(self):
         ruleset_file_name = os.path.join(self.test_dir, 'data/ruleset-test.json')


### PR DESCRIPTION
# Description

- Added `is_default_configuration` SG parameter based on the following ([source](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html)):

```
A default security group is named default, and it has an ID assigned by AWS. The following are the default rules for each default security group:

- Allows all inbound traffic from other instances associated with the default security group. The security group specifies itself as a source security group in its inbound rules.

- Allows all outbound traffic from the instance.
```

- Added previous parameter check to the following rules:
  - `ec2-default-security-group-in-use.json`
  - `ec2-default-security-group-with-rules.json`

Fixes #5

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes