### PR TITLE
Enhancement/Explicitly identify internal IDs

### DIFF
--- a/ScoutSuite/providers/utils.py
+++ b/ScoutSuite/providers/utils.py
@@ -17,7 +17,7 @@ def get_non_provider_id(name):
     """
     name_hash = sha1()
     name_hash.update(name.encode('utf-8'))
-    return name_hash.hexdigest()
+    return f'scoutid-{name_hash.hexdigest()}'
 
 
 async def run_concurrently(function, backoff_seconds=15):


### PR DESCRIPTION
The `ScoutSuite.providers.utils.get_non_provider_id` function is intended to provide unique IDs for the resource tree, which can also be referenced in the browser (this breaks if the ID would include `/` for example). This PR modifies the IDs by prepending `scoutid-`.

The reasoning is that we're currently mixing actual data (i.e. what's returned from the provider) with Scout internal data (an ID we use to uniquely identify a resource, but that doesn't have a meaning outside of the tool's internals). This change allows to explicitly identify internal data, which can then be filtered out by ingestion mechanisms. 