### PR TITLE
Enhancement/Catch task exceptions

### DIFF
--- a/ScoutSuite/providers/base/resources/base.py
+++ b/ScoutSuite/providers/base/resources/base.py
@@ -7,10 +7,19 @@ used to reflect that.
 
 import abc
 import asyncio
+from ScoutSuite.core.console import print_exception
+
+
+async def call(child_name, child):
+    """Calls the child class and implements async error handling."""
+    try:
+        task = asyncio.ensure_future(child())
+        await task
+    except Exception as e:
+        print_exception(f'Failed to call {child.__name__}() for resource {child_name}: {e}')
 
 
 class Resources(dict, metaclass=abc.ABCMeta):
-
     """This is the base class of a hierarchical structure. Everything is basically `Resources`.
     It stores in its internal dictionary instances of a given type of resources, with instance ids as keys and
     instance configurations (which store other nested resources) as values.
@@ -32,7 +41,6 @@ class Resources(dict, metaclass=abc.ABCMeta):
 
 
 class CompositeResources(Resources, metaclass=abc.ABCMeta):
-
     """This class represents a node in the hierarchical structure. As inherited from `Resources`, it still \
     stores instances of a given type of resources internally but also stores some kind of nested resources \
     referred to as its 'children'.
@@ -77,8 +85,8 @@ class CompositeResources(Resources, metaclass=abc.ABCMeta):
                     for (child_class, child_name) in self._children]
         # Fetch all children concurrently:
         await asyncio.wait(
-            {asyncio.ensure_future(child.fetch_all())
-             for (child, _) in children}
+            {call(child_name, child.fetch_all)
+             for (child, child_name) in children}
         )
         # Update parent content:
         for child, child_name in children:


### PR DESCRIPTION
This changes allows catching all async exceptions that get thrown in the resource `fetch_all` class method. This way we won't get `Task exception was never retrieved` exceptions.

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
