### PR TITLE
feat(cli): allow to exclude some folders from scan

### DIFF
--- a/ScoutSuite/__main__.py
+++ b/ScoutSuite/__main__.py
@@ -51,6 +51,7 @@ def run_from_cli():
                    # GCP
                    project_id=args.get('project_id'), folder_id=args.get('folder_id'),
                    organization_id=args.get('organization_id'), all_projects=args.get('all_projects'),
+                   exclude_folders=args.get('exclude_folders'),
                    # Aliyun
                    access_key_id=args.get('access_key_id'), access_key_secret=args.get('access_key_secret'),
                    # General
@@ -96,7 +97,7 @@ def run(provider,
         subscription_ids=None, all_subscriptions=None,
         # GCP
         service_account=None,
-        project_id=None, folder_id=None, organization_id=None, all_projects=False,
+        project_id=None, folder_id=None, organization_id=None, all_projects=False,exclude_folders=None,
         # Aliyun
         access_key_id=None, access_key_secret=None,
         # General
@@ -148,7 +149,7 @@ async def _run(provider,
                username, password,
                # GCP
                service_account,
-               project_id, folder_id, organization_id, all_projects,
+               project_id, folder_id, organization_id, all_projects,exclude_folders,
                # Aliyun
                access_key_id, access_key_secret,
                # General
@@ -220,6 +221,7 @@ async def _run(provider,
                                       folder_id=folder_id,
                                       organization_id=organization_id,
                                       all_projects=all_projects,
+                                      exclude_folders=  set(exclude_folders) if exclude_folders else  set(),
                                       # Other
                                       report_dir=report_dir,
                                       timestamp=timestamp,

--- a/ScoutSuite/core/cli_parser.py
+++ b/ScoutSuite/core/cli_parser.py
@@ -129,6 +129,10 @@ class ScoutSuiteArgumentParser:
                                action='store_true',
                                help='Scan all of the accessible projects')
 
+        gcp_scope.add_argument('--exclude_folders',
+                               nargs='+',
+                               help='Exclude a list of folders')
+
     def _init_azure_parser(self):
         parser = self.subparsers.add_parser("azure",
                                             parents=[self.common_providers_args_parser],

--- a/ScoutSuite/providers/gcp/facade/base.py
+++ b/ScoutSuite/providers/gcp/facade/base.py
@@ -18,11 +18,13 @@ from ScoutSuite.utils import format_service_name
 
 class GCPFacade(GCPBaseFacade):
     def __init__(self,
-                 default_project_id=None, project_id=None, folder_id=None, organization_id=None, all_projects=None):
+                 default_project_id=None, project_id=None, folder_id=None, organization_id=None, all_projects=None, 
+                 exclude_folders=None):
         super().__init__('cloudresourcemanager', 'v1')
 
         self.default_project_id = default_project_id
         self.all_projects = all_projects
+        self.exclude_folders = exclude_folders
         self.project_id = project_id
         self.folder_id = folder_id
         self.organization_id = organization_id
@@ -56,6 +58,10 @@ class GCPFacade(GCPBaseFacade):
                     parent_type='project', parent_id=self.project_id)
             # Folder passed through the CLI
             elif self.folder_id:
+                # Check that the root folder is not excluded
+                if  self.exclude_folders and GCPFacadeUtils.is_excluded(self.folder_id.strip('folders/'), self.exclude_folders):
+                    print_info("{} (root_folder) excluded because of CLI Arguments exclude_folders" .format (self.folder_id))
+                    return []
                 return await self._get_projects_recursively(
                     parent_type='folder', parent_id=self.folder_id)
             # Organization passed through the CLI
@@ -112,6 +118,10 @@ class GCPFacade(GCPBaseFacade):
                 folder_request = resourcemanager_client_v2.folders().list(parent=f'{parent_type}s/{parent_id}')
                 folder_response = await GCPFacadeUtils.get_all('folders', folder_request, projects_group)
                 for folder in folder_response:
+                    # Check that the folder is not excluded
+                    if  self.exclude_folders and GCPFacadeUtils.is_excluded(folder['name'].strip('folders/'), self.exclude_folders):
+                        print_info("{} ({}) excluded because of CLI Arguments exclude_folders".format(folder["displayName"], folder['name']))
+                        continue
                     projects.extend(await self._get_projects_recursively("folder", folder['name'].strip('folders/')))
 
             project_response = await GCPFacadeUtils.get_all('projects', request, projects_group)

--- a/ScoutSuite/providers/gcp/facade/utils.py
+++ b/ScoutSuite/providers/gcp/facade/utils.py
@@ -16,3 +16,7 @@ class GCPFacadeUtils:
         resources = []
         await GCPFacadeUtils._get_all(resources, resource_key, request, resources_group)
         return resources
+
+    @staticmethod
+    def is_excluded(id, exclude_set):
+        return id in exclude_set

--- a/ScoutSuite/providers/gcp/provider.py
+++ b/ScoutSuite/providers/gcp/provider.py
@@ -11,7 +11,7 @@ class GCPProvider(BaseProvider):
     """
 
     def __init__(self,
-                 project_id=None, folder_id=None, organization_id=None, all_projects=None,
+                 project_id=None, folder_id=None, organization_id=None, all_projects=None, exclude_folders=None,
                  report_dir=None, timestamp=None, services=None, skipped_services=None, result_format='json', **kwargs):
         services = [] if services is None else services
         skipped_services = [] if skipped_services is None else skipped_services
@@ -24,6 +24,7 @@ class GCPProvider(BaseProvider):
         self.environment = 'default'
 
         self.all_projects = all_projects
+        self.exclude_folders = exclude_folders
         self.project_id = project_id
         self.folder_id = folder_id
         self.organization_id = organization_id
@@ -32,7 +33,7 @@ class GCPProvider(BaseProvider):
         self._set_account_id()
 
         self.services = GCPServicesConfig(self.credentials, self.credentials.default_project_id,
-                                          self.project_id, self.folder_id, self.organization_id, self.all_projects)
+                                          self.project_id, self.folder_id, self.organization_id, self.all_projects, self.exclude_folders)
 
         self.result_format = result_format
 

--- a/ScoutSuite/providers/gcp/services.py
+++ b/ScoutSuite/providers/gcp/services.py
@@ -14,12 +14,12 @@ from ScoutSuite.providers.gcp.resources.gke.base import KubernetesEngine
 class GCPServicesConfig(BaseServicesConfig):
 
     def __init__(self, credentials=None, default_project_id=None,
-                 project_id=None, folder_id=None, organization_id=None, all_projects=None,
+                 project_id=None, folder_id=None, organization_id=None, all_projects=None,exclude_folders=None,
                  **kwargs):
 
         super().__init__(credentials)
 
-        facade = GCPFacade(default_project_id, project_id, folder_id, organization_id, all_projects)
+        facade = GCPFacade(default_project_id, project_id, folder_id, organization_id, all_projects, exclude_folders)
 
         self.cloudsql = CloudSQL(facade)
         self.cloudmemorystore = MemoryStore(facade)


### PR DESCRIPTION
# Description
This PR introduces the use of the exclude_folders parameter to exclude a list of folders from audit.
This will allow an explicit exclusion to keep track of the list of folders that will not be scanned.

It does the following changes:
* Add a new CLI parameter
* add a check on folder recursive listing to check that the folder is not excluded
* create a function to check that the folder is in the exclude list
* logs the exception as an info (might be disable for clearer output)

Fixes #1314

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes
