### PR TITLE
Fix AWS when building for arm64

### DIFF
--- a/docker/bin/container-install-aws2.sh
+++ b/docker/bin/container-install-aws2.sh
@@ -15,7 +15,7 @@ echo -e "\n\nAWS2 CLI Installation Starting...\n\n"
 # install AWS CLI v2
 # =====================================
 cd ${TMPDIR}
-curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"
 unzip awscliv2.zip
 ./aws/install --update
 


### PR DESCRIPTION
# Description

When building the Docker container for arm64 (like AWS Graviton hosts or MacBook M1/M2), the wrong awscli package is installed.

This fixes the problem.

## Type of change

Select the relevant option(s):

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes
