### PR TITLE
feature/1641 - Add date to the report file name and at the top of the HTML title

### DIFF
--- a/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
+++ b/ScoutSuite/output/data/inc-scoutsuite/scoutsuite.js
@@ -128,9 +128,10 @@ function getPathArray() {
  * Display the account ID -- use of the generic function + templates result in the div not being at the top of the page
  */
 var loadAccountId = function () {
+    const currentDate = new Date().toUTCString();
     var element = document.getElementById('account_id')
     var value = '<i class="fa fa-cloud"></i> ' + runResults['provider_name'] +
-        ' <i class="fa fa-chevron-right"></i> ' + runResults['account_id']
+        ' <i class="fa fa-chevron-right"></i> ' + runResults['account_id'] + ` (Report date: ${currentDate})`
     if (('organization' in runResults) && (value in runResults['organization'])) {
         value += ' (' + runResults['organization'][value]['Name'] + ')'
     }

--- a/ScoutSuite/providers/aws/provider.py
+++ b/ScoutSuite/providers/aws/provider.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import datetime
 
 from ScoutSuite.core.console import print_error, print_exception, print_warning, print_debug
 from ScoutSuite.providers.aws.services import AWSServicesConfig
@@ -8,7 +9,6 @@ from ScoutSuite.providers.aws.utils import ec2_classic, get_aws_account_id, get_
 from ScoutSuite.providers.base.configs.browser import combine_paths, get_object_at, get_value_at
 from ScoutSuite.providers.base.provider import BaseProvider
 from ScoutSuite.utils import manage_dictionary
-
 
 class AWSProvider(BaseProvider):
     """
@@ -46,10 +46,14 @@ class AWSProvider(BaseProvider):
         """
         Returns the name of the report using the provider's configuration
         """
+
+        x = datetime.datetime.now()
+        
+        current_date_time = f"{x.year}-{x.month}-{x.day}-{x.hour}-{x.minute}"
         if self.profile:
-            return f'aws-{self.profile}'
+            return f'aws-{self.profile}-{current_date_time}'
         elif self.account_id:
-            return f'aws-{self.account_id}'
+            return f'aws-{self.account_id}-{current_date_time}'
         else:
             return 'aws'
 


### PR DESCRIPTION
# Description

Fixes #1641 

Added the current date when Scout is run to the report file name, this way we get multiple reports instead of trying to override a report that was already ran:

![image](https://github.com/nccgroup/ScoutSuite/assets/44711170/99722254-8e03-4b90-aea3-1ccd2e5b4dd2)


Added the current date (UTC) when Scout is run to the right side of the "Provider Name - Account ID" section in the html report, for example:

![image](https://github.com/nccgroup/ScoutSuite/assets/44711170/0a3bb768-a04b-4342-9b95-41de8c92c39b)


**Make sure to set the corresponding milestone in the PR.**

Please include a summary of the change(s) and which issue(s) it addresses. Please also include relevant motivation and context.

## Type of change

Select the relevant option(s):

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
