### PR TITLE
Fix false positive root MFA when org centralized root access is enabled

### DIFF
--- a/ScoutSuite/providers/aws/facade/iam.py
+++ b/ScoutSuite/providers/aws/facade/iam.py
@@ -67,8 +67,9 @@ class IAMFacade(AWSBaseFacade):
             response = await run_concurrently(client.list_organizations_features)
             enabled_features = response.get('EnabledFeatures', [])
             return 'RootCredentialsManagement' in enabled_features
-        except Exception:
+        except Exception as e:
             # Expected to fail when not in an org or lacking iam:ListOrganizationsFeatures permission
+            print_warning(f'Could not check Organizations root credentials management: {e}')
             return False
 
     async def get_groups(self):

--- a/ScoutSuite/providers/aws/facade/iam.py
+++ b/ScoutSuite/providers/aws/facade/iam.py
@@ -56,6 +56,21 @@ class IAMFacade(AWSBaseFacade):
                 print_exception(f'Failed to download credential report: {e}')
             return []
 
+    async def get_organizations_root_credentials_managed(self):
+        """
+        Check if centralized root access management is enabled for the organization.
+        Returns True if RootCredentialsManagement is among the enabled features.
+        Returns False if the API call fails (e.g. not in an org, insufficient permissions).
+        """
+        client = AWSFacadeUtils.get_client('iam', self.session)
+        try:
+            response = await run_concurrently(client.list_organizations_features)
+            enabled_features = response.get('EnabledFeatures', [])
+            return 'RootCredentialsManagement' in enabled_features
+        except Exception:
+            # Expected to fail when not in an org or lacking iam:ListOrganizationsFeatures permission
+            return False
+
     async def get_groups(self):
         groups = await AWSFacadeUtils.get_all_pages('iam', None, self.session, 'list_groups', 'Groups')
         await get_and_set_concurrently(
@@ -270,4 +285,3 @@ class IAMFacade(AWSBaseFacade):
             statement[resource_string] = [statement[resource_string]]
         # Result
         return statement
-

--- a/ScoutSuite/providers/aws/resources/iam/credentialreports.py
+++ b/ScoutSuite/providers/aws/resources/iam/credentialreports.py
@@ -6,6 +6,14 @@ from ScoutSuite.core.console import print_exception
 class CredentialReports(AWSResources):
     async def fetch_all(self):
         raw_credential_reports = await self.facade.iam.get_credential_reports()
+
+        # Check if centralized root access management is enabled for this org.
+        # When enabled, root credentials can be removed from member accounts,
+        # making MFA checks irrelevant for those accounts.
+        self._root_credentials_managed_centrally = (
+            await self.facade.iam.get_organizations_root_credentials_managed()
+        )
+
         for raw_credential_report in raw_credential_reports:
             name, resource = await self._parse_credential_reports(raw_credential_report)
             self[name] = resource
@@ -30,6 +38,14 @@ class CredentialReports(AWSResources):
         raw_credential_report['last_used'] = self._compute_last_used(raw_credential_report)
         raw_credential_report['cert_1_active'] = raw_credential_report['cert_1_active']
         raw_credential_report['cert_2_active'] = raw_credential_report['cert_2_active']
+
+        # Flag root accounts where credentials are centrally managed via
+        # AWS Organizations. When root credentials have been removed, MFA
+        # cannot and need not be configured, so MFA findings should be skipped.
+        raw_credential_report['root_credentials_managed_centrally'] = (
+            raw_credential_report['name'] == '<root_account>'
+            and self._root_credentials_managed_centrally
+        )
 
         if raw_credential_report['mfa_active'] == 'true':
             raw_credential_report['mfa_active_hardware'] = await \

--- a/ScoutSuite/providers/aws/rules/findings/iam-root-account-no-hardware-mfa.json
+++ b/ScoutSuite/providers/aws/rules/findings/iam-root-account-no-hardware-mfa.json
@@ -49,6 +49,11 @@
             "iam.credential_reports.id.partition",
             "notEqual",
             "aws-us-gov"
+        ],
+        [
+            "iam.credential_reports.id.root_credentials_managed_centrally",
+            "notTrue",
+            ""
         ]
     ],
     "keys": [

--- a/ScoutSuite/providers/aws/rules/findings/iam-root-account-no-mfa.json
+++ b/ScoutSuite/providers/aws/rules/findings/iam-root-account-no-mfa.json
@@ -36,6 +36,11 @@
             "iam.credential_reports.id.partition",
             "notEqual",
             "aws-us-gov"
+        ],
+        [
+            "iam.credential_reports.id.root_credentials_managed_centrally",
+            "notTrue",
+            ""
         ]
     ],
     "keys": [

--- a/tests/data/rule-configs/iam-root.json
+++ b/tests/data/rule-configs/iam-root.json
@@ -28,7 +28,8 @@
                     "password_last_used": null,
                     "password_next_rotation": "N/A",
                     "user": "api3",
-                    "user_creation_time": "2018-09-18T14:58:26+00:00"
+                    "user_creation_time": "2018-09-18T14:58:26+00:00",
+                    "root_credentials_managed_centrally": false
                 },
                 "68dcc047c3da5bbbc3f3e9d54000b7357f0e507e": {
                     "access_key_1_active": "false",
@@ -55,7 +56,36 @@
                     "password_last_used": "2019-11-26T01:13:39+00:00",
                     "password_next_rotation": "not_supported",
                     "user": "<root_account>",
-                    "user_creation_time": "2018-04-03T21:50:27+00:00"
+                    "user_creation_time": "2018-04-03T21:50:27+00:00",
+                    "root_credentials_managed_centrally": false
+                },
+                "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2": {
+                    "access_key_1_active": "false",
+                    "access_key_1_last_rotated": "N/A",
+                    "access_key_1_last_used_date": null,
+                    "access_key_1_last_used_region": "N/A",
+                    "access_key_1_last_used_service": "N/A",
+                    "access_key_2_active": "false",
+                    "access_key_2_last_rotated": "N/A",
+                    "access_key_2_last_used_date": null,
+                    "access_key_2_last_used_region": "N/A",
+                    "access_key_2_last_used_service": "N/A",
+                    "arn": "arn:aws:iam::999888777666:root",
+                    "cert_1_active": "false",
+                    "cert_1_last_rotated": "N/A",
+                    "cert_2_active": "false",
+                    "cert_2_last_rotated": "N/A",
+                    "id": "<root_account>_centralized",
+                    "last_used": null,
+                    "mfa_active": "not_supported",
+                    "name": "<root_account>",
+                    "password_enabled": "not_supported",
+                    "password_last_changed": "not_supported",
+                    "password_last_used": null,
+                    "password_next_rotation": "not_supported",
+                    "user": "<root_account>",
+                    "user_creation_time": "2020-01-01T00:00:00+00:00",
+                    "root_credentials_managed_centrally": true
                 }
             }
         }

--- a/tests/data/rule-configs/iam-root.json
+++ b/tests/data/rule-configs/iam-root.json
@@ -77,7 +77,7 @@
                     "cert_2_last_rotated": "N/A",
                     "id": "<root_account>_centralized",
                     "last_used": null,
-                    "mfa_active": "not_supported",
+                    "mfa_active": "false",
                     "name": "<root_account>",
                     "password_enabled": "not_supported",
                     "password_last_changed": "not_supported",


### PR DESCRIPTION
## Summary

Fixes #1710

When AWS Organizations centralized root access management is enabled and root credentials are removed from member accounts, ScoutSuite incorrectly flags "Root Account without MFA". This happens because the credential report shows `mfa_active` as `false` for the root user, but MFA cannot and need not be configured when root credentials have been centrally removed.

**Changes:**

- Added `get_organizations_root_credentials_managed()` to the IAM facade, which calls `iam:ListOrganizationsFeatures` to check if `RootCredentialsManagement` is enabled. Fails gracefully (returns `False`) when the account is not in an org or lacks the required permission.
- In `credentialreports.py`, the result is used to set a `root_credentials_managed_centrally` flag on the root credential report entry.
- Both `iam-root-account-no-mfa.json` and `iam-root-account-no-hardware-mfa.json` rules now include a condition to skip accounts where this flag is `true`.
- Updated test fixture `iam-root.json` with the new field and a test case for the centralized root access scenario.

## Test plan

- [ ] Run ScoutSuite against an AWS account **without** Organizations or centralized root access. Verify root MFA finding still fires when MFA is not enabled.
- [ ] Run ScoutSuite against an AWS Organizations member account **with** centralized root access enabled and root credentials removed. Verify root MFA finding does NOT fire.
- [ ] Run ScoutSuite against an account where `iam:ListOrganizationsFeatures` is not permitted. Verify the API call fails silently and root MFA finding behaves as before (no regression).
- [ ] Run `python -m pytest tests/test_rules_processingengine.py` to validate the rule engine test with updated fixtures.