### PR TITLE
Adjust SQS encryption rule for new managed SSE

### DIFF
--- a/ScoutSuite/output/data/html/partials/aws/services.sqs.regions.id.queues.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.sqs.regions.id.queues.html
@@ -8,9 +8,16 @@
           <h4 class="list-group-item-heading">Information</h4>
           <div class="list-group-item-text item-margin">Region: {{region}}</div>
           <div class="list-group-item-text item-margin">ARN: {{arn}}</div>
-          <div class="list-group-item-text item-margin">KMS master key id: <span id="sqs.regions.{{region}}.queues.{{@key}}.server-side-encryption-disabled">
+          <div class="list-group-item-text item-margin">KMS master key id:
+            <span id="sqs.regions.{{region}}.queues.{{@key}}.server-side-encryption-disabled">
               {{#if kms_master_key_id}} {{kms_master_key_id}} {{else}} None {{/if}}
-            </span></div>
+            </span>
+          </div>
+          <div class="list-group-item-text item-margin">SQS-managed encryption keys:
+            <span id="sqs.regions.{{region}}.queues.{{@key}}.server-side-encryption-disabled">
+              {{#ifEqual sqs_managed_sse_enabled "true"}} Enabled {{else}} Disabled {{/ifEqual}}
+            </span>
+          </div>
           <div class="list-group-item-text item-margin">Created on: {{CreatedTimestamp}}</div>
         </div>
         <div class="list-group-item">

--- a/ScoutSuite/providers/aws/resources/sqs/queues.py
+++ b/ScoutSuite/providers/aws/resources/sqs/queues.py
@@ -11,7 +11,7 @@ class Queues(AWSResources):
 
     async def fetch_all(self):
         queues = await self.facade.sqs.get_queues(self.region,
-                                                  ['CreatedTimestamp', 'Policy', 'QueueArn', 'KmsMasterKeyId'])
+                                                  ['CreatedTimestamp', 'Policy', 'QueueArn', 'KmsMasterKeyId', 'SqsManagedSseEnabled'])
         for queue_url, queue_attributes in queues:
             id, queue = self._parse_queue(queue_url, queue_attributes)
             self[id] = queue
@@ -22,6 +22,7 @@ class Queues(AWSResources):
         queue['arn'] = queue_attributes.pop('QueueArn')
         queue['name'] = queue['arn'].split(':')[-1]
         queue['kms_master_key_id'] = queue_attributes.pop('KmsMasterKeyId', None)
+        queue['sqs_managed_sse_enabled'] = queue_attributes.pop('SqsManagedSseEnabled', None)
         queue['CreatedTimestamp'] = queue_attributes.pop('CreatedTimestamp', None)
 
         if 'Policy' in queue_attributes:

--- a/ScoutSuite/providers/aws/rules/findings/sqs-queue-server-side-encryption-disabled.json
+++ b/ScoutSuite/providers/aws/rules/findings/sqs-queue-server-side-encryption-disabled.json
@@ -14,6 +14,11 @@
             "sqs.regions.id.queues.id.kms_master_key_id",
             "null",
             ""
+        ],
+        [
+            "sqs.regions.id.queues.id.sqs_managed_sse_enabled",
+            "false",
+            ""
         ]
     ],
     "id_suffix": "server-side-encryption-disabled"


### PR DESCRIPTION
# Description
In November 2021, AWS added managed server-side encryption for SQS: https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-sqs-server-side-encryption-keys-sse/ 

API reference: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_GetQueueAttributes.html (look for `SqsManagedSseEnabled` attribute)

This should be acceptable to satisfy the "Queue with Encryption Disabled" rule, so I've updated the finding and SQS resource fetching code accordingly.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
