### PR TITLE
Update azure-mgmt-authorization

### DIFF
--- a/ScoutSuite/providers/azure/facade/rbac.py
+++ b/ScoutSuite/providers/azure/facade/rbac.py
@@ -28,7 +28,8 @@ class RBACFacade:
     async def get_role_assignments(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(lambda: list(client.role_assignments.list()))
+            scope = f'/subscriptions/{subscription_id}'
+            return await run_concurrently(lambda: list(client.role_assignments.list_for_scope(scope=scope)))
         except Exception as e:
             print_exception(f'Failed to retrieve role assignments: {e}')
             return []

--- a/ScoutSuite/providers/azure/resources/rbac/role_assignments.py
+++ b/ScoutSuite/providers/azure/resources/rbac/role_assignments.py
@@ -17,11 +17,11 @@ class RoleAssignments(AzureResources):
         role_assignment_dict = {}
         role_assignment_dict['id'] = raw_role_assignment.name
         role_assignment_dict['name'] = raw_role_assignment.name
-        role_assignment_dict['role_definition_id'] = raw_role_assignment.properties.role_definition_id
+        role_assignment_dict['role_definition_id'] = raw_role_assignment.role_definition_id
         role_assignment_dict['type'] = raw_role_assignment.type
-        role_assignment_dict['scope'] = raw_role_assignment.properties.scope
-        role_assignment_dict['principal_id'] = raw_role_assignment.properties.principal_id
-        role_assignment_dict['principal_type'] = "None"
+        role_assignment_dict['scope'] = raw_role_assignment.scope
+        role_assignment_dict['principal_id'] = raw_role_assignment.principal_id
+        role_assignment_dict['principal_type'] = raw_role_assignment.principal_type
         role_assignment_dict['can_delegate'] = "None"
         role_assignment_dict['additional_properties'] = raw_role_assignment.additional_properties
         return role_assignment_dict['id'], role_assignment_dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ azure-mgmt-network==17.1.0
 azure-mgmt-redis==12.0.0
 azure-mgmt-web==1.0.0
 azure-mgmt-compute==18.2.0
-azure-mgmt-authorization==1.0.0
+azure-mgmt-authorization==3.0.0
 azure-mgmt-rdbms==8.0.0
 
 msgraph-core==0.2.2


### PR DESCRIPTION
# Description

When `azure-mgmt-authorization` was upgraded to v1.0.0, the `RoleAssignment` model returned from `role_assignments.list()` no longer provided a `principal_type`. This principalType was used to compile a list of user Ids to pull down in `rbac/base.py.get_user_list()` if `PrincipalType = 'User'`. This user list was then passed to the 'aad' service to be used in `fetch_additional_users`. Since the PrincipalType is no longer returned, no additional users are ever fetched.

Newer releases of `azure-mgmt-authorization` once again include `principal_type` on the `RoleAssignment` object. This package is only used in the `rbac` service in two places. One in `get_roles` and again in `get_role_assignments`, where this issue is focused. `get_roles` uses the `role_definitions_list` which is not affected by the package updates. 

Updating this package and the `_parse_role_assignment` method restores the ability for scoutsuite to pull all users assigned to roles.

Now that these users are pulled, the scoutsuite results object is a better representation of the current environment

Here is a release history of the affected package: https://pypi.org/project/azure-mgmt-authorization/3.0.0/. We are going from 1.0.0 to 3.0.0

Fixes #1503 

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
