### PR TITLE
Fixed bug where returned path was incorrect after sanitizing

### DIFF
--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -1004,7 +1004,7 @@ function updateTitle(title) {
  * Updates the Document Object Model
  */
 function showPageFromHash() {
-    myhash = location.hash.replace(/[^a-z|0-9|.#-]/gi,'')
+    myhash = location.hash.replace(/[^a-z|0-9|.#-_]/gi,'')
     if (myhash) {
         updateDOM(myhash)
     } else {


### PR DESCRIPTION
# Description

Related to PR #964, where some paths have underscores (`_`) which were removed.

Fixes #937 and #964

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
