### PR TITLE
Improves iam-user-no-key-rotation rule

### DIFF
--- a/ScoutSuite/providers/aws/rules/findings/iam-user-no-key-rotation.json
+++ b/ScoutSuite/providers/aws/rules/findings/iam-user-no-key-rotation.json
@@ -1,5 +1,5 @@
 {
-    "description": "Lack of Key Rotation for (_ARG_0_) Days",
+    "description": "Lack of Key Rotation for _ARG_1_ Days (Key Status: _ARG_0_)",
     "rationale": "In case of access key compromise, the lack of credential rotation increases the period during which an attacker has access to the AWS account.",
     "remediation": "Rotate access keys that have not been changed recently",
     "compliance": [


### PR DESCRIPTION
# Description

The current name for the AWS rule `"Lack of Key Rotation for (_ARG_0_) Days"` is unclear.

## Current behavior

The current code produces results such as:

![Screenshot 2024-04-16 at 10 47 00](https://github.com/rieck-srlabs/ScoutSuite/assets/135810953/1c6bcd0b-2651-4a05-baa0-0cf34aff6fdd)

## New

With this code change, the rule now includes the number of days _and_ the access key status:

![Screenshot 2024-04-16 at 10 56 14](https://github.com/nccgroup/ScoutSuite/assets/135810953/a7997e3a-5806-4cb3-bf22-a4bcb90dd9a6)

Fixes #1626 

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
