### PR TITLE
Fix for short auditing and threat detection periods for SQL databases and servers

### DIFF
--- a/ScoutSuite/providers/azure/rules/findings/sqldatabase-databases-threat-detection-low-retention.json
+++ b/ScoutSuite/providers/azure/rules/findings/sqldatabase-databases-threat-detection-low-retention.json
@@ -15,6 +15,11 @@
         "and",
         [
             "sqldatabase.subscriptions.id.servers.id.databases.id.threat_detection.retention_days",
+            "notEqual",
+            "0"
+        ],
+        [
+            "sqldatabase.subscriptions.id.servers.id.databases.id.threat_detection.retention_days",
             "lessThan",
             "_ARG_0_"
         ]

--- a/ScoutSuite/providers/azure/rules/findings/sqldatabase-servers-auditing-low-retention.json
+++ b/ScoutSuite/providers/azure/rules/findings/sqldatabase-servers-auditing-low-retention.json
@@ -15,6 +15,11 @@
         "and",
         [
             "sqldatabase.subscriptions.id.servers.id.auditing.retention_days",
+            "notEqual",
+            "0"
+        ],
+        [
+            "sqldatabase.subscriptions.id.servers.id.auditing.retention_days",
             "lessThan",
             "_ARG_0_"
         ]

--- a/ScoutSuite/providers/azure/rules/findings/sqldatabase-servers-threat-detection-low-retention.json
+++ b/ScoutSuite/providers/azure/rules/findings/sqldatabase-servers-threat-detection-low-retention.json
@@ -15,6 +15,11 @@
         "and",
         [
             "sqldatabase.subscriptions.id.servers.id.threat_detection.retention_days",
+            "notEqual",
+            "0"
+        ],
+        [
+            "sqldatabase.subscriptions.id.servers.id.threat_detection.retention_days",
             "lessThan",
             "_ARG_0_"
         ]


### PR DESCRIPTION
# Description

When an auditing retention period or threat detection retention period had a value of "0", it was flagged as a finding although it's an unlimited retention period or until deleted manually. This was correctly implemented in [Short Auditing Retention Period for SQL Databases](https://github.com/nccgroup/ScoutSuite/blob/master/ScoutSuite/providers/azure/rules/findings/sqldatabase-databases-auditing-low-retention.json) but not in:
* [Short Threat Detection Period for SQL Databases](https://github.com/nccgroup/ScoutSuite/blob/master/ScoutSuite/providers/azure/rules/findings/sqldatabase-databases-threat-detection-low-retention.json)
* [Short Auditing Retention Period for SQL Servers](https://github.com/nccgroup/ScoutSuite/blob/master/ScoutSuite/providers/azure/rules/findings/sqldatabase-servers-auditing-low-retention.json)
* [Short Threat Detection Retention Period for SQL Servers](https://github.com/nccgroup/ScoutSuite/blob/master/ScoutSuite/providers/azure/rules/findings/sqldatabase-servers-threat-detection-low-retention.json)

Fixes #1084 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
