### PR TITLE
Adds highlighting for "EBS Volume Not Encrypted" detail view

### DIFF
--- a/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.volumes.html
+++ b/ScoutSuite/output/data/html/partials/aws/services.ec2.regions.id.volumes.html
@@ -4,8 +4,15 @@
         <h4 class="list-group-item-heading">{{name}}</h4>
     </div>
     <div class="list-group-item">
-        <h4 class="list-group-item-heading">Attributes</h4>
-        {{> generic_object this}}
+        <h4 class="list-group-item-heading">Information</h4>
+        <div class="list-group-item-text item-margin">ID: <span id="ec2.regions.{{region}}.volumes.{{@key}}.id"><samp>{{value_or_none id}}</samp></span></div>
+        <div class="list-group-item-text item-margin">ARN: <span id="ec2.regions.{{region}}.volumes.{{@key}}.arn"><samp>{{value_or_none arn}}</samp></span></div>
+        <div class="list-group-item-text item-margin">Name: <span id="ec2.regions.{{region}}.volumes.{{@key}}.name"><samp>{{value_or_none name}}</samp></span></div>
+        <div class="list-group-item-text item-margin">State: <span id="ec2.regions.{{region}}.volumes.{{@key}}.state"><samp>{{value_or_none State}}</samp></span></div>
+        <div class="list-group-item-text item-margin">Size: <span id="ec2.regions.{{region}}.volumes.{{@key}}.size"><samp>{{value_or_none Size}} GiB</samp></span></div>
+        <div class="list-group-item-text item-margin">Volume Type: <span id="ec2.regions.{{region}}.volumes.{{@key}}.volume_type"><samp>{{value_or_none VolumeType}}</samp></span></div>
+        <div class="list-group-item-text item-margin">Create Time: <span id="ec2.regions.{{region}}.volumes.{{@key}}.create_time"><samp>{{value_or_none CreateTime}}</samp></span></div>
+        <div class="list-group-item-text item-margin">Encryption: <span id="ec2.regions.{{region}}.volumes.{{@key}}.encrypted">{{convert_bool_to_enabled Encrypted}}</span></div>
     </div>
 </script>
 

--- a/ScoutSuite/providers/aws/rules/findings/ec2-ebs-volume-not-encrypted.json
+++ b/ScoutSuite/providers/aws/rules/findings/ec2-ebs-volume-not-encrypted.json
@@ -13,5 +13,6 @@
             "false",
             ""
         ]
-    ]
+    ],
+    "id_suffix": "encrypted"
 }


### PR DESCRIPTION
# Description

Highlights missing encryption for EBS volumes visually in ScoutSuite's detail view:

<img width="1176" alt="Screenshot 2024-04-17 at 09 54 52" src="https://github.com/nccgroup/ScoutSuite/assets/135810953/ef12294c-3567-47e1-adaf-16c8712d9467">

Previously, the detail view dumped the full JSON object for EBS volumes and did not highlight the (missing) encryption visually (see issue #1628).

Addresses #1628 

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
