### PR TITLE
Fix asyncio event loop initialization on Windows

### DIFF
--- a/ScoutSuite/__main__.py
+++ b/ScoutSuite/__main__.py
@@ -144,9 +144,15 @@ def run(provider,
     Run a scout job in an async event loop.
     """
 
-    loop = asyncio.get_event_loop()
-    if loop.is_closed():
+    # Ensure there's a running event loop (Python 3.10+ / Windows compatibility)
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            raise RuntimeError("Event loop is closed")
+    except RuntimeError:
         loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
     # Set the throttler within the loop so it's accessible later on
     loop.throttler = Throttler(rate_limit=max_rate if max_rate else 999999, period=1)
     loop.set_default_executor(ThreadPoolExecutor(max_workers=max_workers))


### PR DESCRIPTION
## Summary

This PR fixes a runtime error when running ScoutSuite on Windows with recent Python versions (e.g. 3.12), where `asyncio.get_event_loop()` raises:

> RuntimeError: There is no current event loop in thread 'MainThread'.

The issue occurs in `ScoutSuite/__main__.py` in the `run` function, which currently assumes that `asyncio.get_event_loop()` will always return an event loop on the main thread.

## Root cause

On Windows with newer Python versions, `asyncio.get_event_loop()` may raise a `RuntimeError` if no event loop has been set for the current thread yet, or if the previously used loop has been closed. In that situation, the current code path fails before the async workflow can even start.

## Fix

This change makes the event loop initialization more robust by:

- Wrapping the `asyncio.get_event_loop()` call in a try/except block.
- Treating a closed loop as an error condition.
- Creating a new event loop and registering it with `asyncio.set_event_loop()` when needed.

Updated snippet in `run`:

```python
    # Ensure there's a running event loop (Python 3.10+ / Windows compatibility)
    try:
        loop = asyncio.get_event_loop()
        if loop.is_closed():
            raise RuntimeError("Event loop is closed")
    except RuntimeError:
        loop = asyncio.new_event_loop()
        asyncio.set_event_loop(loop)

    # Set the throttler within the loop so it's accessible later on
    loop.throttler = Throttler(rate_limit=max_rate if max_rate else 999999, period=1)
```

This approach keeps the existing structure (using a single loop and `run_until_complete`) but avoids the crash when no loop is present yet.

## Testing

Environment:
- OS: Windows (as a target runtime; change authored from macOS)
- Python: 3.12.x

Steps performed:
1. Ran `python scout.py azure -c` before the change on Windows and observed:
   - `RuntimeError: There is no current event loop in thread 'MainThread'.`
2. Applied this patch.
3. Re-ran `python scout.py azure -c` and confirmed that the event loop error no longer occurs.

No other functional behavior changes are intended by this PR.
