### PR TITLE
Bugfix/lb exceptions

### DIFF
--- a/ScoutSuite/output/data/html/partials/aws/services.elb.regions.id.vpcs.id.elbs.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.elb.regions.id.vpcs.id.elbs.html
@@ -24,7 +24,7 @@
             <ul>
                 {{#each listeners}}
                     <li class="list-group-item-text">
-                        {{@key}} ({{Protocol}}{{#if SslPolicy}}, {{SslPolicy}}{{/if}})
+                      <span id="elb.regions.{{../region}}.vpcs.{{../vpc}}.elbs.{{@../key}}.listeners.{{@key}}">{{@key}} ({{Protocol}}{{#if SslPolicy}}, {{SslPolicy}}{{/if}})</span>
                     </li>
                 {{/each}}
           </ul>

--- a/ScoutSuite/output/data/html/partials/aws/services.elbv2.regions.id.vpcs.id.elbs.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.elbv2.regions.id.vpcs.id.elbs.html
@@ -25,7 +25,7 @@
             <ul>
                 {{#each listeners}}
                     <li class="list-group-item-text">
-                        {{@key}} ({{Protocol}}{{#if SslPolicy}}, {{SslPolicy}}{{/if}})
+                        <span id="elbv2.regions.{{../region}}.vpcs.{{../vpc}}.lbs.{{@../key}}.listeners.{{@key}}">{{@key}} ({{Protocol}}{{#if SslPolicy}}, {{SslPolicy}}{{/if}})</span>
                     </li>
                 {{/each}}
             </ul>

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -239,7 +239,7 @@ function processTemplate(id1, containerId, list, replace) {
  * Hide all lists and details
  */
 function hideAll() {
-    $("[id*='.list']").not("[id*='metadata.list']").not("[id='regions.list']").not("[id*='filters.list']").hide()
+    $("[id$='.list']").not("[id='metadata.list']").not("[id='regions.list']").not("[id='filters.list']").hide()
     // Add special case excluded by above selector
     $("[id*='metric_filters.list']").hide()
 

--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -240,8 +240,6 @@ function processTemplate(id1, containerId, list, replace) {
  */
 function hideAll() {
     $("[id$='.list']").not("[id='metadata.list']").not("[id='regions.list']").not("[id='filters.list']").hide()
-    // Add special case excluded by above selector
-    $("[id*='metric_filters.list']").hide()
 
     $("[id*='.details']").hide()
     var element = document.getElementById('scout_display_account_id_on_all_pages')


### PR DESCRIPTION
# Description

Fixes #1532

The HTML templates lacked appropriate `<span>` elements which permitted the application to generate the appropriate highlighting for finding-related listener port properties.

Adding the `<span>` elements revealed another issue in the `hideAll()` function in `scoutsuite.js`. The CSS selector ensured that all elements with ID containing ".list" were hidden. However, the ID relevant to the current issue contained the string "**.list**eners" which was also accidentally hidden. I've changed the CSS selectors to use the `$=` (ends with) rather than `*=` (contains) operator, and replaced some of the `.not()` exclusions to match entire strings of "metadata.list" and "filters.list", to prevent further hacks required in the future.

## Type of change

Select the relevant option(s):

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes
