### PR TITLE
Fix AttributeErrors in Azure VM resources

### DIFF
--- a/ScoutSuite/providers/azure/resources/virtualmachines/disks.py
+++ b/ScoutSuite/providers/azure/resources/virtualmachines/disks.py
@@ -17,7 +17,8 @@ class Disks(AzureResources):
     def _parse_disk(self, raw_disk):
         disk_dict = {}
         disk_dict['id'] = get_non_provider_id(raw_disk.id)
-        disk_dict['unique_id'] = raw_disk.unique_id
+        disk_dict['unique_id'] = raw_disk.unique_id if \
+            hasattr(raw_disk, 'unique_id') else None
         disk_dict['name'] = raw_disk.name
         disk_dict['type'] = raw_disk.type
         disk_dict['location'] = raw_disk.location
@@ -30,14 +31,15 @@ class Disks(AzureResources):
         disk_dict['hyper_vgeneration'] = raw_disk.hyper_vgeneration
         disk_dict['creation_data'] = raw_disk.creation_data
         disk_dict['disk_size_gb'] = raw_disk.disk_size_gb
-        disk_dict['disk_size_bytes'] = raw_disk.disk_size_bytes
+        disk_dict['disk_size_bytes'] = raw_disk.disk_size_bytes if \
+            hasattr(raw_disk, 'disk_size_bytes') else None
         disk_dict['provisioning_state'] = raw_disk.provisioning_state
         disk_dict['disk_iops_read_write'] = raw_disk.disk_iops_read_write
         disk_dict['disk_mbps_read_write'] = raw_disk.disk_mbps_read_write
         disk_dict['disk_state'] = raw_disk.disk_state
         disk_dict['additional_properties'] = raw_disk.additional_properties
 
-        if raw_disk.encryption and raw_disk.encryption.type:
+        if hasattr(raw_disk, 'encryption') and hasattr(raw_disk.encryption, 'type'):
             disk_dict['encryption_type'] = raw_disk.encryption.type
         else:
             disk_dict['encryption_type'] = None

--- a/ScoutSuite/providers/azure/resources/virtualmachines/snapshots.py
+++ b/ScoutSuite/providers/azure/resources/virtualmachines/snapshots.py
@@ -29,21 +29,16 @@ class Snapshots(AzureResources):
         snapshot_dict['hyper_vgeneration'] = raw_snapshot.hyper_vgeneration
         snapshot_dict['creation_data'] = raw_snapshot.creation_data
         snapshot_dict['disk_size_gb'] = raw_snapshot.disk_size_gb
-        snapshot_dict['disk_size_bytes'] = raw_snapshot.disk_size_bytes
-        snapshot_dict['unique_id'] = raw_snapshot.unique_id
+        snapshot_dict['disk_size_bytes'] = raw_snapshot.disk_size_bytes if \
+            hasattr(raw_snapshot, 'disk_size_bytes') else None
+        snapshot_dict['unique_id'] = raw_snapshot.unique_id if \
+            hasattr(raw_snapshot, 'unique_id') else None
         snapshot_dict['provisioning_state'] = raw_snapshot.provisioning_state
-        snapshot_dict['incremental'] = raw_snapshot.incremental
+        snapshot_dict['incremental'] = raw_snapshot.incremental if \
+            hasattr(raw_snapshot, 'incremental') else None
         snapshot_dict['additional_properties'] = raw_snapshot.additional_properties
 
-        # TODO this can be removed
-        # snapshot_dict['encryption'] = raw_snapshot.encryption
-        # snapshot_dict['encryption_settings_collection'] = raw_snapshot.encryption_settings_collection
-        # if raw_snapshot.encryption_settings_collection and raw_snapshot.encryption_settings_collection.enabled:
-        #     snapshot_dict['encryption_enabled'] = True
-        # else:
-        #     snapshot_dict['encryption_enabled'] = False
-
-        if raw_snapshot.encryption and raw_snapshot.encryption.type:
+        if hasattr(raw_snapshot, 'encryption') and hasattr(raw_snapshot.encryption, 'type'):
             snapshot_dict['encryption_type'] = raw_snapshot.encryption.type
         else:
             snapshot_dict['encryption_type'] = None


### PR DESCRIPTION
# Description

This fixes a couple of "AttributeErrors" being thrown by the 'Disk' and 'Snapshot' objects under resources of type 'virtualmachines' in the Azure provider. Some of these attributes (like 'unique_id' and 'disk_size_bytes') are no more exported by the 'Snapshot' and 'Disk' classes under the 'azure-mgmt-compute' python package, see: https://docs.microsoft.com/en-us/python/api/azure-mgmt-compute/?view=azure-python

This also provides a better handling for some conditionals that check snapshots and disks encryption attributes with using a 'hasattr()' rather than than looking up the missing attributes directly, e.g: 'raw_snapshot.encryption', which seems like an old Python2 code, and alternatively we can add a "try .. catch" for the "AttributeError" exception.

Example of some "AttributeError"s being thrown:
```
2020-10-06 08:34:34 xxx scout[430] INFO Fetching resources for the App Services service
2020-10-06 08:35:29 xxx asyncio[430] ERROR Task exception was never retrieved
future: <Task finished name='Task-39' coro=<Disks.fetch_all() done, defined at /../ScoutSuite/ScoutSuite/providers/azure/resources/virtualmachines/disks.py:12> exception=AttributeError("'Disk' object has no attribute 'unique_id'")>
Traceback (most recent call last):
  File "/../ScoutSuite/ScoutSuite/providers/azure/resources/virtualmachines/disks.py", line 14, in fetch_all
    id, disk = self._parse_disk(raw_disk)
  File "/../ScoutSuite/ScoutSuite/providers/azure/resources/virtualmachines/disks.py", line 20, in _parse_disk
    disk_dict['unique_id'] = raw_disk.unique_id
AttributeError: 'Disk' object has no attribute 'unique_id'
2020-10-06 08:35:29 xxx asyncio[430] ERROR Task exception was never retrieved
future: <Task finished name='Task-40' coro=<Snapshots.fetch_all() done, defined at /mnt/../ScoutSuite/ScoutSuite/providers/azure/resources/virtualmachines/snapshots.py:12> exception=AttributeError("'Snapshot' object has no attribute 'disk_size_bytes'")>
Traceback (most recent call last):
  File "/../ScoutSuite/ScoutSuite/providers/azure/resources/virtualmachines/snapshots.py", line 14, in fetch_all
    id, snapshot = self._parse_snapshot(raw_snapshot)
  File "/../ScoutSuite/ScoutSuite/providers/azure/resources/virtualmachines/snapshots.py", line 32, in _parse_snapshot
    snapshot_dict['disk_size_bytes'] = raw_snapshot.disk_size_bytes
AttributeError: 'Snapshot' object has no attribute 'disk_size_bytes'
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
