### PR TITLE
Fix false-positive in acm-certificate-with-transparency-logging-disabled

### DIFF
--- a/ScoutSuite/providers/aws/rules/findings/acm-certificate-with-transparency-logging-disabled.json
+++ b/ScoutSuite/providers/aws/rules/findings/acm-certificate-with-transparency-logging-disabled.json
@@ -12,6 +12,11 @@
             "acm.regions.id.certificates.id.Options.CertificateTransparencyLoggingPreference",
             "equal",
             "DISABLED"
+        ],
+        [
+            "acm.regions.id.certificates.id.Type",
+            "notEqual",
+            "IMPORTED"
         ]
     ],
     "id_suffix": "CertificateTransparencyLoggingPreference"


### PR DESCRIPTION
Fix false-positive in acm-certificate-with-transparency-logging-disabled As called out in issue 1519, certificate transparency logs are irrelevant for certificates that were imported into ACM because transparency logs should be published by the certificate issuer and AWS didn't issue the certificates (as evidenced by the fact that they are marked as "IMPORTED".

This prevents a lack of transparency logging on certificates that were imported into AWS, which was causing a false-positive before this fix.

# Description

Fixes 1519

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes
