### PR TITLE
Correct retrieval of S3 bucket 'CreationDate'

### DIFF
--- a/ScoutSuite/providers/aws/facade/s3.py
+++ b/ScoutSuite/providers/aws/facade/s3.py
@@ -2,7 +2,7 @@ import json
 
 from botocore.exceptions import ClientError
 
-from ScoutSuite.core.console import print_exception
+from ScoutSuite.core.console import print_exception, print_debug
 from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
 from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 from ScoutSuite.providers.utils import run_concurrently, get_and_set_concurrently
@@ -52,7 +52,7 @@ class S3Facade(AWSBaseFacade):
             # Non-async post-processing
             for bucket in buckets:
                 self._set_s3_bucket_secure_transport(bucket)
-            #Update CreationDate of all buckets with the correct values from 'us-east-1'
+            # Try to update CreationDate of all buckets with the correct values from 'us-east-1'
             self._get_and_set_s3_bucket_creationdate(buckets)
 
             return buckets
@@ -195,17 +195,21 @@ class S3Facade(AWSBaseFacade):
             print_exception('Failed to get the public access block configuration for {}: {}'.format(bucket['Name'], e))
 
     def _get_and_set_s3_bucket_creationdate(self, buckets):
-        #When using region other than 'us-east-1', the 'CreationDate' is the last modified time according to bucket's last replication in the respective region
-        #Source: https://github.com/aws/aws-cli/issues/3597#issuecomment-424167129
-        #Fixes issue #858
+        # When using region other than 'us-east-1', the 'CreationDate' is the last modified time according to bucket's
+        # last replication in the respective region
+        # Source: https://github.com/aws/aws-cli/issues/3597#issuecomment-424167129
+        # Fixes issue https://github.com/nccgroup/ScoutSuite/issues/858
         client = AWSFacadeUtils.get_client('s3', self.session, 'us-east-1')
         try:
             buckets_useast1 = client.list_buckets()['Buckets']
             for bucket in buckets:
-                #Find the bucket with the same name and update 'CreationDate' from the 'us-east-1' region data, if doesn't exist keep the original value
-                bucket['CreationDate'] = next((buck['CreationDate'] for buck in buckets_useast1 if buck['Name'] == bucket['Name']), bucket['CreationDate'])
+                # Find the bucket with the same name and update 'CreationDate' from the 'us-east-1' region data,
+                # if doesn't exist keep the original value
+                bucket['CreationDate'] = next((b['CreationDate'] for b in buckets_useast1 if
+                                               b['Name'] == bucket['Name']), bucket['CreationDate'])
         except Exception as e:
-            print_exception('Failed to list buckets using region "us-east-1"')
+            # Only output exception when in debug mode
+            print_debug('Failed to get bucket creation date from "us-east-1" region')
 
     def _set_s3_bucket_secure_transport(self, bucket: {}):
         try:


### PR DESCRIPTION
# Description

The `CreationDate` returned by the AWS SDK and AWS CLI is the last modified time according to the bucket's last replication time depending on the default region which can be modified when changes are done to the bucket (e.g. editing the bucket's policy). This is not the actual creation date which is registered in `us-east-1` region where these are "mastered" .

References:
- https://github.com/aws/aws-cli/issues/3597#issuecomment-424167129
- https://stackoverflow.com/a/52489194

Fixes #858 

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
