### PR TITLE
Ensure correct SQL DB AD Admin check

### DIFF
--- a/ScoutSuite/providers/azure/facade/sqldatabase.py
+++ b/ScoutSuite/providers/azure/facade/sqldatabase.py
@@ -56,8 +56,8 @@ class SQLDatabaseFacade:
         try:
             client = self.get_client(subscription_id)
             return await run_concurrently(
-                lambda: client.replication_links.list_by_database(
-                    resource_group_name, server_name, database_name)
+                lambda: list(client.replication_links.list_by_database(
+                    resource_group_name, server_name, database_name))
             )
         except Exception as e:
             print_exception(f'Failed to retrieve database replication links: {e}')
@@ -67,7 +67,7 @@ class SQLDatabaseFacade:
         try:
             client = self.get_client(subscription_id)
             return await run_concurrently(
-                lambda: client.server_azure_ad_administrators.list_by_server(resource_group_name, server_name)
+                lambda: list(client.server_azure_ad_administrators.list_by_server(resource_group_name, server_name))
             )
         except Exception as e:
             print_exception(f'Failed to retrieve server azure ad administrators: {e}')

--- a/ScoutSuite/providers/azure/resources/sqldatabase/replication_links.py
+++ b/ScoutSuite/providers/azure/resources/sqldatabase/replication_links.py
@@ -18,7 +18,7 @@ class ReplicationLinks(AzureResources):
         self._parse_links(links)
 
     def _parse_links(self, links):
-        links_count = len(list(links))
+        links_count = len(links)
         self.update({
             'replication_configured': links_count > 0
         })

--- a/ScoutSuite/providers/azure/rules/findings/sqldatabase-servers-no-ad-admin-configured.json
+++ b/ScoutSuite/providers/azure/rules/findings/sqldatabase-servers-no-ad-admin-configured.json
@@ -28,7 +28,7 @@
         "and",
         [
             "sqldatabase.subscriptions.id.servers.id.ad_admin",
-            "null",
+            "empty",
             ""
         ]
     ],


### PR DESCRIPTION
# Description

ScoutSuite has a bug when assessing the rule entitled "Azure Active Directory Admin Not Configured for SQL Servers".

As indicated within the CIS benchmark, this should be tested by retrieving the list of AAD Administrators for the database, and failing if the list is empty. The ScoutSuite implementation had two errors:

1. The rule checked for `null` rather than `empty`
2. The facade returned an object which was iterable but not a list, which would not be correctly evaluated.

The fix for the 2nd issue brings the code specific to this check into line with other facade methods that return lists, each of which also use the `list()` constructor to force other iterables into lists at this point. For example, see `sqldatabase.py` line 48.

I have scanned the Azure facade files for similar issues, and fixed one other function `get_database_replication_links()`. This did not cause a bug because the only function which used this converted the result into a `list` by itself. Nonetheless I modified this in order to ensure that all facade functions behave in a consistent way.

## Type of change

Select the relevant option(s):

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes
