### PR TITLE
Added argument parser epilog for clarity

### DIFF
--- a/ScoutSuite/core/cli_parser.py
+++ b/ScoutSuite/core/cli_parser.py
@@ -5,7 +5,7 @@ from ScoutSuite import __version__
 class ScoutSuiteArgumentParser:
 
     def __init__(self):
-        self.parser = argparse.ArgumentParser()
+        self.parser = argparse.ArgumentParser(epilog='To get addtional help on a specific provider run: scout.py {provider} -h')
 
         # People will still be able to use the old --provider syntax
         self.parser.add_argument("--provider",


### PR DESCRIPTION
# Description

Added a help message for clarity indicating that nested help menus exist.

```
python scout.py -h

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit

The provider you want to run scout against:
  {aws,gcp,azure,aliyun,oci}
    aws                 Run Scout against an Amazon Web Services account
    gcp                 Run Scout against a Google Cloud Platform account
    azure               Run Scout against a Microsoft Azure account
    aliyun              Run Scout against an Alibaba Cloud account
    oci                 Run Scout against an Oracle Cloud Infrastructure account

To get addtional help on a specific provider run: scout.py {provider} -h
```

Fixes #506 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
