### PR TITLE
Feature/keyvault expiration dates

### DIFF
--- a/ScoutSuite/output/data/html/partials/azure/services.keyvault.subscriptions.id.vaults.html
+++ b/ScoutSuite/output/data/html/partials/azure/services.keyvault.subscriptions.id.vaults.html
@@ -26,7 +26,7 @@
         <ul>
             {{#each keys}}
                 <li class="list-group-item-text">
-                    {{name}} ({{convert_bool_to_enabled enabled}}, Expiration: <span id="keyvault.subscriptions.{{@../../key}}.vaults.{{@../key}}.keys.{{@key}}.expires">{{format_date expires}}</span>)
+                    {{name}} ({{convert_bool_to_enabled enabled}}, Auto Rotation: <span id="keyvault.subscriptions.{{@../../key}}.vaults.{{@../key}}.keys.{{@key}}.auto_rotation_enabled">{{ convert_bool_to_enabled auto_rotation_enabled }}</span>, Expiration: <span id="keyvault.subscriptions.{{@../../key}}.vaults.{{@../key}}.keys.{{@key}}.expires">{{format_date expires}}</span>)
                 </li>
             {{else}}
                 <div style="display: inline-flex;">None</div>

--- a/ScoutSuite/output/data/html/partials/azure/services.keyvault.subscriptions.id.vaults.html
+++ b/ScoutSuite/output/data/html/partials/azure/services.keyvault.subscriptions.id.vaults.html
@@ -21,6 +21,28 @@
         </div>
         <div class="list-group-item-text item-margin">Resource group: <span id="keyvault.subscriptions.{{@../key}}.vaults.{{@key}}.resource_group_name"><samp>{{value_or_none resource_group_name}}</samp></span></div>
     </div>
+    <div class="list-group-item">
+        <h4>Keys</h4>
+        <ul>
+            {{#each keys}}
+                <li class="list-group-item-text">
+                    {{name}} ({{convert_bool_to_enabled enabled}}, Expiration: <span id="keyvault.subscriptions.{{@../../key}}.vaults.{{@../key}}.keys.{{@key}}.expires">{{value_or_none expires}}</span>)
+                </li>
+            {{else}}
+                <div style="display: inline-flex;">None</div>
+            {{/each}}
+        </ul>
+    </div>
+    <div class="list-group-item">
+        <h4>Secrets</h4>
+        <ul>
+            {{#each secrets}}
+                <li class="list-group-item-text">
+                    {{name}} ({{convert_bool_to_enabled enabled}}, Expiration: <span id="keyvault.subscriptions.{{@../../key}}.vaults.{{@../key}}.secrets.{{@key}}.expires">{{value_or_none expires}}</span>)
+                </li>
+            {{/each}}
+        </ul>
+    </div>
 </script>
 
 <script>

--- a/ScoutSuite/output/data/html/partials/azure/services.keyvault.subscriptions.id.vaults.html
+++ b/ScoutSuite/output/data/html/partials/azure/services.keyvault.subscriptions.id.vaults.html
@@ -26,7 +26,7 @@
         <ul>
             {{#each keys}}
                 <li class="list-group-item-text">
-                    {{name}} ({{convert_bool_to_enabled enabled}}, Expiration: <span id="keyvault.subscriptions.{{@../../key}}.vaults.{{@../key}}.keys.{{@key}}.expires">{{value_or_none expires}}</span>)
+                    {{name}} ({{convert_bool_to_enabled enabled}}, Expiration: <span id="keyvault.subscriptions.{{@../../key}}.vaults.{{@../key}}.keys.{{@key}}.expires">{{format_date expires}}</span>)
                 </li>
             {{else}}
                 <div style="display: inline-flex;">None</div>
@@ -38,7 +38,7 @@
         <ul>
             {{#each secrets}}
                 <li class="list-group-item-text">
-                    {{name}} ({{convert_bool_to_enabled enabled}}, Expiration: <span id="keyvault.subscriptions.{{@../../key}}.vaults.{{@../key}}.secrets.{{@key}}.expires">{{value_or_none expires}}</span>)
+                    {{name}} ({{convert_bool_to_enabled enabled}}, Expiration: <span id="keyvault.subscriptions.{{@../../key}}.vaults.{{@../key}}.secrets.{{@key}}.expires">{{format_date expires}}</span>)
                 </li>
             {{/each}}
         </ul>

--- a/ScoutSuite/providers/azure/facade/keyvault.py
+++ b/ScoutSuite/providers/azure/facade/keyvault.py
@@ -33,6 +33,15 @@ class KeyVaultFacade:
             print_exception(f'Failed to retrieve keys from key vault {keyvault_name}: {e}')
             return []
         
+    async def get_key(self, subscription_id: str, resourcegroup_name: str, keyvault_name: str, key_name: str):
+        try:
+            client = self.get_client(subscription_id)
+            return await run_concurrently(
+                lambda: client.keys.get(resource_group_name=resourcegroup_name, vault_name=keyvault_name, key_name=key_name))
+        except Exception as e:
+            print_exception(f'Failed to retrieve key {key_name}: {e}')
+            return None
+        
     async def get_secrets(self, subscription_id: str, resourcegroup_name: str, keyvault_name: str):
         try:
             client = self.get_client(subscription_id)

--- a/ScoutSuite/providers/azure/facade/keyvault.py
+++ b/ScoutSuite/providers/azure/facade/keyvault.py
@@ -23,3 +23,21 @@ class KeyVaultFacade:
         except Exception as e:
             print_exception(f'Failed to retrieve key vaults: {e}')
             return []
+
+    async def get_keys(self, subscription_id: str, resourcegroup_name: str, keyvault_name: str):
+        try:
+            client = self.get_client(subscription_id)
+            return await run_concurrently(
+                lambda: list(client.keys.list(resource_group_name=resourcegroup_name, vault_name=keyvault_name)))
+        except Exception as e:
+            print_exception(f'Failed to retrieve keys from key vault {keyvault_name}: {e}')
+            return []
+        
+    async def get_secrets(self, subscription_id: str, resourcegroup_name: str, keyvault_name: str):
+        try:
+            client = self.get_client(subscription_id)
+            return await run_concurrently(
+                lambda: list(client.secrets.list(resource_group_name=resourcegroup_name, vault_name=keyvault_name)))
+        except Exception as e:
+            print_exception(f'Failed to retrieve secrets from key vault {keyvault_name}: {e}')
+            return []

--- a/ScoutSuite/providers/azure/resources/keyvault/vaults.py
+++ b/ScoutSuite/providers/azure/resources/keyvault/vaults.py
@@ -3,6 +3,7 @@ from ScoutSuite.providers.azure.resources.base import AzureResources
 from ScoutSuite.providers.utils import get_non_provider_id
 from ScoutSuite.providers.azure.utils import get_resource_group_name
 
+from datetime import datetime
 
 class Vaults(AzureResources):
 
@@ -14,6 +15,14 @@ class Vaults(AzureResources):
         for raw_vault in await self.facade.keyvault.get_key_vaults(self.subscription_id):
             id, vault = self._parse_key_vault(raw_vault)
             self[id] = vault
+            vault['keys'] = []
+            for raw_key in await self.facade.keyvault.get_keys(self.subscription_id, vault['resource_group_name'], vault['name']):
+                key = self._parse_key(raw_key)
+                vault['keys'].append(key)
+            vault['secrets'] = []
+            for raw_secret in await self.facade.keyvault.get_secrets(self.subscription_id, vault['resource_group_name'], vault['name']):
+                secret = self._parse_secret(raw_secret)
+                vault['secrets'].append(secret)
 
     def _parse_key_vault(self, raw_vault):
         vault = {}
@@ -31,9 +40,31 @@ class Vaults(AzureResources):
         vault['properties'] = raw_vault.properties
         vault[
             'recovery_protection_enabled'] = raw_vault.properties.enable_soft_delete and \
-                                             raw_vault.properties.enable_purge_protection
+                                             bool(raw_vault.properties.enable_purge_protection)
         vault['public_access_allowed'] = self._is_public_access_allowed(raw_vault)
         return vault['id'], vault
 
     def _is_public_access_allowed(self, raw_vault):
         return raw_vault.properties.network_acls is None
+    
+    def _parse_key(self, raw_key):
+        raw_attrs = raw_key.attributes
+        key = {}
+        key['id'] = get_non_provider_id(raw_key.id)
+        key['name'] = raw_key.name
+        key['enabled'] = raw_attrs.enabled
+        key['expires'] = datetime.fromtimestamp(raw_attrs.expires) if raw_attrs.expires else None
+        key['not_before'] = datetime.fromtimestamp(raw_attrs.not_before) if raw_attrs.not_before else None
+        key['exportable'] = raw_attrs.exportable
+        key['recovery_level'] = raw_attrs.recovery_level
+        return key
+
+    def _parse_secret(self, raw_secret):
+        raw_attrs = raw_secret.properties.attributes
+        secret = {}
+        secret['id'] = get_non_provider_id(raw_secret.id)
+        secret['name'] = raw_secret.name
+        secret['enabled'] = raw_attrs.enabled
+        secret['expires'] = raw_attrs.expires
+        secret['not_before'] = raw_attrs.not_before
+        return secret

--- a/ScoutSuite/providers/azure/resources/keyvault/vaults.py
+++ b/ScoutSuite/providers/azure/resources/keyvault/vaults.py
@@ -3,7 +3,7 @@ from ScoutSuite.providers.azure.resources.base import AzureResources
 from ScoutSuite.providers.utils import get_non_provider_id
 from ScoutSuite.providers.azure.utils import get_resource_group_name
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 class Vaults(AzureResources):
 
@@ -53,8 +53,8 @@ class Vaults(AzureResources):
         key['id'] = get_non_provider_id(raw_key.id)
         key['name'] = raw_key.name
         key['enabled'] = raw_attrs.enabled
-        key['expires'] = datetime.fromtimestamp(raw_attrs.expires) if raw_attrs.expires else None
-        key['not_before'] = datetime.fromtimestamp(raw_attrs.not_before) if raw_attrs.not_before else None
+        key['expires'] = datetime.fromtimestamp(raw_attrs.expires, tz=timezone.utc) if raw_attrs.expires else None
+        key['not_before'] = datetime.fromtimestamp(raw_attrs.not_before, tz=timezone.utc) if raw_attrs.not_before else None
         key['exportable'] = raw_attrs.exportable
         key['recovery_level'] = raw_attrs.recovery_level
         return key

--- a/ScoutSuite/providers/azure/resources/keyvault/vaults.py
+++ b/ScoutSuite/providers/azure/resources/keyvault/vaults.py
@@ -11,8 +11,8 @@ class Vaults(AzureResources):
     def __init__(self, facade: AzureFacade, subscription_id: str):
         super().__init__(facade)
         self.subscription_id = subscription_id
-        # Hardcoded limit of 5 keys per key vault.
-        self.KEY_FETCH_LIMIT = 5
+        # Hardcoded limit of keys per key vault.
+        self.KEY_FETCH_LIMIT = 3
         self.keys_detailed_fetched = 0
 
     async def fetch_all(self):

--- a/ScoutSuite/providers/azure/rules/findings/keyvault-key-auto-rotation-disabled.json
+++ b/ScoutSuite/providers/azure/rules/findings/keyvault-key-auto-rotation-disabled.json
@@ -5,7 +5,7 @@
     "compliance": [
         {
             "name": "CIS Microsoft Azure Foundations",
-            "version": "1.2.0",
+            "version": "2.0.0",
             "reference": "8.8"
         }
     ],

--- a/ScoutSuite/providers/azure/rules/findings/keyvault-key-auto-rotation-disabled.json
+++ b/ScoutSuite/providers/azure/rules/findings/keyvault-key-auto-rotation-disabled.json
@@ -1,0 +1,34 @@
+{
+    "description": "Automatic Key Rotation Disabled",
+    "rationale": "Cryptographic best practices discourage extensive reuse of encryption keys. Consequently, Customer Master Keys (CMKs) should be rotated Once set up, Automatic Private Key Rotation removes the need for manual administration when keys expire at intervals determined by your organization's policy.",
+    "remediation": "In the Azure console:<ol><li>Go to <samp>Key Vaults</samp></li> <li>For each key vault, go to <samp>Keys</samp>.</li> <li>For each enabled keys, click on the key to visit the Versions view.</li> <li>In the top row, click on <samp>Rotation policy</samp>.</li> <li>Ensure that <samp>Enable auto rotation</samp> is set to <samp>Enabled</samp>.</li></ol>",
+    "compliance": [
+        {
+            "name": "CIS Microsoft Azure Foundations",
+            "version": "1.2.0",
+            "reference": "8.8"
+        }
+    ],
+    "references": [
+        "https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys",
+        "https://learn.microsoft.com/en-us/azure/key-vault/policy-reference",
+        "https://learn.microsoft.com/en-us/security/benchmark/azure/security-controls-v3-data-protection#dp-6-use-a-secure-key-management-process"
+    ],
+    "dashboard_name": "Keys",
+    "display_path": "keyvault.subscriptions.id.vaults.id",
+    "path": "keyvault.subscriptions.id.vaults.id.keys.id",
+    "conditions": [
+        "and",
+        [
+            "keyvault.subscriptions.id.vaults.id.keys.id.enabled",
+            "true",
+            ""
+        ],
+        [
+            "keyvault.subscriptions.id.vaults.id.keys.id.auto_rotation_enabled",
+            "false",
+            ""
+        ]
+    ],
+    "id_suffix": "auto_rotation_enabled"
+}

--- a/ScoutSuite/providers/azure/rules/findings/keyvault-key-no-expiration.json
+++ b/ScoutSuite/providers/azure/rules/findings/keyvault-key-no-expiration.json
@@ -5,12 +5,12 @@
     "compliance": [
         {
             "name": "CIS Microsoft Azure Foundations",
-            "version": "1.2.0",
+            "version": "2.0.0",
             "reference": "8.1"
         },
         {
             "name": "CIS Microsoft Azure Foundations",
-            "version": "1.2.0",
+            "version": "2.0.0",
             "reference": "8.2"
         }
     ],

--- a/ScoutSuite/providers/azure/rules/findings/keyvault-key-no-expiration.json
+++ b/ScoutSuite/providers/azure/rules/findings/keyvault-key-no-expiration.json
@@ -1,0 +1,39 @@
+{
+    "description": "Key Expiration Disabled",
+    "rationale": "Key expiration is disabled. As a result, compromised keys could be used by potential attackers for a indefinite amount of time. Periodic key rotation enforced with an appropriate key expiration policy could help to mitigate this issue.",
+    "remediation": "In the Azure console:<ol><li>Go to <samp>Key Vaults</samp></li> <li>For each key vault, go to <samp>Keys</samp></li> <li>For all enabled keys, ensure that an appropriate <samp>Expiration date</samp> is set</li></ol>",
+    "compliance": [
+        {
+            "name": "CIS Microsoft Azure Foundations",
+            "version": "1.2.0",
+            "reference": "8.1"
+        },
+        {
+            "name": "CIS Microsoft Azure Foundations",
+            "version": "1.2.0",
+            "reference": "8.2"
+        }
+    ],
+    "references": [
+        "https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys",
+        "https://learn.microsoft.com/en-us/azure/key-vault/policy-reference",
+        "https://learn.microsoft.com/en-us/security/benchmark/azure/security-controls-v3-data-protection#dp-6-use-a-secure-key-management-process"
+    ],
+    "dashboard_name": "Keys",
+    "display_path": "keyvault.subscriptions.id.vaults.id",
+    "path": "keyvault.subscriptions.id.vaults.id.keys.id",
+    "conditions": [
+        "and",
+        [
+            "keyvault.subscriptions.id.vaults.id.keys.id.enabled",
+            "true",
+            ""
+        ],
+        [
+            "keyvault.subscriptions.id.vaults.id.keys.id.expires",
+            "equal",
+            "None"
+        ]
+    ],
+    "id_suffix": "expires"
+}

--- a/ScoutSuite/providers/azure/rules/findings/keyvault-secret-no-expiration.json
+++ b/ScoutSuite/providers/azure/rules/findings/keyvault-secret-no-expiration.json
@@ -5,12 +5,12 @@
     "compliance": [
         {
             "name": "CIS Microsoft Azure Foundations",
-            "version": "1.2.0",
+            "version": "2.0.0",
             "reference": "8.3"
         },
         {
             "name": "CIS Microsoft Azure Foundations",
-            "version": "1.2.0",
+            "version": "2.0.0",
             "reference": "8.4"
         }
     ],

--- a/ScoutSuite/providers/azure/rules/findings/keyvault-secret-no-expiration.json
+++ b/ScoutSuite/providers/azure/rules/findings/keyvault-secret-no-expiration.json
@@ -1,0 +1,39 @@
+{
+    "description": "Secret Expiration Disabled",
+    "rationale": "Secret expiration is disabled. As a result, compromised secrets could be used by potential attackers for a indefinite amount of time. Periodic secret rotation enforced with an appropriate secret expiration policy could help to mitigate this issue.",
+    "remediation": "In the Azure console:<ol><li>Go to <samp>Key Vaults</samp></li> <li>For each key vault, go to <samp>Secrets</samp></li> <li>For all enabled secrets, ensure that an appropriate <samp>Expiration date</samp> is set</li></ol>",
+    "compliance": [
+        {
+            "name": "CIS Microsoft Azure Foundations",
+            "version": "1.2.0",
+            "reference": "8.3"
+        },
+        {
+            "name": "CIS Microsoft Azure Foundations",
+            "version": "1.2.0",
+            "reference": "8.4"
+        }
+    ],
+    "references": [
+        "https://learn.microsoft.com/en-us/azure/key-vault/secrets/about-secrets",
+        "https://learn.microsoft.com/en-us/azure/key-vault/policy-reference",
+        "https://learn.microsoft.com/en-us/security/benchmark/azure/security-controls-v3-data-protection#dp-6-use-a-secure-key-management-process"
+    ],
+    "dashboard_name": "Secrets",
+    "display_path": "keyvault.subscriptions.id.vaults.id",
+    "path": "keyvault.subscriptions.id.vaults.id.secrets.id",
+    "conditions": [
+        "and",
+        [
+            "keyvault.subscriptions.id.vaults.id.secrets.id.enabled",
+            "true",
+            ""
+        ],
+        [
+            "keyvault.subscriptions.id.vaults.id.secrets.id.expires",
+            "equal",
+            "None"
+        ]
+    ],
+    "id_suffix": "expires"
+}

--- a/ScoutSuite/providers/azure/rules/rulesets/cis-1.2.0.json
+++ b/ScoutSuite/providers/azure/rules/rulesets/cis-1.2.0.json
@@ -111,7 +111,19 @@
                 "level": "warning"
             }
         ],
+        "keyvault-key-no-expiration.json": [
+            {
+                "enabled": true,
+                "level": "warning"
+            }
+        ],
         "keyvault-not-recoverable.json": [
+            {
+                "enabled": true,
+                "level": "warning"
+            }
+        ],
+        "keyvault-secret-no-expiration.json": [
             {
                 "enabled": true,
                 "level": "warning"

--- a/ScoutSuite/providers/azure/rules/rulesets/cis-1.2.0.json
+++ b/ScoutSuite/providers/azure/rules/rulesets/cis-1.2.0.json
@@ -111,6 +111,12 @@
                 "level": "warning"
             }
         ],
+        "keyvault-key-auto-rotation-disabled.json": [
+            {
+                "enabled": true,
+                "level": "warning"
+            }
+        ],
         "keyvault-key-no-expiration.json": [
             {
                 "enabled": true,

--- a/ScoutSuite/providers/azure/rules/rulesets/cis-1.2.0.json
+++ b/ScoutSuite/providers/azure/rules/rulesets/cis-1.2.0.json
@@ -111,12 +111,6 @@
                 "level": "warning"
             }
         ],
-        "keyvault-key-auto-rotation-disabled.json": [
-            {
-                "enabled": true,
-                "level": "warning"
-            }
-        ],
         "keyvault-key-no-expiration.json": [
             {
                 "enabled": true,

--- a/ScoutSuite/providers/azure/rules/rulesets/default.json
+++ b/ScoutSuite/providers/azure/rules/rulesets/default.json
@@ -85,7 +85,19 @@
                 "level": "warning"
             }
         ],
+        "keyvault-key-no-expiration.json": [
+            {
+                "enabled": true,
+                "level": "warning"
+            }
+        ],
         "keyvault-not-recoverable.json": [
+            {
+                "enabled": true,
+                "level": "warning"
+            }
+        ],
+        "keyvault-secret-no-expiration.json": [
             {
                 "enabled": true,
                 "level": "warning"

--- a/ScoutSuite/providers/azure/rules/rulesets/default.json
+++ b/ScoutSuite/providers/azure/rules/rulesets/default.json
@@ -85,6 +85,12 @@
                 "level": "warning"
             }
         ],
+        "keyvault-key-auto-rotation-disabled.json": [
+            {
+                "enabled": true,
+                "level": "warning"
+            }
+        ],
         "keyvault-key-no-expiration.json": [
             {
                 "enabled": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ azure-mgmt-storage==16.0.0
 azure-mgmt-monitor==2.0.0
 azure-mgmt-sql==1.0.0
 azure-mgmt-security==1.0.0
-azure-mgmt-keyvault==8.0.0
+azure-mgmt-keyvault==10.2.2
 azure-mgmt-network==17.1.0
 azure-mgmt-redis==12.0.0
 azure-mgmt-web==1.0.0


### PR DESCRIPTION
# Description

New rules to measure compliance against several Key Vault recommendations in CIS Azure Foundations Benchmark v2.0.0:

- 8.1/8.2 (Key Expiration Disabled) same rule to check for both recommendations
- 8.3/8.4 (Secret Expiration Disabled) same rule to check for both recommendations
- 8.8 (Automatic Key Rotation Disabled)

The latter rule requires a separate API request to retrieve details of each specific key. Because, for subscriptions with large numbers of keys, this could greatly increase the time required to run the tool, it currently limits the check to 3 enabled keys per vault. This sampling-based approach requires more nuance -- for subscriptions containing few keys, ScoutSuite should just check them all, while for subscriptions containing larger numbers of keys, the user should be able to control how many / which keys are checked, according to their specific requirements. I will raise a separate Issue to discuss this and propose an approach which could be applied to other rules as well.

Additional notes:
- Upgrade of `azure-mgmt-keyvault` dependency is required to support required API requests which were not present in the older version.

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works (optional)
- [X] New and existing unit tests pass locally with my changes
