### PR TITLE
Allowed Azure checks on AAD to run when no subscriptions are found

### DIFF
--- a/ScoutSuite/providers/azure/services.py
+++ b/ScoutSuite/providers/azure/services.py
@@ -41,28 +41,30 @@ class AzureServicesConfig(BaseServicesConfig):
                              programmatic_execution)
 
         self.aad = AAD(facade)
-        self.rbac = RBAC(facade)
-        self.securitycenter = SecurityCenter(facade)
-        self.sqldatabase = Servers(facade)
-        self.storageaccounts = StorageAccounts(facade)
-        self.keyvault = KeyVaults(facade)
-        self.network = Networks(facade)
-        self.virtualmachines = VirtualMachines(facade)
-        self.appservice = AppServices(facade)
 
-        # Instantiate proprietary services
-        try:
-            self.appgateway = ApplicationGateways(facade)
-        except NameError as _:
-            pass
-        try:
-            self.loadbalancer = LoadBalancers(facade)
-        except NameError as _:
-            pass
-        try:
-            self.rediscache = RedisCaches(facade)
-        except NameError as _:
-            pass
+        if len(subscription_ids) > 0:
+            self.rbac = RBAC(facade)
+            self.securitycenter = SecurityCenter(facade)
+            self.sqldatabase = Servers(facade)
+            self.storageaccounts = StorageAccounts(facade)
+            self.keyvault = KeyVaults(facade)
+            self.network = Networks(facade)
+            self.virtualmachines = VirtualMachines(facade)
+            self.appservice = AppServices(facade)
+
+            # Instantiate proprietary services
+            try:
+                self.appgateway = ApplicationGateways(facade)
+            except NameError as _:
+                pass
+            try:
+                self.loadbalancer = LoadBalancers(facade)
+            except NameError as _:
+                pass
+            try:
+                self.rediscache = RedisCaches(facade)
+            except NameError as _:
+                pass
 
     def _is_provider(self, provider_name):
         return provider_name == 'azure'

--- a/ScoutSuite/providers/azure/services.py
+++ b/ScoutSuite/providers/azure/services.py
@@ -42,6 +42,7 @@ class AzureServicesConfig(BaseServicesConfig):
 
         self.aad = AAD(facade)
 
+        # Currently, only AAD can be used without any subscriptions 
         if len(subscription_ids) > 0:
             self.rbac = RBAC(facade)
             self.securitycenter = SecurityCenter(facade)


### PR DESCRIPTION
# Description
This PR allows users to run the AAD check even if the user specified has no active subscriptions.
While there are currently not that many checks for AAD, it could give a lot of value when more checks are developed.

Fixes #1030

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes
