### PR TITLE
fix: restore runtime setuptools for Python 3.12+ pkg_resources

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U setuptools
+        pip install 'setuptools>=65.0.0,<82'
         pip install -r dev-requirements.txt
     - name: Lint with flake8
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,11 @@ cherrypy>=18.1.0
 cherrypy-cors>=1.6
 coloredlogs<=10.0
 asyncio-throttle==0.1.1
+# Needed at runtime on modern Python: several pinned Google client
+# packages still import pkg_resources (provided by setuptools<82).
+# Python 3.12+ venvs no longer ship setuptools by default; setuptools
+# 82+ removed pkg_resources entirely (see issue #1728).
+setuptools>=65.0.0,<82
 
 # AWS Provider
 botocore>=1.20.21

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11'
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13'
     ]
 )


### PR DESCRIPTION
## Description

On Python 3.12/3.13, clean installs no longer provide `setuptools`/`pkg_resources` by default. ScoutSuite still pins older Google client packages (`google-cloud-monitoring==1.1.0`, `google-cloud-kms==1.3.0`, …) that import `pkg_resources`, so GCP initialization fails with:

```text
Initialization failure: No module named 'pkg_resources'
```

This change adds an explicit runtime dependency on `setuptools>=65.0.0,<82` (setuptools 82+ removed `pkg_resources`), aligns CI install with the same pin, and records Python 3.12/3.13 classifiers.

Fixes #1728

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [x] New and existing unit tests pass locally with my changes

## Test plan

- Confirmed `google.cloud.monitoring_v3` / `kms_v1` gapic clients import under `setuptools==81` (`pkg_resources` present)
- Confirmed the same imports fail with `ModuleNotFoundError: pkg_resources` when setuptools is absent
- CI workflow now installs the same setuptools upper bound used at runtime
