### PR TITLE
Fix docker-compose build error

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -16,5 +16,3 @@ services:
         - NAME=${NAME}
         - IMAGE_NAME=${IMAGE_NAME}
         - DESCRIPTION=${DESCRIPTION}
-      env_file:
-        - config/build.env


### PR DESCRIPTION
# Description

**Make sure the PR is against the `develop` branch (see [Contributing](https://github.com/nccgroup/ScoutSuite/blob/master/CONTRIBUTING.md)).**

**Make sure to set the corresponding milestone in the PR.**

Upon building the Docker image following the instructions on the wiki, the following error is shown:

```
$ docker-compose run ncc-scoutsuite bash
ERROR: The Compose file './docker-compose.yaml' is invalid because:
services.ncc-scoutsuite.build contains unsupported option: 'env_file'
```

The `env_file` option is specified twice in `docker-compose.yaml`, so I removed the second one and then the build succeeds.

Fixes #1406 (issue)

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
