### PR TITLE
Feature/661 Azure specific resource group 

### DIFF
--- a/ScoutSuite/__main__.py
+++ b/ScoutSuite/__main__.py
@@ -50,6 +50,7 @@ def run_from_cli():
                    username=args.get('username'), password=args.get('password'),
                    tenant_id=args.get('tenant_id'),
                    subscription_ids=args.get('subscription_ids'), all_subscriptions=args.get('all_subscriptions'),
+                   resource_group=args.get('resource_group'),
                    # GCP
                    project_id=args.get('project_id'), folder_id=args.get('folder_id'),
                    organization_id=args.get('organization_id'), all_projects=args.get('all_projects'),
@@ -102,6 +103,7 @@ def run(provider,
         username=None, password=None,
         tenant_id=None,
         subscription_ids=None, all_subscriptions=None,
+        resource_group=None,
         # GCP
         service_account=None,
         project_id=None, folder_id=None, organization_id=None, all_projects=False,
@@ -160,6 +162,7 @@ async def _run(provider,
                subscription_ids, all_subscriptions,
                client_id, client_secret,
                username, password,
+               resource_group,
                # GCP
                service_account,
                project_id, folder_id, organization_id, all_projects,
@@ -243,6 +246,7 @@ async def _run(provider,
                                       # Azure
                                       subscription_ids=subscription_ids,
                                       all_subscriptions=all_subscriptions,
+                                      resource_group=resource_group,
                                       # GCP
                                       project_id=project_id,
                                       folder_id=folder_id,

--- a/ScoutSuite/core/cli_parser.py
+++ b/ScoutSuite/core/cli_parser.py
@@ -213,6 +213,11 @@ class ScoutSuiteArgumentParser:
                                  action='store_true',
                                  dest='all_subscriptions',
                                  help='Scan all of the accessible subscriptions')
+        azure_scope.add_argument('--resource-group',
+                                action='store',
+                                dest='resource_group',
+                                default=None,
+                                help='Name of the resource group to scan (default is all resource groups)')
 
     def _init_aliyun_parser(self):
         parser = self.subparsers.add_parser("aliyun",

--- a/ScoutSuite/providers/azure/facade/appservice.py
+++ b/ScoutSuite/providers/azure/facade/appservice.py
@@ -8,8 +8,9 @@ from ScoutSuite.utils import get_user_agent
 
 class AppServiceFacade:
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, resource_group=None):
         self.credentials = credentials
+        self.resource_group = resource_group
 
     def get_client(self, subscription_id: str):
         client = WebSiteManagementClient(self.credentials.get_credentials(),
@@ -19,9 +20,15 @@ class AppServiceFacade:
     async def get_web_apps(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            web_apps = await run_concurrently(
-                lambda: list(client.web_apps.list())
-            )
+            
+            if self.resource_group:
+                web_apps = await run_concurrently(
+                    lambda: list(client.web_apps.list_by_resource_group(self.resource_group))
+                )
+            else:
+                web_apps = await run_concurrently(
+                    lambda: list(client.web_apps.list())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve web apps: {e}')
             return []

--- a/ScoutSuite/providers/azure/facade/base.py
+++ b/ScoutSuite/providers/azure/facade/base.py
@@ -38,6 +38,7 @@ class AzureFacade:
     def __init__(self,
                  credentials: AzureCredentials,
                  subscription_ids=[], all_subscriptions=False,
+                 resource_group=None,
                  programmatic_execution=False):
 
         self.credentials = credentials
@@ -48,18 +49,18 @@ class AzureFacade:
         self.all_subscriptions = all_subscriptions
 
         self.aad = AADFacade(credentials)
-        self.rbac = RBACFacade(credentials)
-        self.keyvault = KeyVaultFacade(credentials)
-        self.virtualmachines = VirtualMachineFacade(credentials)
-        self.network = NetworkFacade(credentials)
+        self.rbac = RBACFacade(credentials, resource_group=resource_group)
+        self.keyvault = KeyVaultFacade(credentials, resource_group=resource_group)
+        self.virtualmachines = VirtualMachineFacade(credentials, resource_group=resource_group)
+        self.network = NetworkFacade(credentials, resource_group=resource_group)
         self.securitycenter = SecurityCenterFacade(credentials)
-        self.sqldatabase = SQLDatabaseFacade(credentials)
-        self.storageaccounts = StorageAccountsFacade(credentials)
-        self.appservice = AppServiceFacade(credentials)
-        self.mysqldatabase = MySQLDatabaseFacade(credentials)
-        self.postgresqldatabase = PostgreSQLDatabaseFacade(credentials)
-        self.loggingmonitoring = LoggingMonitoringFacade(credentials)
-        self.resourcemanagement = ResourceManagementFacade(credentials)
+        self.sqldatabase = SQLDatabaseFacade(credentials, resource_group=resource_group)
+        self.storageaccounts = StorageAccountsFacade(credentials,resource_group=resource_group)
+        self.appservice = AppServiceFacade(credentials, resource_group=resource_group)
+        self.mysqldatabase = MySQLDatabaseFacade(credentials, resource_group=resource_group)
+        self.postgresqldatabase = PostgreSQLDatabaseFacade(credentials, resource_group=resource_group)
+        self.loggingmonitoring = LoggingMonitoringFacade(credentials, resource_group=resource_group)
+        self.resourcemanagement = ResourceManagementFacade(credentials, resource_group=resource_group)
 
         # Instantiate facades for proprietary services
         try:

--- a/ScoutSuite/providers/azure/facade/base.py
+++ b/ScoutSuite/providers/azure/facade/base.py
@@ -49,7 +49,7 @@ class AzureFacade:
         self.all_subscriptions = all_subscriptions
 
         self.aad = AADFacade(credentials)
-        self.rbac = RBACFacade(credentials, resource_group=resource_group)
+        self.rbac = RBACFacade(credentials)
         self.keyvault = KeyVaultFacade(credentials, resource_group=resource_group)
         self.virtualmachines = VirtualMachineFacade(credentials, resource_group=resource_group)
         self.network = NetworkFacade(credentials, resource_group=resource_group)

--- a/ScoutSuite/providers/azure/facade/keyvault.py
+++ b/ScoutSuite/providers/azure/facade/keyvault.py
@@ -7,8 +7,9 @@ from ScoutSuite.utils import get_user_agent
 
 class KeyVaultFacade:
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, resource_group=None):
         self.credentials = credentials
+        self.resource_group = resource_group
 
     def get_client(self, subscription_id: str):
         client = KeyVaultManagementClient(self.credentials.get_credentials(),
@@ -18,8 +19,13 @@ class KeyVaultFacade:
     async def get_key_vaults(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.vaults.list_by_subscription()))
+            
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.vaults.list_by_resource_group(self.resource_group)))
+            else:
+                return await run_concurrently(
+                    lambda: list(client.vaults.list_by_subscription()))
         except Exception as e:
             print_exception(f'Failed to retrieve key vaults: {e}')
             return []

--- a/ScoutSuite/providers/azure/facade/loggingmonitoring.py
+++ b/ScoutSuite/providers/azure/facade/loggingmonitoring.py
@@ -6,8 +6,9 @@ from azure.mgmt.monitor import MonitorManagementClient
 
 class LoggingMonitoringFacade:
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, resource_group=None):
         self.credentials = credentials
+        self.resource_group = resource_group
 
     def get_client(self, subscription_id: str):
         client = MonitorManagementClient(self.credentials.get_credentials(),
@@ -51,9 +52,14 @@ class LoggingMonitoringFacade:
     async def get_activity_log_alerts(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            activity_log_alerts = await run_concurrently(
-                lambda: list(client.activity_log_alerts.list_by_subscription_id())
-            )
+            if self.resource_group:
+                activity_log_alerts = await run_concurrently(
+                    lambda: list(client.activity_log_alerts.list_by_resource_group(resource_group_name=self.resource_group))
+                )
+            else:
+                activity_log_alerts = await run_concurrently(
+                    lambda: list(client.activity_log_alerts.list_by_subscription_id())
+                )
             return activity_log_alerts
         except Exception as e:
             print_exception(f'Failed to retrieve activity log alerts: {e}')

--- a/ScoutSuite/providers/azure/facade/mysqldatabase.py
+++ b/ScoutSuite/providers/azure/facade/mysqldatabase.py
@@ -6,8 +6,10 @@ from ScoutSuite.utils import get_user_agent
 
 class MySQLDatabaseFacade:
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, resource_group=None):
         self.credentials = credentials
+        self.resource_group = resource_group
+
 
     def get_client(self, subscription_id: str):
         client = MySQLManagementClient(self.credentials.get_credentials(),
@@ -18,9 +20,14 @@ class MySQLDatabaseFacade:
     async def get_servers(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.servers.list())
-            )
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.servers.list_by_resource_group(self.resource_group))
+                )
+            else:
+                return await run_concurrently(
+                    lambda: list(client.servers.list())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve mySQL servers: {e}')
             return []

--- a/ScoutSuite/providers/azure/facade/network.py
+++ b/ScoutSuite/providers/azure/facade/network.py
@@ -7,8 +7,9 @@ from ScoutSuite.utils import get_user_agent
 
 class NetworkFacade:
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, resource_group=None):
         self.credentials = credentials
+        self.resource_group = resource_group
 
     def get_client(self, subscription_id: str):
         client = NetworkManagementClient(self.credentials.get_credentials(),
@@ -19,9 +20,15 @@ class NetworkFacade:
     async def get_network_watchers(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.network_watchers.list_all())
-            )
+            
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.network_watchers.list(resource_group_name=self.resource_group))
+                )
+            else:
+                return await run_concurrently(
+                    lambda: list(client.network_watchers.list_all())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve network watchers: {e}')
             return []
@@ -29,9 +36,15 @@ class NetworkFacade:
     async def get_network_security_groups(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.network_security_groups.list_all())
-            )
+            
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.network_security_groups.list(resource_group_name=self.resource_group))
+                )
+            else:
+                return await run_concurrently(
+                    lambda: list(client.network_security_groups.list_all())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve network security groups: {e}')
             return []
@@ -39,9 +52,15 @@ class NetworkFacade:
     async def get_application_security_groups(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.application_security_groups.list_all())
-            )
+            
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.application_security_groups.list(resource_group_name=self.resource_group))
+                )
+            else:
+                return await run_concurrently(
+                    lambda: list(client.application_security_groups.list_all())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve application security groups: {e}')
             return []
@@ -49,9 +68,15 @@ class NetworkFacade:
     async def get_virtual_networks(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.virtual_networks.list_all())
-            )
+            
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.virtual_networks.list(resource_group_name=self.resource_group))
+                )
+            else:
+                return await run_concurrently(
+                    lambda: list(client.virtual_networks.list_all())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve virtual networks: {e}')
             return []
@@ -59,9 +84,15 @@ class NetworkFacade:
     async def get_network_interfaces(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.network_interfaces.list_all())
-            )
+            
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.network_interfaces.list(resource_group_name=self.resource_group))
+                )
+            else:
+                return await run_concurrently(
+                    lambda: list(client.network_interfaces.list_all())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve network interfaces: {e}')
             return []

--- a/ScoutSuite/providers/azure/facade/postgresqldatabse.py
+++ b/ScoutSuite/providers/azure/facade/postgresqldatabse.py
@@ -6,8 +6,9 @@ from ScoutSuite.utils import get_user_agent
 
 class PostgreSQLDatabaseFacade:
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, resource_group=None):
         self.credentials = credentials
+        self.resource_group = resource_group
 
     def get_client(self, subscription_id: str):
         client = PostgreSQLManagementClient(self.credentials.get_credentials(),
@@ -18,9 +19,14 @@ class PostgreSQLDatabaseFacade:
     async def get_servers(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.servers.list())
-            )
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.servers.list_by_resource_group(self.resource_group))
+                )
+            else:
+                return await run_concurrently(
+                    lambda: list(client.servers.list())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve postgresSQL servers: {e}')
             return []

--- a/ScoutSuite/providers/azure/facade/rbac.py
+++ b/ScoutSuite/providers/azure/facade/rbac.py
@@ -7,9 +7,8 @@ from ScoutSuite.utils import get_user_agent
 
 class RBACFacade:
 
-    def __init__(self, credentials, resource_group=None):
+    def __init__(self, credentials):
         self.credentials = credentials
-        self.resource_group = resource_group
 
     def get_client(self, subscription_id: str):
         client = AuthorizationManagementClient(self.credentials.get_credentials(),
@@ -21,8 +20,6 @@ class RBACFacade:
         try:
             client = self.get_client(subscription_id)
             scope = f'/subscriptions/{subscription_id}'
-            if self.resource_group:
-                scope += f'/resourceGroups/{self.resource_group}'
             return await run_concurrently(lambda: list(client.role_definitions.list(scope=scope)))
         except Exception as e:
             print_exception(f'Failed to retrieve roles: {e}')
@@ -32,8 +29,6 @@ class RBACFacade:
         try:
             client = self.get_client(subscription_id)
             scope = f'/subscriptions/{subscription_id}'
-            if self.resource_group:
-                scope += f'/resourceGroups/{self.resource_group}'
             return await run_concurrently(lambda: list(client.role_assignments.list_for_scope(scope=scope)))
         except Exception as e:
             print_exception(f'Failed to retrieve role assignments: {e}')

--- a/ScoutSuite/providers/azure/facade/rbac.py
+++ b/ScoutSuite/providers/azure/facade/rbac.py
@@ -7,8 +7,9 @@ from ScoutSuite.utils import get_user_agent
 
 class RBACFacade:
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, resource_group=None):
         self.credentials = credentials
+        self.resource_group = resource_group
 
     def get_client(self, subscription_id: str):
         client = AuthorizationManagementClient(self.credentials.get_credentials(),
@@ -20,6 +21,8 @@ class RBACFacade:
         try:
             client = self.get_client(subscription_id)
             scope = f'/subscriptions/{subscription_id}'
+            if self.resource_group:
+                scope += f'/resourceGroups/{self.resource_group}'
             return await run_concurrently(lambda: list(client.role_definitions.list(scope=scope)))
         except Exception as e:
             print_exception(f'Failed to retrieve roles: {e}')
@@ -29,6 +32,8 @@ class RBACFacade:
         try:
             client = self.get_client(subscription_id)
             scope = f'/subscriptions/{subscription_id}'
+            if self.resource_group:
+                scope += f'/resourceGroups/{self.resource_group}'
             return await run_concurrently(lambda: list(client.role_assignments.list_for_scope(scope=scope)))
         except Exception as e:
             print_exception(f'Failed to retrieve role assignments: {e}')

--- a/ScoutSuite/providers/azure/facade/sqldatabase.py
+++ b/ScoutSuite/providers/azure/facade/sqldatabase.py
@@ -7,8 +7,9 @@ from ScoutSuite.utils import get_user_agent
 
 class SQLDatabaseFacade:
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, resource_group=None):
         self.credentials = credentials
+        self.resource_group = resource_group
 
     def get_client(self, subscription_id: str):
         client = SqlManagementClient(self.credentials.get_credentials(),
@@ -96,9 +97,15 @@ class SQLDatabaseFacade:
     async def get_servers(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.servers.list())
-            )
+            
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.servers.list_by_resource_group(self.resource_group))
+                )
+            else:
+                return await run_concurrently(
+                    lambda: list(client.servers.list())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve servers: {e}')
             return []

--- a/ScoutSuite/providers/azure/facade/storageaccounts.py
+++ b/ScoutSuite/providers/azure/facade/storageaccounts.py
@@ -9,8 +9,9 @@ from ScoutSuite.utils import get_user_agent
 
 class StorageAccountsFacade:
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, resource_group=None):
         self.credentials = credentials
+        self.resource_group=resource_group
 
     def get_client(self, subscription_id: str):
         client = StorageManagementClient(self.credentials.get_credentials(),
@@ -21,9 +22,15 @@ class StorageAccountsFacade:
     async def get_storage_accounts(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            storage_accounts = await run_concurrently(
-                lambda: list(client.storage_accounts.list())
-            )
+            if self.resource_group:
+                storage_accounts = await run_concurrently(
+                    lambda: list(client.storage_accounts.list_by_resource_group(self.resource_group))
+                )
+            else:
+                storage_accounts = await run_concurrently(
+                    lambda: list(client.storage_accounts.list())
+                )
+
         except Exception as e:
             print_exception(f'Failed to retrieve storage accounts: {e}')
             return []

--- a/ScoutSuite/providers/azure/facade/virtualmachines.py
+++ b/ScoutSuite/providers/azure/facade/virtualmachines.py
@@ -7,8 +7,9 @@ from ScoutSuite.utils import get_user_agent
 
 class VirtualMachineFacade:
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, resource_group=None):
         self.credentials = credentials
+        self.resource_group = resource_group
 
     def get_client(self, subscription_id: str):
 
@@ -20,9 +21,14 @@ class VirtualMachineFacade:
     async def get_instances(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.virtual_machines.list_all())
-            )
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.virtual_machines.list(resource_group_name=self.resource_group))
+                )
+            else:
+                return await run_concurrently(
+                    lambda: list(client.virtual_machines.list_all())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve virtual machines: {e}')
             return []
@@ -44,9 +50,14 @@ class VirtualMachineFacade:
     async def get_disks(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.disks.list())
-            )
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.disks.list_by_resource_group(self.resource_group))
+                )
+            else:
+                return await run_concurrently(
+                    lambda: list(client.disks.list())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve disks: {e}')
             return []
@@ -54,9 +65,15 @@ class VirtualMachineFacade:
     async def get_snapshots(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.snapshots.list())
-            )
+
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.snapshots.list_by_resource_group(self.resource_group))
+                )
+            else: 
+                return await run_concurrently(
+                    lambda: list(client.snapshots.list())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve snapshots: {e}')
             return []
@@ -64,9 +81,15 @@ class VirtualMachineFacade:
     async def get_images(self, subscription_id: str):
         try:
             client = self.get_client(subscription_id)
-            return await run_concurrently(
-                lambda: list(client.images.list())
-            )
+
+            if self.resource_group:
+                return await run_concurrently(
+                    lambda: list(client.images.list_by_resource_group(self.resource_group))
+                )
+            else:
+                return await run_concurrently(
+                    lambda: list(client.images.list())
+                )
         except Exception as e:
             print_exception(f'Failed to retrieve images: {e}')
             return []

--- a/ScoutSuite/providers/azure/provider.py
+++ b/ScoutSuite/providers/azure/provider.py
@@ -13,6 +13,7 @@ class AzureProvider(BaseProvider):
 
     def __init__(self,
                  subscription_ids=[], all_subscriptions=None,
+                 resource_group=None,
                  report_dir=None, timestamp=None, services=None, skipped_services=None,
                  result_format='json',
                  **kwargs):
@@ -44,7 +45,8 @@ class AzureProvider(BaseProvider):
         self.services = AzureServicesConfig(self.credentials,
                                             programmatic_execution=self.programmatic_execution,
                                             subscription_ids=self.subscription_ids,
-                                            all_subscriptions=self.all_subscriptions)
+                                            all_subscriptions=self.all_subscriptions,
+                                            resource_group=resource_group)
 
         self.result_format = result_format
 

--- a/ScoutSuite/providers/azure/services.py
+++ b/ScoutSuite/providers/azure/services.py
@@ -34,6 +34,7 @@ class AzureServicesConfig(BaseServicesConfig):
     def __init__(self,
                  credentials: AzureCredentials = None,
                  subscription_ids=[], all_subscriptions=None,
+                 resource_group=None,
                  programmatic_execution=None,
                  **kwargs):
 
@@ -41,7 +42,9 @@ class AzureServicesConfig(BaseServicesConfig):
 
         facade = AzureFacade(credentials,
                              subscription_ids, all_subscriptions,
-                             programmatic_execution)
+                             resource_group,
+                             programmatic_execution,
+                             )
 
         self.aad = AAD(facade)
         self.rbac = RBAC(facade)


### PR DESCRIPTION
# Description

Allows to add the flag --resource-group "RG_NAME" to only scan the specified resource group in Azure.

This is achieved by passing the value of the flag up the abstractions until the facade creation. Then when resources are fetched the Facade classes check if self.resource_group is set, and if it is, it only fetches from that resource group using the appropriate APIs (either list_by_resource_group(resource_group_name=self.resource_group) or list(resource_group_name=self.resource_group) ).
Not sure if this is the best place to put it, let me know if you want refactoring.

I tested it on resources that I spawned up and it worked, I didn't see any existing relevant test suites for Azure.

Didn't modify Facade for AAD, RBAC and security center since those checks are inherently subscription level checks.

Fixes # 661

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
