### PR TITLE
Enhancement/S3-TlsVersion

### DIFF
--- a/ScoutSuite/providers/aws/facade/s3.py
+++ b/ScoutSuite/providers/aws/facade/s3.py
@@ -273,6 +273,14 @@ class S3Facade(AWSBaseFacade):
                              (statement['Condition']['Bool']['aws:SecureTransport'] == 'true' and
                               statement['Effect'] == 'Allow')):
                         bucket['secure_transport_enabled'] = True
+                    elif 'Condition'in statement and \
+                            'NumericLessThan' in statement['Condition'] and \
+                            's3:TlsVersion' in statement['Condition']['NumericLessThan'] and \
+                            ((statement['Condition']['NumericLessThan']['s3:TlsVersion'] >= '1.2' and
+                              statement['Effect'] == 'Deny') or
+                             (statement['Condition']['NumericGreaterThan']['s3:TlsVersion'] >= '1.1' and
+                              statement['Effect'] == 'Allow')):
+                        bucket['secure_transport_enabled'] = True
             else:
                 bucket['secure_transport_enabled'] = False
         except Exception as e:


### PR DESCRIPTION
# Description
Adds additional checks to determine if Secure Transport is enabled. By Default, ScoutSuite only checks for the boolean Aws:SecureTransport. This adds support for S3:TlsVersion, and uses the operating assumption that TLS 1.2 is the lowest secure version. 

Fixes # N/A (no issue opened)

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
