### PR TITLE
Improves 'Access Keys Not Rotated' check

### DIFF
--- a/ScoutSuite/output/data/html/partials/azure/services.storageaccounts.subscriptions.id.storage_accounts.html
+++ b/ScoutSuite/output/data/html/partials/azure/services.storageaccounts.subscriptions.id.storage_accounts.html
@@ -10,6 +10,7 @@
         <div class="list-group-item-text item-margin">Public Traffic: <span id="storageaccounts.subscriptions.{{@../key}}.storage_accounts.{{@key}}.public_traffic_allowed">{{convert_bool_to_enabled public_traffic_allowed }}</span></div>
         <div class="list-group-item-text item-margin">HTTPS Required: <span id="storageaccounts.subscriptions.{{@../key}}.storage_accounts.{{@key}}.https_traffic_enabled">{{convert_bool_to_enabled https_traffic_enabled}}</span></div>
         <div class="list-group-item-text item-margin">Microsoft Trusted Services: <span id="storageaccounts.subscriptions.{{@../key}}.storage_accounts.{{@key}}.trusted_microsoft_services_enabled">{{convert_bool_to_enabled trusted_microsoft_services_enabled }}</span></div>
+        <div class="list-group-item-text item-margin">Access Key Usage: <span id="storageaccounts.subscriptions.{{@../key}}.storage_accounts.{{@key}}.shared_key_access_allowed">{{convert_bool_to_enabled shared_key_access_allowed}}</span></div>
         <div class="list-group-item-text item-margin">Last Access Key Rotation:
             <span id="storageaccounts.subscriptions.{{@../key}}.storage_accounts.{{@key}}.access_keys_rotated">
                 {{#if access_keys_last_rotation_date }}

--- a/ScoutSuite/providers/azure/resources/storageaccounts/storage_accounts.py
+++ b/ScoutSuite/providers/azure/resources/storageaccounts/storage_accounts.py
@@ -45,6 +45,8 @@ class StorageAccounts(AzureCompositeResources):
         storage_account['trusted_microsoft_services_enabled'] = \
             self._is_trusted_microsoft_services_enabled(raw_storage_account)
         storage_account['bypass'] = raw_storage_account.network_rule_set.bypass
+        # The default value (null) is equivalent to True
+        storage_account['shared_key_access_allowed'] = raw_storage_account.allow_shared_key_access != False
         storage_account['access_keys_last_rotation_date'] = \
             self._parse_access_keys_last_rotation_date(raw_storage_account.activity_logs)
         storage_account['encryption_key_source'] = raw_storage_account.encryption.key_source

--- a/ScoutSuite/providers/azure/rules/findings/storageaccount-access-keys-not-rotated.json
+++ b/ScoutSuite/providers/azure/rules/findings/storageaccount-access-keys-not-rotated.json
@@ -21,18 +21,26 @@
     "dashboard_name": "Storage Accounts",
     "path": "storageaccounts.subscriptions.id.storage_accounts.id",
     "conditions": [
-        "or",
+        "and",
         [
-            "storageaccounts.subscriptions.id.storage_accounts.id.access_keys_last_rotation_date",
-            "equal",
-            "None"
+            "storageaccounts.subscriptions.id.storage_accounts.id.shared_key_access_allowed",
+            "true",
+            ""
         ],
         [
-            "storageaccounts.subscriptions.id.storage_accounts.id.access_keys_last_rotation_date",
-            "olderThan",
+            "or",
             [
-                "_ARG_0_",
-                "days"
+                "storageaccounts.subscriptions.id.storage_accounts.id.access_keys_last_rotation_date",
+                "equal",
+                "None"
+            ],
+            [
+                "storageaccounts.subscriptions.id.storage_accounts.id.access_keys_last_rotation_date",
+                "olderThan",
+                [
+                    "_ARG_0_",
+                    "days"
+                ]
             ]
         ]
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ azure-identity==1.5.0
 ## for resources
 
 azure-mgmt-resource==15.0.0
-azure-mgmt-storage==16.0.0
+azure-mgmt-storage==17.0.0
 azure-mgmt-monitor==2.0.0
 azure-mgmt-sql==1.0.0
 azure-mgmt-security==1.0.0


### PR DESCRIPTION
# Description

- Updates `azure-mgmt-storage` dependency to `17.0.0`. Needed because the version currently used in ScoutSuite does not support checking if a storage account support access keys or not.
- **Only consider storage accounts that allow access key access in the 'Access Keys Not Rotated' Azure rule**
- Display the access key status in the UI

Fixes #1609 

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
