### PR TITLE
Enhancement/Load Balancer Allowing Clear Text (HTTP) Communication

### DIFF
--- a/ScoutSuite/providers/aws/rules/findings/elb-listener-allowing-cleartext.json
+++ b/ScoutSuite/providers/aws/rules/findings/elb-listener-allowing-cleartext.json
@@ -16,6 +16,13 @@
                 "HTTPS",
                 "SSL"
             ]
+        ],
+        [
+            "elb.regions.id.vpcs.id.elbs.id.listeners.id.LoadBalancerPort",
+            "containNoneOf",
+            [
+                443
+            ]
         ]
     ]
 }


### PR DESCRIPTION
For classic load balancers (ELB) we shouldn't raise "Load Balancer Allowing Clear Text (HTTP) Communication" if the LB's listener port is 443.