### PR TITLE
fix: resolve GCP monitoring alert policy false negatives

### DIFF
--- a/ScoutSuite/providers/gcp/resources/stackdrivermonitoring/monitoring_alert_policies.py
+++ b/ScoutSuite/providers/gcp/resources/stackdrivermonitoring/monitoring_alert_policies.py
@@ -15,21 +15,29 @@ class MonitoringAlertPolicies(Resources):
     def _parse_alert_policy(self, raw_alert_policies):
         alert_policy_dict = {}
         alert_policy_dict['project_ownership_assignments'] = \
-            self._specific_alert_policy_present(raw_alert_policies)
-        alert_policy_dict['audit_config_change'] = self._specific_alert_policy_present(raw_alert_policies)
-        alert_policy_dict['custom_role_change'] = self._specific_alert_policy_present(raw_alert_policies)
-        alert_policy_dict['vpc_network_firewall_rule_change'] = self._specific_alert_policy_present(raw_alert_policies)
-        alert_policy_dict['vpc_network_route_change'] = self._specific_alert_policy_present(raw_alert_policies)
-        alert_policy_dict['vpc_network_change'] = self._specific_alert_policy_present(raw_alert_policies)
+            self._specific_alert_policy_present(raw_alert_policies, 'project_ownership_changes-counter')
+        alert_policy_dict['audit_config_change'] = \
+            self._specific_alert_policy_present(raw_alert_policies, 'audit_config_change-counter')
+        alert_policy_dict['custom_role_change'] = \
+            self._specific_alert_policy_present(raw_alert_policies, 'custom_role_changes-counter')
+        alert_policy_dict['vpc_network_firewall_rule_change'] = \
+            self._specific_alert_policy_present(raw_alert_policies, 'vpc_firewall_network_changes-counter')
+        alert_policy_dict['vpc_network_route_change'] = \
+            self._specific_alert_policy_present(raw_alert_policies, 'vpc_network_route_changes-counter')
+        alert_policy_dict['vpc_network_change'] = \
+            self._specific_alert_policy_present(raw_alert_policies, 'vpc_network_configuration_changes-counter')
         alert_policy_dict['cloud_storage_iam_permission_change'] = \
-            self._specific_alert_policy_present(raw_alert_policies)
-        alert_policy_dict['sql_instance_conf_change'] = self._specific_alert_policy_present(raw_alert_policies)
+            self._specific_alert_policy_present(raw_alert_policies, 'cloud_storage_iam_changes-counter')
+        alert_policy_dict['sql_instance_conf_change'] = \
+            self._specific_alert_policy_present(raw_alert_policies, 'sql_instance_configuration_changes-counter')
         return alert_policy_dict
 
-    def _specific_alert_policy_present(self, alert_policies):
+    def _specific_alert_policy_present(self, alert_policies, metric_name):
+        expected_fragment = 'logging.googleapis.com/user/{}'.format(metric_name)
         for alert_policy in alert_policies:
+            if not alert_policy.enabled.value:
+                continue
             for condition in alert_policy.conditions:
-                if condition.condition_threshold.filter == 'metric.type=\"logging.googleapis.com/user/<Log Metric ' \
-                                                           'Name>\"' and alert_policy.enabled.value:
+                if expected_fragment in condition.condition_threshold.filter:
                     return True
         return False


### PR DESCRIPTION
Closes #1725

## Summary
- Fix hardcoded `<Log Metric Name>` placeholder that never matched real alert policies, causing all 8 CIS GCP monitoring checks to return false
- Each check now passes the correct CIS-recommended metric name (e.g., `project_ownership_changes-counter`)
- Uses substring match for filter comparison to handle additional clauses like `AND resource.type="global"`

## Changes
- `ScoutSuite/providers/gcp/resources/stackdrivermonitoring/monitoring_alert_policies.py`

## Test plan
- [x] All 50 existing tests pass
- [x] Each of the 8 alert policy checks now receives a unique metric name argument
- [x] Disabled policies are skipped early