### PR TITLE
Fix #1320: Do not print an error when analysing a lambda function and its associated execution role was previously deleted.

### DIFF
--- a/ScoutSuite/providers/aws/facade/awslambda.py
+++ b/ScoutSuite/providers/aws/facade/awslambda.py
@@ -5,6 +5,7 @@ from ScoutSuite.providers.aws.facade.basefacade import AWSBaseFacade
 from ScoutSuite.providers.aws.facade.utils import AWSFacadeUtils
 
 
+
 class LambdaFacade(AWSBaseFacade):
     async def get_functions(self, region):
         try:
@@ -40,7 +41,10 @@ class LambdaFacade(AWSBaseFacade):
             role['policies'] = managed_policies
             return role
         except Exception as e:
-            print_exception('Failed to get role from managed policies: {}'.format(e))
+            # Fix:#1320 If an lambda execution role associated with is deleted a
+            # NoSuchEntityException is triggered. We can ignore it.
+            if "NoSuchEntityException" not in str(e.__class__):
+                print_exception('Failed to get role from managed policies: {}'.format(e))
             return None
 
     async def get_env_variables(self, function_name, region):


### PR DESCRIPTION
# Description
Currently, when analysing a lambda function but its associated role execution does not exist, ScoutSuite triggers a `NoSuchEntityException` exception, printing an error line.

The current change set a condition to check this use case and not printing the corresponding error.

Fixes #1320 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
