### PR TITLE
Use get_non_provider_id for all AWS resources

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,15 @@
+name: Fronted Build CI (dummy version)
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ v6-master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Show environment v1
+        run: env | grep ^GITHUB
+      - name: Show ref v1
+        run: echo "===============> Version from $GITHUB_REF"

--- a/ScoutSuite/providers/aws/facade/cloudtrail.py
+++ b/ScoutSuite/providers/aws/facade/cloudtrail.py
@@ -33,6 +33,6 @@ class CloudTrailFacade(AWSBaseFacade):
         client = AWSFacadeUtils.get_client('cloudtrail', self.session, region)
         try:
             trail['EventSelectors'] = await run_concurrently(
-                lambda: client.get_event_selectors(TrailName=trail['TrailARN'])['EventSelectors'])
+                lambda: client.get_event_selectors(TrailName=trail['TrailARN']).get('EventSelectors', []))
         except Exception as e:
             print_exception(f'Failed to get CloudTrail event selectors: {e}')

--- a/ScoutSuite/providers/aws/resources/awslambda/functions.py
+++ b/ScoutSuite/providers/aws/resources/awslambda/functions.py
@@ -1,5 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class Functions(AWSResources):
@@ -34,7 +35,7 @@ class Functions(AWSResources):
         await self._add_access_policy_information(function_dict)
         await self._add_env_variables(function_dict)
 
-        return function_dict['name'], function_dict
+        return get_non_provider_id(function_dict['name']), function_dict
 
     async def _add_role_information(self, function_dict, role_id):
         # Make it easier to build rules based on policies attached to execution roles

--- a/ScoutSuite/providers/aws/resources/cloudformation/stacks.py
+++ b/ScoutSuite/providers/aws/resources/cloudformation/stacks.py
@@ -2,6 +2,7 @@ import re
 
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class Stacks(AWSResources):
@@ -32,7 +33,7 @@ class Stacks(AWSResources):
                     raw_stack['deletion_policy'] = template[group]
                     break
 
-        return raw_stack['name'], raw_stack
+        return get_non_provider_id(raw_stack['name']), raw_stack
 
     @staticmethod
     def has_deletion_policy(template):

--- a/ScoutSuite/providers/aws/resources/config/recorders.py
+++ b/ScoutSuite/providers/aws/resources/config/recorders.py
@@ -1,5 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class Recorders(AWSResources):
@@ -23,4 +24,4 @@ class Recorders(AWSResources):
         recorder['last_status'] = raw_recorder['ConfigurationRecordersStatus'].get('lastStatus')
         recorder['last_start_time'] = raw_recorder['ConfigurationRecordersStatus'].get('lastStartTime')
         recorder['last_status_change_time'] = raw_recorder['ConfigurationRecordersStatus'].get('lastStatusChangeTime')
-        return recorder['name'], recorder
+        return get_non_provider_id(recorder['name']), recorder

--- a/ScoutSuite/providers/aws/resources/config/rules.py
+++ b/ScoutSuite/providers/aws/resources/config/rules.py
@@ -1,5 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class Rules(AWSResources):
@@ -24,4 +25,4 @@ class Rules(AWSResources):
         rule['input_parameters'] = raw_rule.pop('InputParameters', None)
         rule['maximum_execution_frequency'] = raw_rule.pop('MaximumExecutionFrequency', None)
         rule['state'] = raw_rule.pop('ConfigRuleState', None)
-        return rule['name'], rule
+        return get_non_provider_id(rule['name']), rule

--- a/ScoutSuite/providers/aws/resources/elasticache/cluster.py
+++ b/ScoutSuite/providers/aws/resources/elasticache/cluster.py
@@ -1,5 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class Clusters(AWSResources):
@@ -19,4 +20,4 @@ class Clusters(AWSResources):
         raw_cluster['arn'] = 'arn:aws:elasticache:{}:{}:cluster/{}'.format(self.region,
                                                                              self.facade.owner_id,
                                                                              raw_cluster.get('name'))
-        return raw_cluster['name'], raw_cluster
+        return get_non_provider_id(raw_cluster['name']), raw_cluster

--- a/ScoutSuite/providers/aws/resources/elasticache/securitygroups.py
+++ b/ScoutSuite/providers/aws/resources/elasticache/securitygroups.py
@@ -1,5 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class SecurityGroups(AWSResources):
@@ -16,4 +17,4 @@ class SecurityGroups(AWSResources):
 
     def _parse_security_group(self, raw_security_group):
         raw_security_group['name'] = raw_security_group.pop('CacheSecurityGroupName')
-        return raw_security_group['name'], raw_security_group
+        return get_non_provider_id(raw_security_group['name']), raw_security_group

--- a/ScoutSuite/providers/aws/resources/elasticache/subnetgroups.py
+++ b/ScoutSuite/providers/aws/resources/elasticache/subnetgroups.py
@@ -1,5 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class SubnetGroups(AWSResources):
@@ -16,4 +17,4 @@ class SubnetGroups(AWSResources):
 
     def _parse_subnet_group(self, raw_subnet_group):
         raw_subnet_group['name'] = raw_subnet_group.pop('CacheSubnetGroupName')
-        return raw_subnet_group['name'], raw_subnet_group
+        return get_non_provider_id(raw_subnet_group['name']), raw_subnet_group

--- a/ScoutSuite/providers/aws/resources/rds/instances.py
+++ b/ScoutSuite/providers/aws/resources/rds/instances.py
@@ -1,5 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class RDSInstances(AWSResources):
@@ -27,7 +28,7 @@ class RDSInstances(AWSResources):
         instance['arn'] = 'arn:aws:rds:{}:{}:instance/{}'.format(self.region,
                                                                            self.facade.owner_id,
                                                                            raw_instance.get('DbiResourceId'))
-        return instance['name'], instance
+        return get_non_provider_id(instance['name']), instance
 
     @staticmethod
     def _is_read_replica(instance):

--- a/ScoutSuite/providers/aws/resources/rds/securitygroups.py
+++ b/ScoutSuite/providers/aws/resources/rds/securitygroups.py
@@ -1,5 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class SecurityGroups(AWSResources):
@@ -16,4 +17,4 @@ class SecurityGroups(AWSResources):
     def _parse_security_group(self, raw_security_group):
         raw_security_group['arn'] = raw_security_group.pop('DBSecurityGroupArn')
         raw_security_group['name'] = raw_security_group.pop('DBSecurityGroupName')
-        return raw_security_group['name'], raw_security_group
+        return get_non_provider_id(raw_security_group['name']), raw_security_group

--- a/ScoutSuite/providers/aws/resources/rds/subnetgroups.py
+++ b/ScoutSuite/providers/aws/resources/rds/subnetgroups.py
@@ -1,5 +1,6 @@
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class SubnetGroups(AWSResources):
@@ -16,4 +17,4 @@ class SubnetGroups(AWSResources):
 
     def _parse_subnet_group(self, raw_subnet_group):
         raw_subnet_group['name'] = raw_subnet_group['DBSubnetGroupName']
-        return raw_subnet_group['name'], raw_subnet_group
+        return get_non_provider_id(raw_subnet_group['name']), raw_subnet_group

--- a/ScoutSuite/providers/aws/resources/sns/topics.py
+++ b/ScoutSuite/providers/aws/resources/sns/topics.py
@@ -2,6 +2,7 @@ import json
 
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSCompositeResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 from .subscriptions import Subscriptions
 
@@ -41,4 +42,4 @@ class Topics(AWSCompositeResources):
         for k in ['Policy', 'DeliveryPolicy', 'EffectiveDeliveryPolicy']:
             raw_topic[k] = json.loads(attributes[k]) if k in attributes else None
 
-        return raw_topic['name'], raw_topic
+        return get_non_provider_id(raw_topic['name']), raw_topic

--- a/ScoutSuite/providers/aws/resources/sqs/queues.py
+++ b/ScoutSuite/providers/aws/resources/sqs/queues.py
@@ -19,11 +19,11 @@ class Queues(AWSResources):
 
     def _parse_queue(self, queue_url, queue_attributes):
         queue = {}
+        queue['arn'] = queue_attributes.get('QueueArn')
         queue['name'] = queue['arn'].split(':')[-1]
-        queue['arn'] = queue_attributes.pop('QueueArn')
         queue['QueueUrl'] = queue_url
-        queue['kms_master_key_id'] = queue_attributes.pop('KmsMasterKeyId', None)
-        queue['CreatedTimestamp'] = queue_attributes.pop('CreatedTimestamp', None)
+        queue['kms_master_key_id'] = queue_attributes.get('KmsMasterKeyId', None)
+        queue['CreatedTimestamp'] = queue_attributes.get('CreatedTimestamp', None)
 
         if 'Policy' in queue_attributes:
             queue['Policy'] = json.loads(queue_attributes['Policy'])

--- a/ScoutSuite/providers/aws/resources/sqs/queues.py
+++ b/ScoutSuite/providers/aws/resources/sqs/queues.py
@@ -2,6 +2,7 @@ import json
 
 from ScoutSuite.providers.aws.facade.base import AWSFacade
 from ScoutSuite.providers.aws.resources.base import AWSResources
+from ScoutSuite.providers.utils import get_non_provider_id
 
 
 class Queues(AWSResources):
@@ -18,9 +19,9 @@ class Queues(AWSResources):
 
     def _parse_queue(self, queue_url, queue_attributes):
         queue = {}
-        queue['QueueUrl'] = queue_url
-        queue['arn'] = queue_attributes.pop('QueueArn')
         queue['name'] = queue['arn'].split(':')[-1]
+        queue['arn'] = queue_attributes.pop('QueueArn')
+        queue['QueueUrl'] = queue_url
         queue['kms_master_key_id'] = queue_attributes.pop('KmsMasterKeyId', None)
         queue['CreatedTimestamp'] = queue_attributes.pop('CreatedTimestamp', None)
 
@@ -29,4 +30,4 @@ class Queues(AWSResources):
         else:
             queue['Policy'] = {'Statement': []}
 
-        return queue['name'], queue
+        return get_non_provider_id(queue['name']), queue

--- a/ScoutSuite/providers/aws/rules/findings/cloudfront-distribution-insecure-origin.json
+++ b/ScoutSuite/providers/aws/rules/findings/cloudfront-distribution-insecure-origin.json
@@ -14,7 +14,7 @@
             "http-only"
         ],
         [
-            "cloudfront.distributions.id.view_certificate.MinimumProtocolVersion.",
+            "cloudfront.distributions.id.viewer_certificate.MinimumProtocolVersion.",
             "containNoneOf",
             [
                 "TLSv1.1",


### PR DESCRIPTION
Enforce the use of `get_non_provider_id` as some resource names may include dots (`.`), which breaks functionality.

Similar to https://github.com/nccgroup/ScoutSuite/pull/405.

Also irons out a few bugs.