### PR TITLE
iam rule

### DIFF
--- a/ScoutSuite/providers/gcp/rules/findings/iam-user-has-sa-user-role.json
+++ b/ScoutSuite/providers/gcp/rules/findings/iam-user-has-sa-user-role.json
@@ -1,6 +1,6 @@
 {
-    "description": "User with \"Service Account User\" or \"Service Account Token Creator\" Role at the Project Level",
-    "rationale": "Granting the iam.serviceAccountUser or the iam.serviceAccountTokenCreator role to a user for a project gives the user access to all service accounts in the project, including service accounts that may be created in the future. This can result into elevation of privileges by using service accounts and corresponding Compute Engine instances.",
+    "description": "User with Privileged Service Account Roles at the Project Level",
+    "rationale": "Granting the iam.serviceAccountUser, iam.serviceAccountTokenCreator, or iam.serviceAccountActor role to a user for a project gives the user access to all service accounts in the project, including service accounts that may be created in the future. This can result into elevation of privileges by using service accounts and corresponding Compute Engine instances.",
     "compliance": [
         {
             "name": "CIS Google Cloud Platform Foundations",
@@ -22,7 +22,8 @@
             "containAtLeastOneOf",
             [
                 "iam.serviceAccountUser",
-                "iam.serviceAccountTokenCreator"
+                "iam.serviceAccountTokenCreator",
+                "iam.serviceAccountActor"
             ]
         ]
     ],

--- a/ScoutSuite/providers/gcp/rules/findings/iam-user-has-sa-user-role.json
+++ b/ScoutSuite/providers/gcp/rules/findings/iam-user-has-sa-user-role.json
@@ -1,6 +1,6 @@
 {
-    "description": "User with \"Service Account User\" Role at the Project Level",
-    "rationale": "Granting the iam.serviceAccountUser role to a user for a project gives the user access to all service accounts in the project, including service accounts that may be created in the future. This can result into elevation of privileges by using service accounts and corresponding Compute Engine instances.",
+    "description": "User with \"Service Account User\" or \"Service Account Token Creator\" Role at the Project Level",
+    "rationale": "Granting the iam.serviceAccountUser or the iam.serviceAccountTokenCreator role to a user for a project gives the user access to all service accounts in the project, including service accounts that may be created in the future. This can result into elevation of privileges by using service accounts and corresponding Compute Engine instances.",
     "compliance": [
         {
             "name": "CIS Google Cloud Platform Foundations",
@@ -21,7 +21,8 @@
             "iam.projects.id.bindings.id.name",
             "containAtLeastOneOf",
             [
-                "iam.serviceAccountUser"
+                "iam.serviceAccountUser",
+                "iam.serviceAccountTokenCreator"
             ]
         ]
     ],


### PR DESCRIPTION
# Description

**Make sure the PR is against the `develop` branch (see [Contributing](https://github.com/nccgroup/ScoutSuite/blob/master/CONTRIBUTING.md)).**

Please include a summary of the change(s) and which issue(s) it addresses. Please also include relevant motivation and context.

Currently, the ```User with \"Service Account User\" Role at the Project Level``` rule includes only service account user permissions assigned at the project level, which would  ostensibly allow someone to elevate privileges if they also had compute permissions. I am proposing to add the Service Account Token Creator rule to this as well. In addition to the former, this would allow users to directly impersonate a service account, ostensibly shortening the path to privilege escalation. The Service Account Actor role is a deprecated role that is the union of the previous two roles, and also applies. (https://cloud.google.com/iam/docs/service-accounts#the_service_account_actor_role)

## Type of change
Rule change.

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes
