### PR TITLE
Ignore profiling output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,7 @@ report-*
 /private*/
 /**/private*/
 
+#Profiling output
+*.prof
+
 !docker/bin


### PR DESCRIPTION
# Description

Added `*.prof` to `.gitignore` to ignore profiling output (e.g. when using cProfile with `-o` flag).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
