### PR TITLE
Fixed incompatible packages - Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,10 @@ google-cloud-container>=2.1.0
 google-cloud-core>=0.29.1
 google-cloud-iam>=0.1.0
 google-cloud-logging>=2.2.0
-google-cloud-monitoring==1.1.0
+google-cloud-monitoring==1.1.1
 google-cloud-resource-manager>=0.28.3
 google-cloud-storage>=1.13.2
-google-cloud-kms==1.3.0
+google-cloud-kms==1.4.1
 ## API Client Libraries
 google-api-python-client>=2.47.0
 oauth2client>=4.1.3


### PR DESCRIPTION
# Description

I got this error running python. I incremented each version on starting with ```google-cloud-monitoring``` then with ```google-cloud-kms``` until I did not get error. It then was able to install version: 5.13.0 successfully from releases with my modified requests.txt. 

Enviroment: ```Running python 3.10 base from mini conda env.```

Command: ```python setup.py build && python setup.py install```
Error: ```setup.py install error: google-api-core 2.14.0 is installed but google-api-core[grpc]<2.0.0dev,>=1.14.0 is required by {'google-cloud-monitoring', 'google-cloud-kms'}``` 

Fixes # (issue)

- Changed ```google-cloud-monitoring==1.1.0``` to version ```google-cloud-monitoring==1.1.1```
- Changed ```google-cloud-kms 1.3.0``` to version ```google-cloud-kms==1.4.1```


Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue) I have not come across any broken features since the change.
