### PR TITLE
Use Azure ADE status to prevent false positives

### DIFF
--- a/ScoutSuite/output/data/html/partials/azure/services.virtualmachines.subscriptions.id.disks.html
+++ b/ScoutSuite/output/data/html/partials/azure/services.virtualmachines.subscriptions.id.disks.html
@@ -13,6 +13,7 @@
         <div class="list-group-item-text item-margin">Disk State: <span id="virtualmachines.subscriptions.{{subscription}}.disks.{{@key}}.disk_state"><samp>{{value_or_none disk_state}}</samp></span></div>
         <div class="list-group-item-text item-margin">Zones: <span id="virtualmachines.subscriptions.{{subscription}}.disks.{{@key}}.zones"><samp>{{value_or_none zones}}</samp></span></div>
         <div class="list-group-item-text item-margin">Encryption Type: <span id="virtualmachines.subscriptions.{{subscription}}.disks.{{@key}}.encryption_type"><samp>{{value_or_none encryption_type}}</samp></span></div>
+        <div class="list-group-item-text item-margin">Encrypted using ADE: <span id="virtualmachines.subscriptions.{{subscription}}.disks.{{@key}}.encryption_type"><samp>{{convert_bool_to_enabled encryption_ade}}</samp></span></div>
         <div class="list-group-item-text item-margin">OS Type: <span id="virtualmachines.subscriptions.{{subscription}}.disks.{{@key}}.os_type"><samp>{{value_or_none os_type}}</samp></span></div>
         <div class="list-group-item-text item-margin">Hyper V Generation: <span id="virtualmachines.subscriptions.{{subscription}}.disks.{{@key}}.hyper_vgeneration"><samp>{{value_or_none hyper_vgeneration}}</samp></span></div>
         <div class="list-group-item-text item-margin">Disk Size GB: <span id="virtualmachines.subscriptions.{{subscription}}.disks.{{@key}}.disk_size_gb"><samp>{{value_or_none disk_size_gb}}</samp></span></div>

--- a/ScoutSuite/providers/azure/resources/virtualmachines/disks.py
+++ b/ScoutSuite/providers/azure/resources/virtualmachines/disks.py
@@ -43,6 +43,12 @@ class Disks(AzureResources):
         else:
             disk_dict['encryption_type'] = None
 
+        if getattr(raw_disk, 'encryption_settings_collection', None):
+            disk_dict['encryption_ade'] = raw_disk.encryption_settings_collection.enabled and \
+                getattr(raw_disk.encryption_settings_collection, 'encryption_settings_version') in ['1.0','1.1']
+        else:
+            disk_dict['encryption_ade'] = False
+
         return disk_dict['id'], disk_dict
 
 

--- a/ScoutSuite/providers/azure/resources/virtualmachines/instances.py
+++ b/ScoutSuite/providers/azure/resources/virtualmachines/instances.py
@@ -118,4 +118,6 @@ class Instances(AzureResources):
             instance_name=instance_dict['name'],
             resource_group=get_resource_group_name(raw_instance.id))
 
+        instance_dict['extension_names'] = [extension.name for extension in instance_dict['extensions']]
+
         return instance_dict['id'], instance_dict

--- a/ScoutSuite/providers/azure/rules/findings/virtual-machines-disk-encryption.json
+++ b/ScoutSuite/providers/azure/rules/findings/virtual-machines-disk-encryption.json
@@ -41,6 +41,11 @@
             "virtualmachines.subscriptions.id.disks.id.encryption_type",
             "null",
             ""
+        ],
+        [
+            "virtualmachines.subscriptions.id.disks.id.encryption_ade",
+            "false",
+            ""
         ]
     ],
     "id_suffix": "encryption_type"

--- a/ScoutSuite/providers/azure/rules/findings/virtual-machines-extensions-installed.json
+++ b/ScoutSuite/providers/azure/rules/findings/virtual-machines-extensions-installed.json
@@ -28,9 +28,12 @@
     "conditions": [
         "and",
         [
-            "virtualmachines.subscriptions.id.instances.id.extensions",
-            "notEmpty",
-            ""
+            "virtualmachines.subscriptions.id.instances.id.extension_names",
+            "containAtLeastOneDifferentFrom",
+            [ 
+                "AzureDiskEncryption",
+                "AzureDiskEncryptionForLinux"
+            ]
         ]
     ],
     "id_suffix": "extensions"

--- a/ScoutSuite/providers/azure/rules/findings/virtual-machines-os-data-encrypted-cmk.json
+++ b/ScoutSuite/providers/azure/rules/findings/virtual-machines-os-data-encrypted-cmk.json
@@ -20,15 +20,23 @@
     "dashboard_name": "Disks",
     "path": "virtualmachines.subscriptions.id.disks.id",
     "conditions": [
-        "or",
+        "and",
         [
-            "virtualmachines.subscriptions.id.disks.id.encryption_type",
-            "equal",
-            "EncryptionAtRestWithPlatformKey"
+            "or",
+            [
+                "virtualmachines.subscriptions.id.disks.id.encryption_type",
+                "null",
+                ""
+            ],
+            [
+                "virtualmachines.subscriptions.id.disks.id.encryption_type",
+                "equal",
+                "EncryptionAtRestWithPlatformKey"
+            ]
         ],
         [
-            "virtualmachines.subscriptions.id.disks.id.encryption_type",
-            "null",
+            "virtualmachines.subscriptions.id.disks.id.encryption_ade",
+            "false",
             ""
         ]
     ],

--- a/ScoutSuite/providers/azure/rules/findings/virtual-machines-unattached-disks-encrypted-cmk.json
+++ b/ScoutSuite/providers/azure/rules/findings/virtual-machines-unattached-disks-encrypted-cmk.json
@@ -39,6 +39,11 @@
                 "equal",
                 "EncryptionAtRestWithPlatformKey"
             ]
+        ],
+        [
+            "virtualmachines.subscriptions.id.disks.id.encryption_ade",
+            "false",
+            ""
         ]
     ],
     "id_suffix": "encryption_type"


### PR DESCRIPTION
# Description

In certain circumstances, ScoutSuite can generate false positive reports regarding the rules:

- OS and Data Disks Not Encrypted with CMK
- Unattached Disks Not Encrypted with CMK

This can occur when the VMs are configured to use Azure Disk Encryption (ADE). In this case, Server Side Encryption (SSE) is still enabled, but cannot be used in conjunction with CMK. Because ADE is a suitable alternative which provides stronger protection than SSE, it is not correct to flag the lack of CMK as an issue when ADE is enabled.

The changes in this PR ensure that the presence of ADE is detected. The simplest way I found to do this was to look for the `encryption_settings_collection` attribute in the `raw_disk` object. Based on my testing it seems that this attribute is *only* present when ADE is enabled, and it is set to `None` otherwise. Furthermore, the `encryption_settings_version` property must be set to 1.0 or 1.1 (see https://learn.microsoft.com/en-us/python/api/azure-mgmt-compute/azure.mgmt.compute.v2022_07_02.models.encryptionsettingscollection?view=azure-python). Practically it might be 1.1 only but 1.0 is mentioned in the doc as related to "Azure Disk Encryption with AAD app" so I thought I'd include it.

Because ADE requires the presence of extensions named "AzureDiskEncryption" or "AzureDiskEncryptionForLinux", I decided also to modify the "Virtual Machine Extensions Installed" rule, to prevent it triggering in the presence of those extensions. 

## Type of change

Select the relevant option(s):

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes