### PR TITLE
Fix RDS not-found checks: test str(e), not the exception

### DIFF
--- a/ScoutSuite/providers/aws/facade/rds.py
+++ b/ScoutSuite/providers/aws/facade/rds.py
@@ -54,7 +54,7 @@ class RDSFacade(AWSBaseFacade):
             if e.response['Error']['Code'] != 'NoSuchTagSet':
                 print_exception('Failed to get db instance tags for {}: {}'.format(instance['DBInstanceIdentifier'], e))
         except Exception as e:
-            if 'DBInstanceNotFound' in e:
+            if 'DBInstanceNotFound' in str(e):
                 print_warning('Failed to get db instance tags for {}: {}'.format(instance['DBInstanceIdentifier'], e))
             else:
                 print_exception('Failed to get db instance tags for {}: {}'.format(instance['DBInstanceIdentifier'], e))
@@ -116,7 +116,7 @@ class RDSFacade(AWSBaseFacade):
             snapshot['Attributes'] =\
                 attributes['DBSnapshotAttributes'] if 'DBSnapshotAttributes' in attributes else {}
         except Exception as e:
-            if 'DBSnapshotNotFound' in e:
+            if 'DBSnapshotNotFound' in str(e):
                 print_warning(f'Failed to describe RDS snapshot attributes: {e}')
             else:
                 print_exception(f'Failed to describe RDS snapshot attributes: {e}')


### PR DESCRIPTION
# Description

Fixes #1739

Two `except Exception as e:` handlers in `ScoutSuite/providers/aws/facade/rds.py` test `'DBSnapshotNotFound' in e` and `'DBInstanceNotFound' in e`. Membership on an exception object raises `TypeError: argument of type 'DBSnapshotNotFoundFault' is not iterable`, so the not-found case the handler exists to downgrade to a warning escapes it instead.

Observed on a long AWS scan: an automated RDS snapshot listed by `describe_db_snapshots` was rotated away before `describe_db_snapshot_attributes` reached it. The `TypeError` left the snapshot without an `Attributes` key, `fetch_all()` for `snapshots` then failed with `KeyError: 'Attributes'`, and the run exited 200 with a handled error.

This change tests the message with `in str(e)` in both places, which is what the surrounding code intends.

## Type of change

Select the relevant option(s):

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (optional)
- [ ] New and existing unit tests pass locally with my changes
