### PR TITLE
Amended parser logic for GCP legacy networks

### DIFF
--- a/ScoutSuite/providers/gcp/resources/gce/networks.py
+++ b/ScoutSuite/providers/gcp/resources/gce/networks.py
@@ -28,7 +28,8 @@ class Networks(Resources):
         network_dict['subnetwork_urls'] = raw_network.get('subnetworks', None)
         # Network is legacy if there is no subnets
         network_dict['legacy_mode'] = True \
-            if raw_network.get('subnetworks', None) is None or not raw_network.get('subnetworks', None) \
+            if (raw_network.get('subnetworks', None) is None or not raw_network.get('subnetworks', None)) and \
+            raw_network.get('autoCreateSubnetworks', None) is None \
             else False
 
         return network_dict['id'], network_dict


### PR DESCRIPTION
Additional logic when parsing GCP networks to identify legacy networks.

References:
- [Using legacy networks](https://cloud.google.com/vpc/docs/using-legacy#restrictions)
- [Legacy networks](https://cloud.google.com/vpc/docs/legacy)
- [REST Resource: networks](https://cloud.google.com/compute/docs/reference/rest/v1/networks)