### PR TITLE
Downloda awscli from AWS official URL

### DIFF
--- a/docker/bin/container-install-aws2.sh
+++ b/docker/bin/container-install-aws2.sh
@@ -15,7 +15,7 @@ echo -e "\n\nAWS2 CLI Installation Starting...\n\n"
 # install AWS CLI v2
 # =====================================
 cd ${TMPDIR}
-curl "https://d1vvhvl2y92vvt.cloudfront.net/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip awscliv2.zip
 ./aws/install --update
 


### PR DESCRIPTION
# Description

I don't know why this script is downloading awscli from a different URL than the original.

Reference: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
