### PR TITLE
GCP Network Benchmarks - 3.1 & 3.2

### DIFF
--- a/ScoutSuite/output/data/html/partials/gcp/services.computeengine.projects.id.networks.html
+++ b/ScoutSuite/output/data/html/partials/gcp/services.computeengine.projects.id.networks.html
@@ -11,6 +11,7 @@
         <div class="list-group-item-text item-margin">Project ID: <span id="computeengine.projects.{{@../key}}.networks.{{@key}}.project_id">{{project_id}}</span></div>
         <div class="list-group-item-text item-margin">Description: <span id="computeengine.projects.{{@../key}}.networks.{{@key}}.description"><samp>{{description}}</samp></span></div>
         <div class="list-group-item-text item-margin">Creation Date: <span id="computeengine.projects.{{@../key}}.networks.{{@key}}.creation_timestamp">{{format_date creation_timestamp}}</span></div>
+        <div class="list-group-item-text item-margin">Legacy Mode: <span id="computeengine.projects.{{@../key}}.networks.{{@key}}.legacy_mode">{{ legacy_mode}}</span></div>
     </div>
     <div class="list-group-item">
         <h4 class="list-group-item-heading accordion-heading">Firewall Rules

--- a/ScoutSuite/providers/gcp/resources/gce/networks.py
+++ b/ScoutSuite/providers/gcp/resources/gce/networks.py
@@ -18,6 +18,7 @@ class Networks(Resources):
         network_dict['id'] = raw_network['id']
         network_dict['project_id'] = raw_network['selfLink'].split('/')[-4]
         network_dict['name'] = raw_network['name']
+
         network_dict['description'] = self._get_description(raw_network)
         network_dict['creation_timestamp'] = raw_network['creationTimestamp']
         network_dict['auto_subnet'] = raw_network.get('autoCreateSubnetworks', None)
@@ -25,6 +26,7 @@ class Networks(Resources):
 
         network_dict['network_url'] = raw_network['selfLink']
         network_dict['subnetwork_urls'] = raw_network.get('subnetworks', None)
+
 
         return network_dict['id'], network_dict
 

--- a/ScoutSuite/providers/gcp/resources/gce/networks.py
+++ b/ScoutSuite/providers/gcp/resources/gce/networks.py
@@ -26,7 +26,10 @@ class Networks(Resources):
 
         network_dict['network_url'] = raw_network['selfLink']
         network_dict['subnetwork_urls'] = raw_network.get('subnetworks', None)
-
+        # Network is legacy if there is no subnets
+        network_dict['legacy_mode'] = True \
+            if raw_network.get('subnetworks', None) is None or not raw_network.get('subnetworks', None) \
+            else False
 
         return network_dict['id'], network_dict
 

--- a/ScoutSuite/providers/gcp/rules/findings/computeengine-network-default-in-use.json
+++ b/ScoutSuite/providers/gcp/rules/findings/computeengine-network-default-in-use.json
@@ -1,5 +1,5 @@
 {
-    "description": "Default Network should not exist in a project",
+    "description": "Default Network should should be removed",
     "rationale": "The default network has a preconfigured network configuration and automatically generates insecure firewall rules. These automatically created firewall rules do not get audit logged and cannot be configured to enable firewall rule logging.",
     "remediation": "From  Console:\n<ol>\n    <li>Go to <samp>VPC networks</samp> page by visiting:\n        <a href=\"https://console.cloud.google.com/networking/networks/list\">https://console.cloud.google.com/networking/networks/list</a>\n    </li>\n    <li>Click the network named <samp>default</samp></li>\n    <li>On the network detail page, click <samp>EDIT</samp></li>\n    <li>Click <samp>DELETE VPC NETWORK</samp> </li>\n    <li>If needed, create a new network to replace the default network</li>\n</ol>",
     "compliance": [

--- a/ScoutSuite/providers/gcp/rules/findings/computeengine-network-default-in-use.json
+++ b/ScoutSuite/providers/gcp/rules/findings/computeengine-network-default-in-use.json
@@ -1,0 +1,32 @@
+{
+    "description": "Default Network should not exist in a project",
+    "rationale": "The default network has a preconfigured network configuration and automatically generates insecure firewall rules. These automatically created firewall rules do not get audit logged and cannot be configured to enable firewall rule logging.",
+    "remediation": "From  Console:\n<ol>\n    <li>Go to <samp>VPC networks</samp> page by visiting:\n        <a href=\"https://console.cloud.google.com/networking/networks/list\">https://console.cloud.google.com/networking/networks/list</a>\n    </li>\n    <li>Click the network named <samp>default</samp></li>\n    <li>On the network detail page, click <samp>EDIT</samp></li>\n    <li>Click <samp>DELETE VPC NETWORK</samp> </li>\n    <li>If needed, create a new network to replace the default network</li>\n</ol>",
+    "compliance": [
+        {
+            "name": "CIS Google Cloud Platform Foundations",
+            "version": "1.1.0",
+            "reference": "3.1"
+        }
+    ],
+    "dashboard_name": "Networks",
+    "path": "computeengine.projects.id.networks.id",
+    "references": [
+        "https://cloud.google.com/compute/docs/networking#firewall_rules",
+        "https://cloud.google.com/compute/docs/reference/latest/networks/insert",
+        "https://cloud.google.com/compute/docs/reference/latest/networks/delete",
+        "https://cloud.google.com/vpc/docs/firewall-rules-logging",
+        "https://cloud.google.com/vpc/docs/vpc#default-network",
+        "https://cloud.google.com/sdk/gcloud/reference/compute/networks/delete"
+    ],
+    "conditions": [
+        "and",
+        [
+            "computeengine.projects.id.networks.id.name",
+            "equal",
+            "default"
+        ]
+    ],
+    "id_suffix": "name"
+
+}

--- a/ScoutSuite/providers/gcp/rules/findings/computeengine-network-legacy-in-use.json
+++ b/ScoutSuite/providers/gcp/rules/findings/computeengine-network-legacy-in-use.json
@@ -16,17 +16,12 @@
     "https://cloud.google.com/vpc/docs/using-legacy#deleting_a_legacy_network"
   ],
   "conditions": [
-    "or",
+    "and",
     [
-      "computeengine.projects.id.networks.id.subnetwork_urls",
-      "empty",
+      "computeengine.projects.id.networks.id.legacy_mode",
+      "true",
       ""
-    ],
-    [
-      "computeengine.projects.id.networks.id.subnetwork_urls",
-      "equal",
-      "None"
     ]
   ],
-  "id_suffix": "name"
+  "id_suffix": "legacy_mode"
 }

--- a/ScoutSuite/providers/gcp/rules/findings/computeengine-network-legacy-in-use.json
+++ b/ScoutSuite/providers/gcp/rules/findings/computeengine-network-legacy-in-use.json
@@ -1,0 +1,32 @@
+{
+  "description": "Legacy Network should be removed",
+  "rationale": "Legacy networks have a single network IPv4 prefix range and a single gateway IP address for the whole network. The network is global in scope and spans all cloud regions. Subnetworks cannot be created in a legacy network and are unable to switch from legacy to auto or custom subnet networks. Legacy networks can have an impact for high network traffic projects and are subject to a single point of contention or failure.",
+  "remediation": "For each Google Cloud Platform project,\n<ol>\n    <li>\n        1. Follow the documentation and create a non-legacy network suitable for the organization's requirements.\n    </li>\n    <li>Follow the documentation and delete the networks in the <samp>legacy</samp> mode.</li>\n\n</ol>",
+  "compliance": [
+    {
+      "name": "CIS Google Cloud Platform Foundations",
+      "version": "1.1.0",
+      "reference": "3.2"
+    }
+  ],
+  "dashboard_name": "Networks",
+  "path": "computeengine.projects.id.networks.id",
+  "references": [
+    "https://cloud.google.com/vpc/docs/using-legacy#creating_a_legacy_network",
+    "https://cloud.google.com/vpc/docs/using-legacy#deleting_a_legacy_network"
+  ],
+  "conditions": [
+    "or",
+    [
+      "computeengine.projects.id.networks.id.subnetwork_urls",
+      "empty",
+      ""
+    ],
+    [
+      "computeengine.projects.id.networks.id.subnetwork_urls",
+      "equal",
+      "None"
+    ]
+  ],
+  "id_suffix": "name"
+}

--- a/ScoutSuite/providers/gcp/rules/rulesets/cis-1.1.0.json
+++ b/ScoutSuite/providers/gcp/rules/rulesets/cis-1.1.0.json
@@ -10,7 +10,7 @@
       "computeengine-network-default-in-use.json": [
             {
                 "enabled": true,
-                "level": "danger"
+                "level": "warning"
             }
         ],
       "computeengine-network-legacy-in-use.json": [

--- a/ScoutSuite/providers/gcp/rules/rulesets/cis-1.1.0.json
+++ b/ScoutSuite/providers/gcp/rules/rulesets/cis-1.1.0.json
@@ -6,7 +6,13 @@
               "enabled": true,
               "level": "warning"
           }
-      ]
+      ],
+      "computeengine-network-default-in-use.json": [
+            {
+                "enabled": true,
+                "level": "danger"
+            }
+        ]
     }
 
 }

--- a/ScoutSuite/providers/gcp/rules/rulesets/cis-1.1.0.json
+++ b/ScoutSuite/providers/gcp/rules/rulesets/cis-1.1.0.json
@@ -12,6 +12,12 @@
                 "enabled": true,
                 "level": "danger"
             }
+        ],
+      "computeengine-network-legacy-in-use.json": [
+            {
+                "enabled": true,
+                "level": "warning"
+            }
         ]
     }
 

--- a/ScoutSuite/providers/gcp/rules/rulesets/default.json
+++ b/ScoutSuite/providers/gcp/rules/rulesets/default.json
@@ -140,6 +140,12 @@
                 "level": "danger"
             }
         ],
+        "computeengine-network-legacy-in-use.json": [
+            {
+                "enabled": true,
+                "level": "warning"
+            }
+        ],
         "computeengine-old-disk-snapshot.json": [
             {
                 "enabled": true,

--- a/ScoutSuite/providers/gcp/rules/rulesets/default.json
+++ b/ScoutSuite/providers/gcp/rules/rulesets/default.json
@@ -134,6 +134,12 @@
                 "level": "warning"
             }
         ],
+        "computeengine-network-default-in-use.json": [
+            {
+                "enabled": true,
+                "level": "danger"
+            }
+        ],
         "computeengine-old-disk-snapshot.json": [
             {
                 "enabled": true,

--- a/ScoutSuite/providers/gcp/rules/rulesets/default.json
+++ b/ScoutSuite/providers/gcp/rules/rulesets/default.json
@@ -137,7 +137,7 @@
         "computeengine-network-default-in-use.json": [
             {
                 "enabled": true,
-                "level": "danger"
+                "level": "warning"
             }
         ],
         "computeengine-network-legacy-in-use.json": [


### PR DESCRIPTION
# Description
Benchmark to verify default network is not used(3.1) and to verify there is no legacy network(3.2). Please note that it is not possible to create legacy network anymore since the gcloud command was deprecated. 3.1 has been tested, but 3.2 has not been tested for that reason. The benchmarks will be found under compute engine.

Fixes # (issue)

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
