### PR TITLE
Check for dropping invalid header fields only for ALB

### DIFF
--- a/ScoutSuite/providers/aws/rules/findings/elbv2-http-request-smuggling.json
+++ b/ScoutSuite/providers/aws/rules/findings/elbv2-http-request-smuggling.json
@@ -13,6 +13,11 @@
     "conditions": [
         "and",
         [
+            "elbv2.regions.id.vpcs.id.lbs.id.Type",
+            "equal",
+            "application"
+        ],
+        [
             "Key",
             "equal",
             "routing.http.drop_invalid_header_fields.enabled"


### PR DESCRIPTION
# Description

As mentioned in [AWS docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_LoadBalancerAttribute.html), this attribute can be applied only to Application Load Balancers.

PS: not sure if the syntax is quite correct, but wanted to try to address https://github.com/kubernetes/kops/issues/13976.

**Make sure the PR is against the `develop` branch (see [Contributing](https://github.com/nccgroup/ScoutSuite/blob/master/CONTRIBUTING.md)).**

**Make sure to set the corresponding milestone in the PR.**

Please include a summary of the change(s) and which issue(s) it addresses. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
