### PR TITLE
Fixing typo in container-set-init.sh

### DIFF
--- a/docker/bin/container-set-init.sh
+++ b/docker/bin/container-set-init.sh
@@ -3,5 +3,5 @@ cat <<'EOF' >> /root/.bashrc
 export TERM=linux
 cd ${HOME}
 source ${HOME}/scoutsuite/bin/activate
-echo -e "Welcome to Sscoutsuite!\nYou are already in the Scoutsuite virtual environment, so just type \`scout\` to run it!\n    (for example: \`scout -h\` to see the help documentation).\n\nHave fun!\n\n"
+echo -e "Welcome to Scoutsuite!\nYou are already in the Scoutsuite virtual environment, so just type \`scout\` to run it!\n    (for example: \`scout -h\` to see the help documentation).\n\nHave fun!\n\n"
 EOF


### PR DESCRIPTION
# Description

Fixing a typo in container-set-init.sh

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes

^ I couldn't get tests to run, but there's no tests looking for this string so I don't see an issue occurring?