### PR TITLE
Make scout Dockerfile entrypoint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,4 +52,6 @@ RUN ["/bin/bash", "-c", "/root/bin/container-set-init.sh"]
 RUN ["rm", "-rf", "/root/bin"]
 
 # Command
-CMD ["/bin/bash"]
+ENV PATH=/root/scoutsuite/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENTRYPOINT [ "/root/scoutsuite/bin/scout" ]
+CMD ["--help"]

--- a/docker/config/build.env
+++ b/docker/config/build.env
@@ -1,6 +1,6 @@
 VCS_REF=$(git rev-parse --short HEAD)
 VCS_URL='https://github.com/nccgroup/ScoutSuite'
-VERSION='0.3.0'
+VERSION=$(git describe --all | cut -d/ -f2-)
 BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 VENDOR='nccgroup'
 NAME='scoutsuite'


### PR DESCRIPTION
# Description

**Make sure the PR is against the `develop` branch (see [Contributing](https://github.com/nccgroup/ScoutSuite/blob/master/CONTRIBUTING.md)).**

**Make sure to set the corresponding milestone in the PR.**

This change makes `scout` the entrypoint of the Docker image.
Before this change the image would start a bash prompt.
After this change the image image is running scout directly and can be used for example like this:

`docker run --rm -it -v "$HOME/.aws:/root/.aws" -v "$(pwd):/out" scoutsuite aws --no-browser --report-dir /out/ --report-name test`.

This makes it easier to run and reproducible.

To get the old behaviour the entrypoint can be overridden with `docker run --entrypoint /bin/bash scoutsuite`

This change also sets the `VERSION` variable in the `config/build.env` to be based off the git branch/tag.

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

The wiki will need to be updated on how to run the image.
It is currently mildly out of date already as it includes instructions for entering the virtual-env which is already done by the way the image is built.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
