### PR TITLE
fixed possible FPs for some GCP instances checks when 'true' is capitalized

### DIFF
--- a/ScoutSuite/providers/gcp/resources/gce/instances.py
+++ b/ScoutSuite/providers/gcp/resources/gce/instances.py
@@ -65,16 +65,28 @@ class Instances(GCPCompositeResources):
         return description if description else 'N/A'
 
     def _is_block_project_ssh_keys_enabled(self, raw_instance):
-        return raw_instance['metadata'].get('block-project-ssh-keys') == 'true'
+        try:
+            return raw_instance['metadata'].get('block-project-ssh-keys').lower() == 'true'
+        except:
+            pass
 
     def _is_oslogin_enabled(self, raw_instance):
         instance_logging_enabled = raw_instance['metadata'].get('enable-oslogin')
         project_logging_enabled = raw_instance['commonInstanceMetadata'].get('enable-oslogin')
-        return instance_logging_enabled == 'TRUE' \
-               or instance_logging_enabled is None and project_logging_enabled == 'TRUE'
+        try:
+            return instance_logging_enabled.upper() == 'TRUE'
+        except:
+            pass
+        try:
+            return instance_logging_enabled is None and project_logging_enabled.upper() == 'TRUE'
+        except:
+            pass
 
     def _is_serial_port_enabled(self, raw_instance):
-        return raw_instance['metadata'].get('serial-port-enable') == 'true'
+        try:
+            return raw_instance['metadata'].get('serial-port-enable').lower() == 'true'
+        except:
+            pass
 
     def _is_default_service_account(self, service_account: str):
         if '-compute@developer.gserviceaccount.com' in service_account:


### PR DESCRIPTION
# Description

**Make sure the PR is against the `develop` branch (see [Contributing](https://github.com/nccgroup/ScoutSuite/blob/master/CONTRIBUTING.md)).**

**Make sure to set the corresponding milestone in the PR.**
Sorry, I am not sure what this is...

During a GCP assessment, I noticed that SS was reporting some false positives for "block project-wide ssh keys".
I identified the problem in the fact that in the GCP project, some values were reported in capital "TRUE", while SS only checks for "true". Code fixed to handle both cases, also for "OS login enabled" and "serial port enabled", just in case.

Fixes # (issue)
I don't think there is an open issue for this.

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
