### PR TITLE
Bugfix/false negative keyvault purge protection

### DIFF
--- a/ScoutSuite/providers/azure/resources/keyvault/vaults.py
+++ b/ScoutSuite/providers/azure/resources/keyvault/vaults.py
@@ -31,7 +31,7 @@ class Vaults(AzureResources):
         vault['properties'] = raw_vault.properties
         vault[
             'recovery_protection_enabled'] = raw_vault.properties.enable_soft_delete and \
-                                             raw_vault.properties.enable_purge_protection
+                                             bool(raw_vault.properties.enable_purge_protection)
         vault['public_access_allowed'] = self._is_public_access_allowed(raw_vault)
         return vault['id'], vault
 

--- a/ScoutSuite/providers/azure/rules/findings/keyvault-not-recoverable.json
+++ b/ScoutSuite/providers/azure/rules/findings/keyvault-not-recoverable.json
@@ -6,7 +6,7 @@
         {
             "name": "CIS Microsoft Azure Foundations",
             "version": "1.2.0",
-            "reference": "8.4"
+            "reference": "8.5"
         }
     ],
     "references": [
@@ -14,7 +14,7 @@
         "https://blogs.technet.microsoft.com/kv/2017/05/10/azure-key-vault-recovery-options/",
         "https://learn.microsoft.com/en-us/azure/security/benchmarks/security-controls-v2-governance-strategy#gs-8-define-backup-and-recovery-strategy"
     ],
-    "dashboard_name": "PostgreSQL Servers",
+    "dashboard_name": "Keys",
     "path": "keyvault.subscriptions.id.vaults.id",
     "conditions": [
         "and",


### PR DESCRIPTION
# Description

The rule was not being fired because the `raw_vault.properties.enable_purge_protection` property was set to None rather than False by the Azure SDK. Because, in Python, `False or None` evaluated to `None` rather than `False`, this was interfering with the subsequent evaluation of the rule and the display of the value in the report.

Also, I have spotted some errors in the finding template which I fixed.

## Type of change

Select the relevant option(s):

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes
