### PR TITLE
Bugfix/handle gcp api and auth errors

### DIFF
--- a/ScoutSuite/providers/gcp/authentication_strategy.py
+++ b/ScoutSuite/providers/gcp/authentication_strategy.py
@@ -1,9 +1,11 @@
+from datetime import datetime
 import logging
 import os
 import warnings
 
 from google import auth
 
+from ScoutSuite.core.console import print_warning
 from ScoutSuite.providers.base.authentication_strategy import AuthenticationStrategy, AuthenticationException
 
 
@@ -36,6 +38,11 @@ class GCPAuthenticationStrategy(AuthenticationStrategy):
 
             if not credentials:
                 raise AuthenticationException('No credentials')
+
+            if hasattr(credentials, 'valid') and not credentials.valid:
+                if hasattr(credentials, 'expiry') and credentials.expiry < datetime.now():
+                    print_warning(f'Credentials expired on {credentials.expiry}')
+                raise AuthenticationException('Credentials are invalid')
 
             credentials.is_service_account = service_account is not None
             credentials.default_project_id = default_project_id

--- a/ScoutSuite/providers/gcp/facade/base.py
+++ b/ScoutSuite/providers/gcp/facade/base.py
@@ -134,16 +134,20 @@ class GCPFacade(GCPBaseFacade):
                                 'you may have specified a non-existing Organization, Folder or Project')
 
         except Exception as e:
-            if 'The service is currently unavailable' in e or 'Internal error encountered' in e:
-                print_level = print_warning
-            else:
-                print_level = print_exception
+            print_level = print_exception
+            exception_str = str(e)
             try:
-                content = e.content.decode("utf-8")
-                content_dict = json.loads(content)
-                print_level(f'Unable to list accessible Projects: {content_dict.get("error").get("message")}')
-            except Exception as e:
-                print_level(f'Unable to list accessible Projects: {e}')
+                if 'The service is currently unavailable' in exception_str or 'Internal error encountered' in exception_str:
+                    print_level = print_warning
+                if hasattr(e, 'content'):
+                    content = e.content.decode("utf-8")
+                    content_dict = json.loads(content)
+                    exception_str = content_dict.get("error").get("message")
+            except Exception:
+                # The default output level and message have been set. Use those in the event of any error processing the exception.
+                pass
+
+            print_level(f'Unable to list accessible Projects: {exception_str}')
 
         finally:
             return projects


### PR DESCRIPTION
# Description

If the currently saved GCP credentials were expired, the script did not check and proceeded to make all GCP API requests, which would subsequently fail.

On such failures, the exception raised by the Google SDK did not support the `in` operator, causing an additional exception to be raised and subsequently swallowed by the `return` statement in the `finally` block.

Both factors combined meant that the user received no feedback that the credentials were expired, and a report was "successfully" produced with zero resources and zero findings.

Fixes # (issue)

## Type of change

Select the relevant option(s):

- [+] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [+] My code follows the style guidelines of this project
- [+] I have performed a self-review of my own code
- [+] I have commented my code, particularly in hard-to-understand areas
- [+] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
