### PR TITLE
Basic Azure China support

### DIFF
--- a/ScoutSuite/providers/azure/authentication_strategy.py
+++ b/ScoutSuite/providers/azure/authentication_strategy.py
@@ -13,7 +13,7 @@ import adal
 from ScoutSuite.providers.base.authentication_strategy import AuthenticationStrategy, AuthenticationException
 
 
-AUTHORITY_HOST_URI = 'https://login.microsoftonline.com'
+AUTHORITY_HOST_URI = 'https://login.partner.microsoftonline.cn'
 AZURE_CLI_CLIENT_ID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
 
 
@@ -39,7 +39,7 @@ class AzureCredentials:
             # This is a last resort, e.g. for MSI authentication
             try:
                 h = {'Authorization': 'Bearer {}'.format(self.arm_credentials.token['access_token'])}
-                r = requests.get('https://management.azure.com/tenants?api-version=2020-01-01', headers=h)
+                r = requests.get('https://management.chinacloudapi.cn/tenants?api-version=2020-01-01', headers=h)
                 r2 = r.json()
                 return r2.get('value')[0].get('tenantId')
             except Exception as e:
@@ -113,7 +113,7 @@ class AzureAuthenticationStrategy(AuthenticationStrategy):
                 arm_credentials, subscription_id, tenant_id = \
                     get_azure_cli_credentials(with_tenant=True)
                 aad_graph_credentials, placeholder_1, placeholder_2 = \
-                    get_azure_cli_credentials(with_tenant=True, resource='https://graph.windows.net')
+                    get_azure_cli_credentials(with_tenant=True, resource='https://graph.chinacloudapi.cn')
 
             elif user_account:
 
@@ -126,7 +126,7 @@ class AzureAuthenticationStrategy(AuthenticationStrategy):
 
                 arm_credentials = UserPassCredentials(username, password)
                 aad_graph_credentials = UserPassCredentials(username, password,
-                                                            resource='https://graph.windows.net')
+                                                            resource='https://graph.chinacloudapi.cn')
 
             elif user_account_browser:
 
@@ -134,7 +134,7 @@ class AzureAuthenticationStrategy(AuthenticationStrategy):
                 context = adal.AuthenticationContext(authority_uri, api_version=None)
 
                 # Resource Manager
-                resource_uri = 'https://management.core.windows.net/'
+                resource_uri = 'https://management.core.chinacloudapi.cn/'
                 code = context.acquire_user_code(resource_uri, AZURE_CLI_CLIENT_ID)
                 print_info('To authenticate to the Resource Manager API, use a web browser to '
                            'access {} and enter the {} code.'.format(code['verification_url'],
@@ -143,7 +143,7 @@ class AzureAuthenticationStrategy(AuthenticationStrategy):
                 arm_credentials = AADTokenCredentials(arm_token, AZURE_CLI_CLIENT_ID)
 
                 # AAD Graph
-                resource_uri = 'https://graph.windows.net'
+                resource_uri = 'https://graph.chinacloudapi.cn'
                 code = context.acquire_user_code(resource_uri, AZURE_CLI_CLIENT_ID)
                 print_info('To authenticate to the Azure AD Graph API, use a web browser to '
                            'access {} and enter the {} code.'.format(code['verification_url'],
@@ -181,7 +181,7 @@ class AzureAuthenticationStrategy(AuthenticationStrategy):
                     client_id=client_id,
                     secret=client_secret,
                     tenant=tenant_id,
-                    resource='https://graph.windows.net'
+                    resource='https://graph.chinacloudapi.cn'
                 )
 
             elif file_auth:
@@ -201,13 +201,13 @@ class AzureAuthenticationStrategy(AuthenticationStrategy):
                     client_id=client_id,
                     secret=client_secret,
                     tenant=tenant_id,
-                    resource='https://graph.windows.net'
+                    resource='https://graph.chinacloudapi.cn'
                 )
 
             elif msi:
 
                 arm_credentials = MSIAuthentication()
-                aad_graph_credentials = MSIAuthentication(resource='https://graph.windows.net')
+                aad_graph_credentials = MSIAuthentication(resource='https://graph.chinacloudapi.cn')
 
             else:
                 raise AuthenticationException('Unknown authentication method')

--- a/ScoutSuite/providers/azure/facade/aad.py
+++ b/ScoutSuite/providers/azure/facade/aad.py
@@ -12,7 +12,8 @@ class AADFacade:
 
     def get_client(self):
         client = GraphRbacManagementClient(self.credentials.get_credentials('aad_graph'),
-                                         tenant_id=self.credentials.get_tenant_id())
+                                         tenant_id=self.credentials.get_tenant_id(),
+                                         base_url="https://graph.chinacloudapi.cn")
         client._client.config.add_user_agent(get_user_agent())
         return client
 

--- a/ScoutSuite/providers/azure/facade/appservice.py
+++ b/ScoutSuite/providers/azure/facade/appservice.py
@@ -13,7 +13,8 @@ class AppServiceFacade:
 
     def get_client(self, subscription_id: str):
         client = WebSiteManagementClient(self.credentials.get_credentials('arm'),
-                                       subscription_id=subscription_id)
+                                        subscription_id=subscription_id,
+                                        base_url="https://management.chinacloudapi.cn")
         client._client.config.add_user_agent(get_user_agent())
         return client
 

--- a/ScoutSuite/providers/azure/facade/base.py
+++ b/ScoutSuite/providers/azure/facade/base.py
@@ -15,6 +15,8 @@ from ScoutSuite.utils import get_user_agent
 
 from ScoutSuite.core.console import print_info, print_exception
 
+from msrestazure.azure_cloud import AZURE_CHINA_CLOUD
+
 # Try to import proprietary services
 try:
     from ScoutSuite.providers.azure.facade.appgateway_private import AppGatewayFacade
@@ -78,7 +80,7 @@ class AzureFacade:
     def _set_subscriptions(self):
 
         # Create the client
-        subscription_client = SubscriptionClient(self.credentials.arm_credentials)
+        subscription_client = SubscriptionClient(self.credentials.arm_credentials, base_url=AZURE_CHINA_CLOUD.endpoints.resource_manager)
         subscription_client._client.config.add_user_agent(get_user_agent())
         # Get all the accessible subscriptions
         accessible_subscriptions_list = list(subscription_client.subscriptions.list())

--- a/ScoutSuite/providers/azure/facade/keyvault.py
+++ b/ScoutSuite/providers/azure/facade/keyvault.py
@@ -12,7 +12,8 @@ class KeyVaultFacade:
 
     def get_client(self, subscription_id: str):
         client = KeyVaultManagementClient(self.credentials.get_credentials('arm'),
-                                        subscription_id=subscription_id)
+                                        subscription_id=subscription_id,
+                                        base_url="https://management.chinacloudapi.cn")
         client._client.config.add_user_agent(get_user_agent())
         return client
 

--- a/ScoutSuite/providers/azure/facade/network.py
+++ b/ScoutSuite/providers/azure/facade/network.py
@@ -12,7 +12,8 @@ class NetworkFacade:
 
     def get_client(self, subscription_id: str):
         client = NetworkManagementClient(self.credentials.get_credentials('arm'),
-                                       subscription_id=subscription_id)
+                                        subscription_id=subscription_id,
+                                        base_url="https://management.chinacloudapi.cn")
         client._client.config.add_user_agent(get_user_agent())
         return client
 

--- a/ScoutSuite/providers/azure/facade/rbac.py
+++ b/ScoutSuite/providers/azure/facade/rbac.py
@@ -12,7 +12,8 @@ class RBACFacade:
 
     def get_client(self, subscription_id: str):
         client = AuthorizationManagementClient(self.credentials.get_credentials('arm'),
-                                             subscription_id=subscription_id)
+                                        subscription_id=subscription_id,
+                                        base_url="https://management.chinacloudapi.cn")
         client._client.config.add_user_agent(get_user_agent())
         return client
 

--- a/ScoutSuite/providers/azure/facade/securitycenter.py
+++ b/ScoutSuite/providers/azure/facade/securitycenter.py
@@ -12,7 +12,8 @@ class SecurityCenterFacade:
 
     def get_client(self, subscription_id: str):
         client = SecurityCenter(self.credentials.get_credentials('arm'),
-                              subscription_id, '')
+                                subscription_id, '',
+                                base_url="https://management.chinacloudapi.cn")
         client._client.config.add_user_agent(get_user_agent())
         return client
 

--- a/ScoutSuite/providers/azure/facade/sqldatabase.py
+++ b/ScoutSuite/providers/azure/facade/sqldatabase.py
@@ -13,7 +13,8 @@ class SQLDatabaseFacade:
 
     def get_client(self, subscription_id: str):
         client = SqlManagementClient(self.credentials.get_credentials('arm'),
-                                   subscription_id=subscription_id)
+                                    subscription_id=subscription_id,
+                                    base_url="https://management.chinacloudapi.cn")
         client._client.config.add_user_agent(get_user_agent())
         return client
 

--- a/ScoutSuite/providers/azure/facade/storageaccounts.py
+++ b/ScoutSuite/providers/azure/facade/storageaccounts.py
@@ -15,7 +15,8 @@ class StorageAccountsFacade:
 
     def get_client(self, subscription_id: str):
         client = StorageManagementClient(self.credentials.get_credentials('arm'),
-                                       subscription_id=subscription_id)
+                                       subscription_id=subscription_id,
+                                       base_url="https://management.chinacloudapi.cn")
         client._client.config.add_user_agent(get_user_agent())
         return client
 
@@ -46,7 +47,7 @@ class StorageAccountsFacade:
             return containers
 
     async def _get_and_set_activity_logs(self, storage_account, subscription_id: str):
-        client = MonitorManagementClient(self.credentials.arm_credentials, subscription_id)
+        client = MonitorManagementClient(self.credentials.arm_credentials, subscription_id, base_url="https://management.chinacloudapi.cn")
         client._client.config.add_user_agent(get_user_agent())
 
         # Time format used by Azure API:

--- a/ScoutSuite/providers/azure/facade/virtualmachines.py
+++ b/ScoutSuite/providers/azure/facade/virtualmachines.py
@@ -12,7 +12,8 @@ class VirtualMachineFacade:
 
     def get_client(self, subscription_id: str):
         client = ComputeManagementClient(self.credentials.get_credentials('arm'),
-                                       subscription_id=subscription_id)
+                                       subscription_id=subscription_id,
+                                       base_url="https://management.chinacloudapi.cn")
         client._client.config.add_user_agent(get_user_agent())
         return client
 


### PR DESCRIPTION
When running ScoutSuite v5.10.2 against an Azure account in Azure China, the execution fails with the following message: `msrestazure.azure_exceptions.CloudError: Azure Error: AuthenticationFailed`.

The endpoints used should be changed to their respective Azure China endpoints. As an example, the following snippet is from `site-packages\azure\mgmt\compute\compute_management_client.py` which is used to retrieve virtual machine details. The `base_url` defaults to the Azure Resource Manager global URI, which should be changed when creating a new object specifying `https://management.chinacloudapi.cn` as the `base_url`.

```
def __init__(
            self, credentials, subscription_id, base_url=None):

    if credentials is None:
        raise ValueError("Parameter 'credentials' must not be None.")
    if subscription_id is None:
        raise ValueError("Parameter 'subscription_id' must not be None.")
    if not base_url:
        base_url = 'https://management.azure.com'
    <SNIPPED>
```

Following the example, the following change should be made in `ScoutSuite\providers\azure\facade\virtualmachines.py`:
```
def get_client(self, subscription_id: str):
    client = ComputeManagementClient(self.credentials.get_credentials('arm'),
    							subscription_id=subscription_id,
							base_url="https://management.chinacloudapi.cn")
    client._client.config.add_user_agent(get_user_agent())
    return client
```

Currently supported services that need changes:
- ScoutSuite\providers\azure\facade\aad.py
- ScoutSuite\providers\azure\facade\appservice.py
- ScoutSuite\providers\azure\facade\keyvault.py
- ScoutSuite\providers\azure\facade\network.py
- ScoutSuite\providers\azure\facade\rbac.py
- ScoutSuite\providers\azure\facade\securitycenter.py
- ScoutSuite\providers\azure\facade\sqldatabase.py
- ScoutSuite\providers\azure\facade\storageaccounts.py
- ScoutSuite\providers\azure\facade\virtualmachines.py

Other files related to athentication that need changes:
- ScoutSuite\providers\azure\facade\base.py
- ScoutSuite\providers\azure\authentication_strategy.py

All fixes have been implemented in https://github.com/nccgroup/ScoutSuite/tree/tmp/basic_azure_china_support as a temporary solution.

Related issue [#836](https://github.com/nccgroup/ScoutSuite/issues/836)

References:
- [National clouds](https://docs.microsoft.com/en-us/azure/active-directory/develop/authentication-national-cloud)
- [Microsoft Azure operated by 21Vianet](https://docs.microsoft.com/es-es/azure/china/overview-operations)
- [Endpoints for Azure China](https://docs.microsoft.com/en-us/azure/china/resources-developer-guide#check-endpoints-in-azure)
- [Use an Azure sovereign national cloud](https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate#use-an-azure-sovereign-national-cloud)
- [Using pre-defined sovereign cloud constants](https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-sovereign-domain)