### PR TITLE
Fixes 'Key Vault Not Recoverable' check

### DIFF
--- a/ScoutSuite/providers/azure/resources/keyvault/vaults.py
+++ b/ScoutSuite/providers/azure/resources/keyvault/vaults.py
@@ -30,7 +30,7 @@ class Vaults(AzureResources):
         vault['resource_group_name'] = get_resource_group_name(raw_vault.id)
         vault['properties'] = raw_vault.properties
         vault[
-            'recovery_protection_enabled'] = raw_vault.properties.enable_soft_delete and \
+            'recovery_protection_enabled'] = bool(raw_vault.properties.enable_soft_delete) and \
                                              bool(raw_vault.properties.enable_purge_protection)
         vault['public_access_allowed'] = self._is_public_access_allowed(raw_vault)
         vault['rbac_authorization_enabled'] = raw_vault.properties.enable_rbac_authorization


### PR DESCRIPTION
# Description

ScoutSuite *incorrectly did not* flag key vaults for which the API returned `enable_soft_delete = null`. Such key vaults have neither soft-delete nor purge protection enabled and are also not recoverable. The check would only flag key vaults with `enable_soft_delete = false`

Fixes #1606 

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
