### PR TITLE
Corrected display name for 'Blob Containers Allowing Public Access'

### DIFF
--- a/ScoutSuite/providers/azure/rules/findings/storageaccount-public-blob-container.json
+++ b/ScoutSuite/providers/azure/rules/findings/storageaccount-public-blob-container.json
@@ -18,7 +18,7 @@
         "https://learn.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources",
         "https://learn.microsoft.com/en-us/azure/security/benchmarks/security-controls-v2-privileged-access"
     ],
-    "dashboard_name": "Storage Accounts",
+    "dashboard_name": "Blob Containers",
     "display_path": "storageaccounts.subscriptions.id.storage_accounts.id",
     "path": "storageaccounts.subscriptions.id.storage_accounts.id.blob_containers.id",
     "conditions": [


### PR DESCRIPTION
# Description

This commit changes the UI description for the Azure rule 'Blob Containers Allowing Public Access'. The UI incorrectly specified that the rule scans Storage Accounts, while it actually scans 'Blob Containers'. Since there are potentially more Blob Containers than Storage Accounts, the reported statistics are incorrect.

Fixes #1608 

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
