### PR TITLE
Publish container into GHCR.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches:
       - master
+      - feature/855-publish-container
   release:
     types:
       - released
-  push:
-    branches:
-      - feature/855-publish-container
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Publish Container
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - released
+  push:
+    branches:
+      - feature/855-publish-container
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Container - Login GitHub
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}   
+
+      - name: Container - Setup QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Container - Setup Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Container - Meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/scoutsuite
+          tags: |
+            type=semver,prefix=v,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,prefix=v,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,prefix=v,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ !startsWith(github.ref, 'refs/heads/master') }}
+
+      - name: Container - Build & Push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: docker
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/scoutsuite:latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - feature/855-publish-container
   release:
     types:
       - released
@@ -42,10 +41,10 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/scoutsuite
           tags: |
-            type=semver,prefix=v,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=semver,prefix=v,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=semver,prefix=v,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=latest,enable=${{ !startsWith(github.ref, 'refs/heads/master') }}
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=semver,pattern={{major}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/heads/master') }}
 
       - name: Container - Build & Push
         uses: docker/build-push-action@v2


### PR DESCRIPTION
# Description

This PR adds workflow to GitHub Action that creates and publishes container image as an artefact to GitHub Container Registry. The build process is base on the best practices (includes `opencontainers` labels) and builds for two architecture: **linux/amd64** and **linux/arm64**. 

It produces:
 - latest tag for the master branch
 - X version tag according to SemVer
 - X.Y version tag according to SemVer
 - X.Y.Z version tag according to SemVer

Fixes #855

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
