### PR TITLE
Handle missing CloudFormation stack attributes gracefully

### DIFF
--- a/ScoutSuite/providers/aws/resources/cloudformation/stacks.py
+++ b/ScoutSuite/providers/aws/resources/cloudformation/stacks.py
@@ -21,7 +21,7 @@ class Stacks(AWSResources):
         raw_stack['name'] = raw_stack.pop('StackName')
         raw_stack['drifted'] = raw_stack.pop('DriftInformation')[
                                    'StackDriftStatus'] == 'DRIFTED'
-        raw_stack['termination_protection'] = raw_stack['EnableTerminationProtection']
+        raw_stack['termination_protection'] = raw_stack.get('EnableTerminationProtection', False)
         raw_stack['arn'] = raw_stack['id']
         raw_stack['notificationARNs'] = raw_stack['NotificationARNs']
         template = raw_stack.pop('template')

--- a/ScoutSuite/providers/aws/resources/cloudformation/stacks.py
+++ b/ScoutSuite/providers/aws/resources/cloudformation/stacks.py
@@ -23,7 +23,7 @@ class Stacks(AWSResources):
                                    'StackDriftStatus'] == 'DRIFTED'
         raw_stack['termination_protection'] = raw_stack.get('EnableTerminationProtection', False)
         raw_stack['arn'] = raw_stack['id']
-        raw_stack['notificationARNs'] = raw_stack['NotificationARNs']
+        raw_stack['notificationARNs'] = raw_stack.get('NotificationARNs', [])
         template = raw_stack.pop('template')
         raw_stack['deletion_policy'] = self.has_deletion_policy(template)
 


### PR DESCRIPTION
# Description

Stop attempting to make unguarded references to stack attributes that don't always exist (at least in my environment).

Fixes #1478 

## Type of change

Select the relevant option(s):

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
