### PR TITLE
Correct matching for EC2 instances in VPCs partial

### DIFF
--- a/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.vpcs.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.vpc.regions.id.vpcs.html
@@ -35,13 +35,13 @@
                 {{> count_badge count=(count_vpc_instances instances) target=(concat '#services.vpc.regions' region 'vpcs' @key 'instances')}}
             </h4>
             <div id="services.vpc.regions.{{region}}.vpcs.{{@key}}.instances" class="accordion-body">
-              <div class="accordion-inner">
-                <ul class="no-bullet">
-                  {{#each instances}}
-                    <li><a href="javascript:showObject('services.vpc.regions.{{../region}}.vpcs.{{@../key}}.instances.{{@key}}')">{{@key}}</a></li>
-                  {{/each}}
-                </ul>
-              </div>
+              <ul>
+                {{#each instances}}
+                  <li class="list-group-item-text"><a href="javascript:showObject('services.ec2.regions.{{../region}}.vpcs.{{@../key}}.instances.{{this}}')">
+                    {{getValueAt 'services.ec2.regions' ../region 'vpcs' @../key 'instances' this 'name'}}
+                  </a></li>
+                {{/each}}
+              </ul>
             </div>
           </div>
         </div>

--- a/ScoutSuite/providers/aws/metadata.json
+++ b/ScoutSuite/providers/aws/metadata.json
@@ -181,9 +181,7 @@
                 "instances": {
                     "cols": 2,
                     "path": "services.ec2.regions.id.vpcs.id.instances",
-                    "callbacks": [
-                        [ "match_instances_and_subnets_callback", { } ]
-                    ]
+                    "callbacks": [  ]
                 },
                 "security_groups": {
                     "cols": 2,

--- a/ScoutSuite/providers/aws/metadata.json
+++ b/ScoutSuite/providers/aws/metadata.json
@@ -182,8 +182,7 @@
                     "cols": 2,
                     "path": "services.ec2.regions.id.vpcs.id.instances",
                     "callbacks": [
-                        [ "match_instances_and_subnets_callback", { } ],
-                        [ "match_instances_and_vpcs_callback", { } ]
+                        [ "match_instances_and_subnets_callback", { } ]
                     ]
                 },
                 "security_groups": {

--- a/ScoutSuite/providers/aws/metadata.json
+++ b/ScoutSuite/providers/aws/metadata.json
@@ -182,10 +182,8 @@
                     "cols": 2,
                     "path": "services.ec2.regions.id.vpcs.id.instances",
                     "callbacks": [
-                        [
-                            "match_instances_and_subnets_callback",
-                            { }
-                        ]
+                        [ "match_instances_and_subnets_callback", { } ],
+                        [ "match_instances_and_vpcs_callback", { } ]
                     ]
                 },
                 "security_groups": {

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -410,6 +410,16 @@ class AWSProvider(BaseProvider):
                 if instance_id not in subnet['instances']:
                     subnet['instances'].append(instance_id)
 
+    def match_instances_and_vpcs_callback(self, current_config, path, current_path, instance_id, callback_args):
+        if 'ec2' in self.service_list and 'vpc' in self.service_list:  # validate both services were included in run
+            subnet_id = current_config['SubnetId']  # get the subnet ID
+            if subnet_id:
+                vpc_data = self.subnet_map[subnet_id]  # get the corresponding VPC ID and region
+                vpc = self.services['vpc']['regions'][vpc_data['region']]['vpcs'][vpc_data['vpc_id']]  # find the VPC reference
+                manage_dictionary(vpc, 'instances', [])  # initialize instances list for the VPC (if not already set)
+                if instance_id not in vpc['instances']:  # if instance is not already mapped to the VPC
+                    vpc['instances'].append(instance_id)  # append EC2 instance ID to instance list in VPC
+
     def _match_instances_and_roles(self):
         if 'ec2' in self.service_list and 'iam' in self.service_list:  # validate both services were included in run
             ec2_config = self.services['ec2']

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -82,6 +82,7 @@ class AWSProvider(BaseProvider):
         
         if 'ec2' in self.service_list and 'vpc' in self.service_list:
             self._match_instances_and_vpcs()
+            self._match_instances_and_subnets()
 
         if 'awslambda' in self.service_list and 'iam' in self.service_list:
             self._match_lambdas_and_roles()
@@ -403,15 +404,13 @@ class AWSProvider(BaseProvider):
             subnet = get_object_at(self, subnet_path)
             subnet['network_acl'] = acl_id
 
-    def match_instances_and_subnets_callback(self, current_config, path, current_path, instance_id, callback_args):
-        if 'ec2' in self.service_list and 'vpc' in self.service_list:  # validate both services were included in run
-            subnet_id = current_config['SubnetId']
-            if subnet_id:
-                vpc = self.subnet_map[subnet_id]
-                subnet = self.services['vpc']['regions'][vpc['region']]['vpcs'][vpc['vpc_id']]['subnets'][subnet_id]
-                manage_dictionary(subnet, 'instances', [])
-                if instance_id not in subnet['instances']:
-                    subnet['instances'].append(instance_id)
+    def _match_instances_and_subnets(self):
+        ec2_instances = self._get_ec2_instances_details(['id', 'vpc', 'region', 'SubnetId'])  # fetch all EC2 instances with only required fields
+        for instance in ec2_instances.values():
+            subnet = self.services['vpc']['regions'][instance['region']]['vpcs'][instance['vpc']]['subnets'][instance['SubnetId']]  # find the subnet reference
+            manage_dictionary(subnet, 'instances', [])  # initialize instances list for the subnet (if not already set)
+            if instance['id'] not in subnet['instances']:  # if instance is not already mapped to the subnet
+                subnet['instances'].append(instance['id'])  # append EC2 instance ID to instance list in subnet
 
     def _get_ec2_instances_details(self, details=None):
         """

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -80,6 +80,9 @@ class AWSProvider(BaseProvider):
         if 'ec2' in self.service_list and 'iam' in self.service_list:
             self._match_instances_and_roles()
         
+        if 'ec2' in self.service_list and 'vpc' in self.service_list:
+            self._match_instances_and_vpcs()
+
         if 'awslambda' in self.service_list and 'iam' in self.service_list:
             self._match_lambdas_and_roles()
 
@@ -410,15 +413,36 @@ class AWSProvider(BaseProvider):
                 if instance_id not in subnet['instances']:
                     subnet['instances'].append(instance_id)
 
-    def match_instances_and_vpcs_callback(self, current_config, path, current_path, instance_id, callback_args):
-        if 'ec2' in self.service_list and 'vpc' in self.service_list:  # validate both services were included in run
-            subnet_id = current_config['SubnetId']  # get the subnet ID
-            if subnet_id:
-                vpc_data = self.subnet_map[subnet_id]  # get the corresponding VPC ID and region
-                vpc = self.services['vpc']['regions'][vpc_data['region']]['vpcs'][vpc_data['vpc_id']]  # find the VPC reference
-                manage_dictionary(vpc, 'instances', [])  # initialize instances list for the VPC (if not already set)
-                if instance_id not in vpc['instances']:  # if instance is not already mapped to the VPC
-                    vpc['instances'].append(instance_id)  # append EC2 instance ID to instance list in VPC
+    def _get_ec2_instances_details(self, details=None):
+        """
+        Fetches a list of EC2 instances 
+
+        :param details [str]:       (Optional) List of details to be included, if not specified, all details will be included
+        :return:                    A dictionary of EC2 instances with the specified details
+        """
+        ec2_instances = {}
+        for ec2_region_id, ec2_region_data in self.services['ec2']['regions'].items():
+            if ec2_region_data['instances_count'] > 0:
+                for region_vpc_id, region_vpc_data in ec2_region_data['vpcs'].items():
+                    if region_vpc_data['instances_count'] > 0:
+                        for ec2_instance_id, ec2_instance_data in region_vpc_data['instances'].items():
+                            ec2_instances[ec2_instance_id] = ec2_instance_data.copy()
+                            ec2_instances[ec2_instance_id]['region'] = ec2_region_id
+                            ec2_instances[ec2_instance_id]['vpc'] = region_vpc_id
+        if details is not None:
+            for instance_key in ec2_instances.keys():
+                for detail in list(ec2_instances[instance_key].keys()):
+                    if detail not in details:
+                        ec2_instances[instance_key].pop(detail, None)
+        return ec2_instances
+
+    def _match_instances_and_vpcs(self):
+        ec2_instances = self._get_ec2_instances_details(['id', 'vpc', 'region'])  # fetch all EC2 instances with only required fields
+        for instance in ec2_instances.values():
+            vpc = self.services['vpc']['regions'][instance['region']]['vpcs'][instance['vpc']]  # find the VPC reference
+            manage_dictionary(vpc, 'instances', [])  # initialize instances list for the VPC (if not already set)
+            if instance['id'] not in vpc['instances']:  # if instance is not already mapped to the VPC
+                vpc['instances'].append(instance['id'])  # append EC2 instance ID to instance list in VPC
 
     def _match_instances_and_roles(self):
         if 'ec2' in self.service_list and 'iam' in self.service_list:  # validate both services were included in run


### PR DESCRIPTION
# Description

Implemented and added a new methods to `aws/provider.py:preprocessing` to match EC2 instances to their respective VPCs and subnets. Removed the old callbacks from `aws/metadata.json`. Also the VPCs partial has been modified to reflect the new changes and now the corresponding EC2 instances are displayed correctly (count, name and the specific details with `showObject`).

Fixes #878 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
