### PR TITLE
Enhancement/Improve ARN processing performance

### DIFF
--- a/ScoutSuite/providers/aws/facade/base.py
+++ b/ScoutSuite/providers/aws/facade/base.py
@@ -26,7 +26,7 @@ from ScoutSuite.providers.aws.facade.ses import SESFacade
 from ScoutSuite.providers.aws.facade.sns import SNSFacade
 from ScoutSuite.providers.aws.facade.sqs import SQSFacade
 from ScoutSuite.providers.aws.facade.secretsmanager import SecretsManagerFacade
-from ScoutSuite.providers.aws.utils import get_aws_account_id
+from ScoutSuite.providers.aws.utils import get_aws_account_id, get_partition_name
 from ScoutSuite.providers.utils import run_concurrently
 
 from ScoutSuite.core.conditions import print_error
@@ -66,6 +66,7 @@ class AWSFacade(AWSBaseFacade):
     def __init__(self, credentials=None):
         super().__init__()
         self.owner_id = get_aws_account_id(credentials.session)
+        self.partition = get_partition_name(credentials.session)
         self.session = credentials.session
         self._instantiate_facades()
 

--- a/ScoutSuite/providers/aws/resources/cloudwatch/metric_filters.py
+++ b/ScoutSuite/providers/aws/resources/cloudwatch/metric_filters.py
@@ -1,7 +1,7 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
 from ScoutSuite.providers.utils import get_non_provider_id
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class MetricFilters(AWSResources):

--- a/ScoutSuite/providers/aws/resources/cloudwatch/metric_filters.py
+++ b/ScoutSuite/providers/aws/resources/cloudwatch/metric_filters.py
@@ -8,7 +8,7 @@ class MetricFilters(AWSResources):
     def __init__(self, facade: AWSFacade, region: str):
         super(MetricFilters, self).__init__(facade)
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'cloudwatch'
         self.resource_type = 'metric-filter'
 

--- a/ScoutSuite/providers/aws/resources/directconnect/connections.py
+++ b/ScoutSuite/providers/aws/resources/directconnect/connections.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class Connections(AWSResources):

--- a/ScoutSuite/providers/aws/resources/directconnect/connections.py
+++ b/ScoutSuite/providers/aws/resources/directconnect/connections.py
@@ -7,7 +7,7 @@ class Connections(AWSResources):
     def __init__(self, facade: AWSFacade, region: str):
         super().__init__(facade)
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'directconnect'
         self.resource_type = 'connection'
 

--- a/ScoutSuite/providers/aws/resources/ec2/ami.py
+++ b/ScoutSuite/providers/aws/resources/ec2/ami.py
@@ -7,7 +7,7 @@ class AmazonMachineImages(AWSResources):
     def __init__(self, facade: AWSFacade, region: str):
         super().__init__(facade)
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'ec2'
         self.resource_type = 'amazon-machine-image'
 

--- a/ScoutSuite/providers/aws/resources/ec2/ami.py
+++ b/ScoutSuite/providers/aws/resources/ec2/ami.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.resources.base import AWSResources
 from ScoutSuite.providers.aws.facade.base import AWSFacade
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class AmazonMachineImages(AWSResources):

--- a/ScoutSuite/providers/aws/resources/ec2/instances.py
+++ b/ScoutSuite/providers/aws/resources/ec2/instances.py
@@ -10,7 +10,7 @@ class EC2Instances(AWSResources):
         super().__init__(facade)
         self.region = region
         self.vpc = vpc
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'ec2'
         self.resource_type = 'instance'
 

--- a/ScoutSuite/providers/aws/resources/ec2/networkinterfaces.py
+++ b/ScoutSuite/providers/aws/resources/ec2/networkinterfaces.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.resources.base import AWSResources
 from ScoutSuite.providers.aws.facade.base import AWSFacade
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class NetworkInterfaces(AWSResources):

--- a/ScoutSuite/providers/aws/resources/ec2/networkinterfaces.py
+++ b/ScoutSuite/providers/aws/resources/ec2/networkinterfaces.py
@@ -8,7 +8,7 @@ class NetworkInterfaces(AWSResources):
         super().__init__(facade)
         self.region = region
         self.vpc = vpc
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'ec2'
         self.resource_type = 'network-interface'
 

--- a/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
+++ b/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.resources.base import AWSResources
 from ScoutSuite.providers.aws.facade.base import AWSFacade
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 from ScoutSuite.utils import manage_dictionary
 from ScoutSuite.core.fs import load_data
 

--- a/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
+++ b/ScoutSuite/providers/aws/resources/ec2/securitygroups.py
@@ -12,7 +12,7 @@ class SecurityGroups(AWSResources):
         super().__init__(facade)
         self.region = region
         self.vpc = vpc
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'ec2'
         self.resource_type = 'security-group'
 

--- a/ScoutSuite/providers/aws/resources/ec2/snapshots.py
+++ b/ScoutSuite/providers/aws/resources/ec2/snapshots.py
@@ -7,7 +7,7 @@ class Snapshots(AWSResources):
     def __init__(self, facade: AWSFacade, region: str):
         super().__init__(facade)
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'ec2'
         self.resource_type = 'snapshot'
 

--- a/ScoutSuite/providers/aws/resources/ec2/volumes.py
+++ b/ScoutSuite/providers/aws/resources/ec2/volumes.py
@@ -7,7 +7,7 @@ class Volumes(AWSResources):
     def __init__(self, facade: AWSFacade, region: str):
         super().__init__(facade)
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'ec2'
         self.resource_type = 'volume'
 

--- a/ScoutSuite/providers/aws/resources/efs/filesystems.py
+++ b/ScoutSuite/providers/aws/resources/efs/filesystems.py
@@ -7,7 +7,7 @@ class FileSystems(AWSResources):
     def __init__(self, facade: AWSFacade, region: str):
         super().__init__(facade)
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'elasticfilesystem'
         self.resource_type = 'file-system'
 

--- a/ScoutSuite/providers/aws/resources/efs/filesystems.py
+++ b/ScoutSuite/providers/aws/resources/efs/filesystems.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class FileSystems(AWSResources):

--- a/ScoutSuite/providers/aws/resources/elasticache/cluster.py
+++ b/ScoutSuite/providers/aws/resources/elasticache/cluster.py
@@ -8,7 +8,7 @@ class Clusters(AWSResources):
         super().__init__(facade)
         self.region = region
         self.vpc = vpc
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'elasticache'
         self.resource_type = 'cluster'
 

--- a/ScoutSuite/providers/aws/resources/elasticache/cluster.py
+++ b/ScoutSuite/providers/aws/resources/elasticache/cluster.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class Clusters(AWSResources):

--- a/ScoutSuite/providers/aws/resources/elb/load_balancers.py
+++ b/ScoutSuite/providers/aws/resources/elb/load_balancers.py
@@ -9,7 +9,7 @@ class LoadBalancers(AWSResources):
         super().__init__(facade)
         self.region = region
         self.vpc = vpc
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'elb'
         self.resource_type = 'load-balancer'
 

--- a/ScoutSuite/providers/aws/resources/elb/policies.py
+++ b/ScoutSuite/providers/aws/resources/elb/policies.py
@@ -8,7 +8,7 @@ class Policies(AWSResources):
     def __init__(self, facade: AWSFacade, region: str):
         super().__init__(facade)
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'elb'
         self.resource_type = 'policy'
 

--- a/ScoutSuite/providers/aws/resources/elb/policies.py
+++ b/ScoutSuite/providers/aws/resources/elb/policies.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.resources.base import AWSResources
 from ScoutSuite.providers.aws.facade.base import AWSFacade
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 from ScoutSuite.providers.utils import get_non_provider_id
 
 

--- a/ScoutSuite/providers/aws/resources/kms/grants.py
+++ b/ScoutSuite/providers/aws/resources/kms/grants.py
@@ -8,7 +8,7 @@ class Grants(AWSResources):
         super().__init__(facade)
         self.region = region
         self.key_id = key_id
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'kms'
         self.resource_type = 'grant'
 

--- a/ScoutSuite/providers/aws/resources/kms/grants.py
+++ b/ScoutSuite/providers/aws/resources/kms/grants.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class Grants(AWSResources):

--- a/ScoutSuite/providers/aws/resources/redshift/cluster_parameter_groups.py
+++ b/ScoutSuite/providers/aws/resources/redshift/cluster_parameter_groups.py
@@ -14,7 +14,7 @@ class ClusterParameterGroups(AWSCompositeResources):
     def __init__(self, facade: AWSFacade, region: str):
         super().__init__(facade)
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'redshift'
         self.resource_type = 'parametergroup'
 

--- a/ScoutSuite/providers/aws/resources/redshift/cluster_parameter_groups.py
+++ b/ScoutSuite/providers/aws/resources/redshift/cluster_parameter_groups.py
@@ -1,7 +1,7 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSCompositeResources
 from ScoutSuite.providers.utils import get_non_provider_id
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 from .cluster_parameters import ClusterParameters
 

--- a/ScoutSuite/providers/aws/resources/redshift/cluster_parameters.py
+++ b/ScoutSuite/providers/aws/resources/redshift/cluster_parameters.py
@@ -8,7 +8,7 @@ class ClusterParameters(AWSResources):
         super().__init__(facade)
         self.region = region
         self.parameter_group_name = parameter_group_name
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'redshift'
         self.resource_type = 'cluster-parameter'
 

--- a/ScoutSuite/providers/aws/resources/redshift/cluster_parameters.py
+++ b/ScoutSuite/providers/aws/resources/redshift/cluster_parameters.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class ClusterParameters(AWSResources):

--- a/ScoutSuite/providers/aws/resources/redshift/clusters.py
+++ b/ScoutSuite/providers/aws/resources/redshift/clusters.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class Clusters(AWSResources):

--- a/ScoutSuite/providers/aws/resources/redshift/clusters.py
+++ b/ScoutSuite/providers/aws/resources/redshift/clusters.py
@@ -8,7 +8,7 @@ class Clusters(AWSResources):
         super().__init__(facade)
         self.region = region
         self.vpc = vpc
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'redshift'
         self.resource_type = 'cluster'
 

--- a/ScoutSuite/providers/aws/resources/route53/domains.py
+++ b/ScoutSuite/providers/aws/resources/route53/domains.py
@@ -8,7 +8,7 @@ class Domains(AWSResources):
     def __init__(self, facade: AWSFacade, region: str):
         super().__init__(facade)
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'route53'
         self.resource_type = 'domain'
 

--- a/ScoutSuite/providers/aws/resources/route53/domains.py
+++ b/ScoutSuite/providers/aws/resources/route53/domains.py
@@ -1,7 +1,7 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
 from ScoutSuite.providers.utils import get_non_provider_id
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class Domains(AWSResources):

--- a/ScoutSuite/providers/aws/resources/route53/hosted_zones.py
+++ b/ScoutSuite/providers/aws/resources/route53/hosted_zones.py
@@ -7,7 +7,7 @@ class HostedZones(AWSResources):
     def __init__(self, facade: AWSFacade, region: str):
         super().__init__(facade)
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'route53'
         self.resource_type = 'hosted-zone'
 

--- a/ScoutSuite/providers/aws/resources/route53/hosted_zones.py
+++ b/ScoutSuite/providers/aws/resources/route53/hosted_zones.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.resources.base import AWSResources
 from ScoutSuite.providers.aws.facade.base import AWSFacade
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class HostedZones(AWSResources):

--- a/ScoutSuite/providers/aws/resources/s3/buckets.py
+++ b/ScoutSuite/providers/aws/resources/s3/buckets.py
@@ -1,5 +1,5 @@
 from ScoutSuite.providers.aws.resources.base import AWSResources
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 from ScoutSuite.providers.utils import get_non_provider_id
 
 

--- a/ScoutSuite/providers/aws/resources/ses/identities.py
+++ b/ScoutSuite/providers/aws/resources/ses/identities.py
@@ -1,7 +1,7 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSCompositeResources
 from ScoutSuite.providers.utils import get_non_provider_id
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 from .identity_policies import IdentityPolicies
 

--- a/ScoutSuite/providers/aws/resources/ses/identities.py
+++ b/ScoutSuite/providers/aws/resources/ses/identities.py
@@ -14,7 +14,7 @@ class Identities(AWSCompositeResources):
     def __init__(self, facade: AWSFacade, region: str):
         super().__init__(facade)
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'ses'
         self.resource_type = 'identity'
 

--- a/ScoutSuite/providers/aws/resources/ses/identity_policies.py
+++ b/ScoutSuite/providers/aws/resources/ses/identity_policies.py
@@ -2,7 +2,7 @@ import json
 
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class IdentityPolicies(AWSResources):

--- a/ScoutSuite/providers/aws/resources/ses/identity_policies.py
+++ b/ScoutSuite/providers/aws/resources/ses/identity_policies.py
@@ -11,7 +11,7 @@ class IdentityPolicies(AWSResources):
         super().__init__(facade)
         self.region = region
         self.identity_name = identity_name
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'ses'
         self.resource_type = 'identity-policy'
 

--- a/ScoutSuite/providers/aws/resources/vpc/flow_logs.py
+++ b/ScoutSuite/providers/aws/resources/vpc/flow_logs.py
@@ -8,7 +8,7 @@ class FlowLogs(AWSResources):
         super().__init__(facade)
         self.facade = facade
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'vpc'
         self.resource_type = 'flow-log'
 

--- a/ScoutSuite/providers/aws/resources/vpc/network_acls.py
+++ b/ScoutSuite/providers/aws/resources/vpc/network_acls.py
@@ -10,7 +10,7 @@ class NetworkACLs(AWSResources):
     def __init__(self, facade: AWSFacade, region: str, vpc: str):
         self.region = region
         self.vpc = vpc
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'vpc'
         self.resource_type = 'network-acl'
 

--- a/ScoutSuite/providers/aws/resources/vpc/peering_connections.py
+++ b/ScoutSuite/providers/aws/resources/vpc/peering_connections.py
@@ -1,6 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 
 class PeeringConnections(AWSResources):

--- a/ScoutSuite/providers/aws/resources/vpc/peering_connections.py
+++ b/ScoutSuite/providers/aws/resources/vpc/peering_connections.py
@@ -8,7 +8,7 @@ class PeeringConnections(AWSResources):
         super().__init__(facade)
         self.facade = facade
         self.region = region
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'vpc'
         self.resource_type = 'peering-connection'
 

--- a/ScoutSuite/providers/aws/resources/vpcs.py
+++ b/ScoutSuite/providers/aws/resources/vpcs.py
@@ -11,7 +11,7 @@ class Vpcs(AWSCompositeResources):
         super().__init__(facade)
         self.region = region
         self.add_ec2_classic = add_ec2_classic
-        self.partition = get_partition_name(facade.session)
+        self.partition = facade.partition
         self.service = 'vpc'
         self.resource_type = 'virtual-private-cloud'
 

--- a/ScoutSuite/providers/aws/resources/vpcs.py
+++ b/ScoutSuite/providers/aws/resources/vpcs.py
@@ -1,5 +1,5 @@
 from ScoutSuite.providers.aws.resources.base import AWSCompositeResources
-from ScoutSuite.providers.aws.utils import get_partition_name, format_arn
+from ScoutSuite.providers.aws.utils import format_arn
 
 class Vpcs(AWSCompositeResources):
     """


### PR DESCRIPTION
# Description

After implementing PR #1022, a large number of calls were made to [get_partition_name()](https://github.com/nccgroup/ScoutSuite/blob/3be326d0b6b14ea67f9cfcd118a726eb5f31e811/ScoutSuite/providers/aws/utils.py#L19). The following table shows a comparison between the original number of calls, the merged changes and the proposed changes (output merged from different Python's cProfiles):

| ncalls | tottime | percall | cumtime | percall | filename:lineno(function) | Branch |
|:------:|:-------:|:-------:|:-------:|:-------:|:-------------------------:|:------:|
| 25 | 0.02894 | 0.001158 | 11.3 | 0.4522 | utils.py:19(get\_partition\_name) | master |
| 501 | 0.4284 | 0.0008551 | 225.1 | 0.4494 | utils.py:19(get\_partition\_name) | develop (with PR #1022) |
| 28 | 0.03598 | 0.001285 | 13.86 | 0.4951 | utils.py:19(get\_partition\_name)| new changes |

Example of generating a profile:
`python -m cProfile -o tesrun.prof .\scout.py aws -f --profile {profile}`

The important columns are `ncalls`, which is the total number of calls to the function, and `cumtime`, which is the cumulative time spent in the function (and all sub-functions).

The proposed change is to expose the partition through the `AWSFacade` which is available when processing the resources and thus reducing the number of calls and could even avoid hitting the API rate limit.

Fixes issue #935 and PR #1022

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
