### PR TITLE
Bugfix/Handle GCP API Quotas

### DIFF
--- a/ScoutSuite/providers/gcp/facade/utils.py
+++ b/ScoutSuite/providers/gcp/facade/utils.py
@@ -1,17 +1,18 @@
 from ScoutSuite.providers.utils import run_concurrently
 
+
 class GCPFacadeUtils:
     @staticmethod
-    def _get_all(resources, resource_key: str, request, resources_group):
+    async def _get_all(resources, resource_key: str, request, resources_group):
         while request is not None:
             response = request.execute()
             resources.extend(response.get(resource_key, []))
-            request = resources_group.list_next(previous_request=request, previous_response=response)
+            request = await run_concurrently(
+                lambda: resources_group.list_next(previous_request=request, previous_response=response)
+            )
 
     @staticmethod
     async def get_all(resource_key: str, request, resources_group):
         resources = []
-        await run_concurrently(
-            lambda: GCPFacadeUtils._get_all(resources, resource_key, request, resources_group)
-        )
+        await GCPFacadeUtils._get_all(resources, resource_key, request, resources_group)
         return resources

--- a/ScoutSuite/providers/gcp/utils.py
+++ b/ScoutSuite/providers/gcp/utils.py
@@ -1,0 +1,17 @@
+from ScoutSuite.core.console import print_exception
+
+def is_throttled(e):
+    """
+    Determines whether the exception is due to API throttling.
+
+    :param e:                           Exception raised
+    :return:                            True if it's a throttling exception else False
+    """
+    try:
+        if 'Quota exceeded' in str(e):
+            return True
+        else:
+            return False
+    except Exception as e:
+        print_exception(f'Unable to validate exception for throttling: {e}')
+        return False

--- a/ScoutSuite/providers/utils.py
+++ b/ScoutSuite/providers/utils.py
@@ -3,6 +3,7 @@ from hashlib import sha1
 
 from ScoutSuite.core.console import print_info
 from ScoutSuite.providers.aws.utils import is_throttled as aws_is_throttled
+from ScoutSuite.providers.gcp.utils import is_throttled as gcp_is_throttled
 
 
 def get_non_provider_id(name):
@@ -118,4 +119,4 @@ def is_throttled(e):
              'projects/' in e.message):
         return False
     else:
-        return aws_is_throttled(e)
+        return aws_is_throttled(e) or gcp_is_throttled(e)


### PR DESCRIPTION
# Description

Fixes https://github.com/nccgroup/ScoutSuite/issues/815 by:
- Moving the calls to `run_concurrently` into the paginator, to allow `--max-rate` to come into effect.
- Added detection for rate limiting, so the exponential back-off should kick in.

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
