### PR TITLE
Removed hardcoded RDS ARN partition when fetching tags

### DIFF
--- a/ScoutSuite/providers/aws/facade/rds.py
+++ b/ScoutSuite/providers/aws/facade/rds.py
@@ -49,7 +49,7 @@ class RDSFacade(AWSBaseFacade):
         account_id = get_aws_account_id(self.session)
         try:
             instance_tagset = await run_concurrently(lambda: client.list_tags_for_resource(
-                ResourceName="arn:aws:rds:"+region+":"+account_id+":db:"+instance['DBInstanceIdentifier']))
+                ResourceName=instance['DBInstanceArn']))
             instance['Tags'] = {x['Key']: x['Value'] for x in instance_tagset['TagList']}
         except ClientError as e:
             if e.response['Error']['Code'] != 'NoSuchTagSet':


### PR DESCRIPTION
# Description

The partition part of the RDS ARN was hardcoded when fetching tags. This has been ammended by using the returned ARN instead of a custom parsed one.

Fixes #1183

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
