### PR TITLE
Let google.auth use Application Default Credentials

### DIFF
--- a/ScoutSuite/core/cli_parser.py
+++ b/ScoutSuite/core/cli_parser.py
@@ -97,7 +97,7 @@ class ScoutSuiteArgumentParser:
 
         gcp_parser = parser.add_argument_group('Authentication modes')
 
-        gcp_auth_modes = gcp_parser.add_mutually_exclusive_group(required=True)
+        gcp_auth_modes = gcp_parser.add_mutually_exclusive_group(required=False)
 
         gcp_auth_modes.add_argument('-u',
                                     '--user-account',

--- a/ScoutSuite/providers/gcp/authentication_strategy.py
+++ b/ScoutSuite/providers/gcp/authentication_strategy.py
@@ -29,15 +29,12 @@ class GCPAuthenticationStrategy(AuthenticationStrategy):
             elif service_account:
                 client_secrets_path = os.path.abspath(service_account)
                 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = client_secrets_path
-            else:
-                raise AuthenticationException('Failed to authenticate to GCP - no supported account type')
 
             credentials, default_project_id = auth.default()
 
             if not credentials:
                 raise AuthenticationException('No credentials')
 
-            credentials.is_service_account = service_account is not None
             credentials.default_project_id = default_project_id
 
             return credentials

--- a/ScoutSuite/providers/gcp/provider.py
+++ b/ScoutSuite/providers/gcp/provider.py
@@ -52,7 +52,7 @@ class GCPProvider(BaseProvider):
         # All accessible projects
         if self.all_projects:
             # Service Account
-            if self.credentials.is_service_account and hasattr(self.credentials, 'service_account_email'):
+            if hasattr(self.credentials, 'service_account_email'):
                 self.account_id = self.credentials.service_account_email
             else:
                 # TODO use username email (can't find it...)


### PR DESCRIPTION
# Description

To run ScoutSuite in a container at GCP Cloud Run is need to use Application Default Credentials (ADC), this way google.auth uses the service account that is attached to the resource that is running the container (it isn't passed through GOOGLE_APPLICATION_CREDENTIALS).

This PR makes --user-account and --service-account not required and google.auth do what is need to do to find a credential.
If any credential is found a exception is raised. 

Reference: https://cloud.google.com/docs/authentication/production

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
