### PR TITLE
Fixes 'Key Vault Role Based Access Control Disabled' check

### DIFF
--- a/ScoutSuite/providers/azure/resources/keyvault/vaults.py
+++ b/ScoutSuite/providers/azure/resources/keyvault/vaults.py
@@ -33,7 +33,7 @@ class Vaults(AzureResources):
             'recovery_protection_enabled'] = raw_vault.properties.enable_soft_delete and \
                                              bool(raw_vault.properties.enable_purge_protection)
         vault['public_access_allowed'] = self._is_public_access_allowed(raw_vault)
-        vault['rbac_authorization_enabled'] = raw_vault.properties.enable_rbac_authorization
+        vault['rbac_authorization_enabled'] = bool(raw_vault.properties.enable_rbac_authorization)
         return vault['id'], vault
 
     def _is_public_access_allowed(self, raw_vault):


### PR DESCRIPTION
# Description

ScoutSuite failed to flag key vaults where the `enable_rbac_authorization field` was set to `null`. Through manual configuration in the Azure portal I confirmed that RBAC Access Control is disabled if this field is set to `null`.

Fixes #1607 

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
