### PR TITLE
Added 'management' type to IAM policy

### DIFF
--- a/ScoutSuite/providers/aws/resources/iam/policies.py
+++ b/ScoutSuite/providers/aws/resources/iam/policies.py
@@ -15,6 +15,6 @@ class Policies(AWSResources):
         policy['arn'] = raw_policy.pop('Arn')
         policy['PolicyDocument'] = raw_policy.pop('PolicyDocument')
         policy['attached_to'] = raw_policy.pop('attached_to')
-        policy['scope'] = 'AWS' if policy['arn'].startswith(f"arn:{self.facade.partition}:iam::aws:") else 'Local'
+        policy['management'] = 'AWS' if policy['arn'].startswith(f"arn:{self.facade.partition}:iam::aws:") else 'Customer'
 
         return policy['id'], policy

--- a/ScoutSuite/providers/aws/resources/iam/policies.py
+++ b/ScoutSuite/providers/aws/resources/iam/policies.py
@@ -15,6 +15,6 @@ class Policies(AWSResources):
         policy['arn'] = raw_policy.pop('Arn')
         policy['PolicyDocument'] = raw_policy.pop('PolicyDocument')
         policy['attached_to'] = raw_policy.pop('attached_to')
-        policy['scope'] = 'AWS' if policy['arn'].startswith('arn:aws:iam::aws:') else 'Local'
+        policy['scope'] = 'AWS' if policy['arn'].startswith(f"arn:{self.facade.partition}:iam::aws:") else 'Local'
 
         return policy['id'], policy

--- a/ScoutSuite/providers/aws/resources/iam/policies.py
+++ b/ScoutSuite/providers/aws/resources/iam/policies.py
@@ -15,5 +15,6 @@ class Policies(AWSResources):
         policy['arn'] = raw_policy.pop('Arn')
         policy['PolicyDocument'] = raw_policy.pop('PolicyDocument')
         policy['attached_to'] = raw_policy.pop('attached_to')
+        policy['scope'] = 'AWS' if policy['arn'].startswith('arn:aws:iam::aws:') else 'Local'
 
         return policy['id'], policy


### PR DESCRIPTION
# Description

A "scope" field was added to IAM policies to distinguish between Customer Managed or AWS Managed. This is done by checking the ARN of the policy.

Usually the AWS managed policies have the following ARN format where `account-id` is `aws`: `arn:partition:service:region:account-id:resource-type/resource-id`. As for the customer managed policies, they include a numeric `account-id`.

Fixes #1265 and depends on #1269

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
