### PR TITLE
Fixed bug where returned path was incorrect after sanitizing

### DIFF
--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -1004,7 +1004,7 @@ function updateTitle(title) {
  * Updates the Document Object Model
  */
 function showPageFromHash() {
-    myhash = location.hash.replace(/[^a-z|0-9|.]/gi,'')
+    myhash = location.hash.replace(/[^a-z|0-9|.#-]/gi,'')
     if (myhash) {
         updateDOM(myhash)
     } else {


### PR DESCRIPTION
# Description

The following code was changed to fix #937:

```javascript
function showPageFromHash() {
    myhash = location.hash.replace(/[^a-z|0-9|.]/gi,'')
    if (myhash) {
        updateDOM(myhash)
    } else {
        updateDOM('')
    }
}
```

As a result, this would generate errors and would not allow a user to, for example, browse to specific issues. This is due to the replacement of `-` and `#` characters which will break a further call to `getValueAt` (lines [1187](https://github.com/nccgroup/ScoutSuite/blob/69ba1943e9ad64dd19a8fc650a5d63e4bcc4bb2c/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js#L1187) and [1189](https://github.com/nccgroup/ScoutSuite/blob/69ba1943e9ad64dd19a8fc650a5d63e4bcc4bb2c/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js#L1189)) in [`getResourcePath`](https://github.com/nccgroup/ScoutSuite/blob/69ba1943e9ad64dd19a8fc650a5d63e4bcc4bb2c/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js#L1185).

Fixes #937

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
