### PR TITLE
Fix '--update' functionality to include previous results

### DIFF
--- a/ScoutSuite/__main__.py
+++ b/ScoutSuite/__main__.py
@@ -273,11 +273,14 @@ async def _run(provider,
         if update:
             try:
                 print_info('Updating existing data')
-                current_run_services = copy.deepcopy(cloud_provider.services)
+                #Load previous results
                 last_run_dict = report.encoder.load_from_file('RESULTS')
-                cloud_provider.services = last_run_dict['services']
-                for service in cloud_provider.service_list:
-                    cloud_provider.services[service] = current_run_services[service]
+                #Get list of previous services which were not updated during this run
+                previous_services = [prev_service for prev_service in last_run_dict['service_list'] if prev_service not in cloud_provider.service_list]
+                #Add previous services
+                for service in previous_services:
+                    cloud_provider.service_list.append(service)
+                    cloud_provider.services[service] = last_run_dict['services'][service]
             except Exception as e:
                 print_exception('Failure while updating report: {}'.format(e))
 


### PR DESCRIPTION
# Description

- The `--update` feature was fixed to include all the previous results and update the relevant services specified by the user.
- The updated services are reflected in the final HTML report.
- Also removed one usage of deepcopy (related to #365).

Fixes #361 

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
