### PR TITLE
Add API documentation using flask-restx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ python-dateutil<2.8.1,>=2.1
 netaddr>=0.8.0
 flask>=1.1.2
 flask-cors>=3.0.10
+flask-restx>=0.3.0
 coloredlogs<=10.0
 asyncio-throttle==0.1.1
 


### PR DESCRIPTION
# Description

API documentation can be consulted by starting the server with a report (or by generating a report) and accessing `http://localhost:5000/api-docs`. The documentation has been implemented using [flask-restx](https://flask-restx.readthedocs.io/en/latest/index.html).
Fixes # (issue)

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes
