### PR TITLE
Root account without MFA and without hardware MFA findings do not apply to GovCloud accounts

### DIFF
--- a/ScoutSuite/providers/aws/resources/iam/credentialreports.py
+++ b/ScoutSuite/providers/aws/resources/iam/credentialreports.py
@@ -37,6 +37,8 @@ class CredentialReports(AWSResources):
         else:
             raw_credential_report['mfa_active_hardware'] = False
 
+        raw_credential_report['partition'] = self.facade.partition
+
         return raw_credential_report['id'], raw_credential_report
 
     async def _user_has_hardware_mfa_devices(self, username):

--- a/ScoutSuite/providers/aws/rules/findings/iam-root-account-no-hardware-mfa.json
+++ b/ScoutSuite/providers/aws/rules/findings/iam-root-account-no-hardware-mfa.json
@@ -44,6 +44,11 @@
                 "false",
                 ""
             ]
+        ],
+        [
+            "iam.credential_reports.id.partition",
+            "notEqual",
+            "aws-us-gov" 
         ]
     ],
     "keys": [

--- a/ScoutSuite/providers/aws/rules/findings/iam-root-account-no-mfa.json
+++ b/ScoutSuite/providers/aws/rules/findings/iam-root-account-no-mfa.json
@@ -31,6 +31,11 @@
             "iam.credential_reports.id.mfa_active",
             "notTrue",
             ""
+        ],
+        [
+            "iam.credential_reports.id.partition",
+            "notEqual",
+            "aws-us-gov"
         ]
     ],
     "keys": [


### PR DESCRIPTION
# Description

The following findings to not apply to a GovCloud account:
* [Root Account without MFA](https://github.com/nccgroup/ScoutSuite/blob/master/ScoutSuite/providers/aws/rules/findings/iam-root-account-no-mfa.json)
* [Root Account without Hardware MFA](https://github.com/nccgroup/ScoutSuite/blob/master/ScoutSuite/providers/aws/rules/findings/iam-root-account-no-hardware-mfa.json)

The changes include exposing the partition to the credential report and checking if the partition is not `aws-us-gov` in the previously mentioned findings.

Fixes #1132, depends on #1269 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
