### PR TITLE
Fix #1081: returning an empty dict in case the "SecurityGroups" key is not set

### DIFF
--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -712,7 +712,7 @@ class AWSProvider(BaseProvider):
             public_dns = current_config['ConfigurationEndpoint']['Address'].replace(
                 '.cfg', '')
             listeners = [current_config['ConfigurationEndpoint']['Port']]
-            security_groups = current_config['SecurityGroups']
+            security_groups = current_config.get('SecurityGroups', {})
             self._security_group_to_attack_surface(service_config['external_attack_surface'], public_dns,
                                                    current_path, [
                                                        g['SecurityGroupId'] for g in security_groups],


### PR DESCRIPTION
# Description

An error is generated when a Memcached instance is configured without any Security Groups. When `get_db_attack_surface` is called, on line 680 a non-existent key is being retrieved and generates an exception.

Fixes #1081 
The builtin `get` method was used to default to an empty dictionary in case the `SecurityGroups` key does not exist.

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
