### PR TITLE
Implemented CodeBuild service support for unused security group false positives 

### DIFF
--- a/ScoutSuite/providers/aws/facade/base.py
+++ b/ScoutSuite/providers/aws/facade/base.py
@@ -7,6 +7,7 @@ from ScoutSuite.providers.aws.facade.cloudformation import CloudFormation
 from ScoutSuite.providers.aws.facade.cloudtrail import CloudTrailFacade
 from ScoutSuite.providers.aws.facade.cloudwatch import CloudWatch
 from ScoutSuite.providers.aws.facade.cloudfront import CloudFront
+from ScoutSuite.providers.aws.facade.codebuild import CodeBuild
 from ScoutSuite.providers.aws.facade.config import ConfigFacade
 from ScoutSuite.providers.aws.facade.directconnect import DirectConnectFacade
 from ScoutSuite.providers.aws.facade.dynamodb import DynamoDBFacade
@@ -257,6 +258,7 @@ class AWSFacade(AWSBaseFacade):
         self.elasticache = ElastiCacheFacade(self.session)
         self.route53 = Route53Facade(self.session)
         self.cloudfront = CloudFront(self.session)
+        self.codebuild = CodeBuild(self.session)
         self.elb = ELBFacade(self.session)
         self.elbv2 = ELBv2Facade(self.session)
         self.iam = IAMFacade(self.session)

--- a/ScoutSuite/providers/aws/facade/codebuild.py
+++ b/ScoutSuite/providers/aws/facade/codebuild.py
@@ -1,0 +1,30 @@
+from ScoutSuite.core.console import print_exception
+from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
+from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
+from ScoutSuite.providers.utils import run_concurrently, map_concurrently
+
+
+class CodeBuild(AWSBaseFacade):
+    async def get_projects(self, region: str):
+        codebuild_client = AWSFacadeUtils.get_client('codebuild', self.session, region)
+        try:
+            projects = await run_concurrently(lambda: codebuild_client.list_projects()['projects'])
+        except Exception as e:
+            print_exception(f'Failed to get CodeBuild projects: {e}')
+            return []
+        else:
+            if not projects:
+                return []
+            return await map_concurrently(self._get_project_details, projects, region=region)
+        
+    async def _get_project_details(self, project: str, region: str):
+        codebuild_client = AWSFacadeUtils.get_client('codebuild', self.session, region)
+        try:
+            project_details = await run_concurrently(lambda: codebuild_client.batch_get_projects(names=[project]))
+        except Exception as e:
+            print_exception(f'Failed to get CodeBuild project details: {e}')
+            return project
+        else:
+            project_details.pop('ResponseMetadata')
+            project_details.pop('projectsNotFound')
+            return project_details

--- a/ScoutSuite/providers/aws/resources/codebuild/base.py
+++ b/ScoutSuite/providers/aws/resources/codebuild/base.py
@@ -1,0 +1,13 @@
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.regions import Regions
+
+from .build_projects import BuildProjects
+
+
+class CodeBuild(Regions):
+    _children = [
+        (BuildProjects, 'build_projects')
+    ]
+
+    def __init__(self, facade: AWSFacade):
+        super().__init__('codebuild', facade)

--- a/ScoutSuite/providers/aws/resources/codebuild/build_projects.py
+++ b/ScoutSuite/providers/aws/resources/codebuild/build_projects.py
@@ -1,0 +1,27 @@
+from ScoutSuite.providers.aws.facade.base import AWSFacade
+from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
+
+
+class BuildProjects(AWSResources):
+    def __init__(self, facade: AWSFacade, region: str):
+        super().__init__(facade)
+        self.region = region
+
+    async def fetch_all(self):
+        raw_projects = await self.facade.codebuild.get_projects(self.region)
+        for list_raw_project in raw_projects:
+            for raw_project in list_raw_project.get('projects'):
+                id, build_project = self._parse_build_projects(raw_project)
+                self[id] = build_project
+
+    def _parse_build_projects(self, raw_build_project):
+        project_dict = {}
+        project_dict['id'] = raw_build_project.get('arn')
+        project_dict['arn'] = raw_build_project.get('arn')
+        project_dict['name'] = raw_build_project.get('name')
+        if 'vpcConfig' in raw_build_project:
+            project_dict['vpc'] = raw_build_project.get('vpcConfig').get('vpcId')
+            project_dict['subnets'] = raw_build_project.get('vpcConfig').get('subnets')
+            project_dict['security_groups'] = raw_build_project.get('vpcConfig').get('securityGroupIds')
+        return project_dict['id'], project_dict

--- a/ScoutSuite/providers/aws/services.py
+++ b/ScoutSuite/providers/aws/services.py
@@ -5,6 +5,7 @@ from ScoutSuite.providers.aws.resources.cloudformation.base import CloudFormatio
 from ScoutSuite.providers.aws.resources.cloudtrail.base import CloudTrail
 from ScoutSuite.providers.aws.resources.cloudwatch.base import CloudWatch
 from ScoutSuite.providers.aws.resources.cloudfront.base import CloudFront
+from ScoutSuite.providers.aws.resources.codebuild.base import CodeBuild
 from ScoutSuite.providers.aws.resources.config.base import Config
 from ScoutSuite.providers.aws.resources.directconnect.base import DirectConnect
 from ScoutSuite.providers.aws.resources.dynamodb.base import DynamoDB
@@ -94,6 +95,7 @@ class AWSServicesConfig(BaseServicesConfig):
         self.cloudtrail = CloudTrail(facade)
         self.cloudwatch = CloudWatch(facade)
         self.cloudfront = CloudFront(facade)
+        self.codebuild = CodeBuild(facade)
         self.config = Config(facade)
         self.directconnect = DirectConnect(facade)
         self.dynamodb = DynamoDB(facade)

--- a/ScoutSuite/utils.py
+++ b/ScoutSuite/utils.py
@@ -17,6 +17,7 @@ formatted_service_name = {
     'cloudwatch': 'CloudWatch',
     'cloudfront': 'CloudFront',
     'credentials': 'Credentials',
+    'codebuild': 'CodeBuild',
     'cognito': 'Cognito',
     'config': 'Config',
     'directconnect': 'Direct Connect',


### PR DESCRIPTION
# Description

Added basic support for CodeBuild in AWS and logic to "preprocessing" to check usage of security groups for this service. The current rule "Unused Security Group" no longer flags security groups used by CodeBuild as "unused".

Fixes #620 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
