### PR TITLE
Security Contact Phone in azure means a phone number

### DIFF
--- a/ScoutSuite/providers/azure/rules/findings/securitycenter-security-contacts-phone-not-set.json
+++ b/ScoutSuite/providers/azure/rules/findings/securitycenter-security-contacts-phone-not-set.json
@@ -1,6 +1,6 @@
 {
     "description": "No Security Contact Phone Set",
-    "rationale": "Set at least one security contact email.",
+    "rationale": "Set at least one security contact phone number.",
     "compliance": [
         {
             "name": "CIS Microsoft Azure Foundations",


### PR DESCRIPTION
# Description
Security Contact Phone in azure means a phone number, not an email address.

The CLI example shown in [Microsoft Docs](https://docs.microsoft.com/en-us/cli/azure/security/contact?view=azure-cli-latest#az-security-contact-create-examples) also has a phone number specified:

```
$ az security contact create -n "default1" --email 'john@contoso.com' --phone '(214)275-4038' --alert-notifications 'on' --alerts-admins 'on'
```


## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
