### PR TITLE
Fix case sensitivity issue in ActivityLogAlerts (Azure region name)

### DIFF
--- a/ScoutSuite/providers/azure/resources/loggingmonitoring/activity_log_alerts.py
+++ b/ScoutSuite/providers/azure/resources/loggingmonitoring/activity_log_alerts.py
@@ -43,7 +43,7 @@ class ActivityLogAlerts(AzureResources):
 
     def ensure_alert_exist(self, log_alerts, equals_value: str):
         for log_alert in log_alerts:
-            if log_alert.location == 'Global' and log_alert.enabled:
+            if log_alert.location.lower() == 'global' and log_alert.enabled:
                 if '/subscriptions/' + self.subscription_id in log_alert.scopes:
                     for condition in log_alert.condition.all_of:
                         if condition.field == 'operationName' and condition.equals == equals_value:


### PR DESCRIPTION
# Description

Azure region names are case insensitive (i.e. `global`, not `Global`). This is different for display names, but they are not used here.

This PR fixes the condition `log_alert.location == 'Global'` and additionally makes case insensitive.

Fixes #1644

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
