### PR TITLE
Stop reporting KMS keys as having rotation disabled when they're pending deletion

### DIFF
--- a/ScoutSuite/providers/aws/resources/kms/keys.py
+++ b/ScoutSuite/providers/aws/resources/kms/keys.py
@@ -34,7 +34,8 @@ class Keys(AWSCompositeResources):
         if 'metadata' in raw_key:
             key_dict['creation_date'] = raw_key['metadata']['KeyMetadata']['CreationDate'] if \
                 raw_key['metadata']['KeyMetadata']['CreationDate'] else None
-            key_dict['key_enabled'] = False if raw_key['metadata']['KeyMetadata']['KeyState'] == 'Disabled' else True
+            key_dict['key_enabled'] = False if raw_key['metadata']['KeyMetadata']['KeyState'] in \
+                ['Disabled', 'PendingDeletion'] else True
             key_dict['description'] = raw_key['metadata']['KeyMetadata']['Description'] if len(
                 raw_key['metadata']['KeyMetadata']['Description'].strip()) > 0 else None
             key_dict['origin'] = raw_key['metadata']['KeyMetadata']['Origin'] if len(

--- a/ScoutSuite/providers/aws/rules/findings/kms-cmk-rotation-disabled.json
+++ b/ScoutSuite/providers/aws/rules/findings/kms-cmk-rotation-disabled.json
@@ -41,6 +41,11 @@
             "kms.regions.id.keys.id.key_manager",
             "equal",
             "CUSTOMER"
+        ],
+        [
+            "kms.regions.id.keys.id.key_enabled",
+            "true",
+            ""
         ]
     ],
     "id_suffix": "rotation_enabled"


### PR DESCRIPTION
# Description

When deleting a KMS key, AWS forces it into a "pending deletion" state for at least 7 days.  During this time, it will report the key as having rotation disabled, causing the `kms-cmk-rotation-disabled` warning to fire.  Recognize this case and don't warn.

Fixes #1174

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes
